### PR TITLE
chore(surge-ui): use workspace chrono

### DIFF
--- a/crates/surge-ui/Cargo.toml
+++ b/crates/surge-ui/Cargo.toml
@@ -25,4 +25,4 @@ toml.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 pulldown-cmark = "0.12"
-chrono = "0.4"
+chrono = { workspace = true }


### PR DESCRIPTION
## Summary

- Switch `surge-ui` from a bare `chrono = "0.4"` pin to `chrono = { workspace = true }` so it inherits the workspace declaration (`version = "0.4"`, `features = ["serde"]`) like every other crate.
- Pure workspace-hygiene fix — no behavior change, no API change.

## Why

Bare version pins in member crates silently diverge from the workspace declaration: `surge-ui` was getting chrono with **no features**, while the workspace declares `serde`. Inheriting via `workspace = true` keeps feature resolution consistent and prevents future surprise when something in surge-ui (or a dep) starts relying on the serde-decorated chrono types.

## Notes for reviewer

- surge-ui itself only uses chrono for timestamp formatting (`chrono::{Local,Utc}::now().format(...)` in `src/screens/gate_approval.rs` and `tests/gate_approval_ui_e2e.rs`); it does not (yet) need the `serde` feature directly. Inheriting it is harmless — Cargo features are additive — and avoids a one-off feature-less build of chrono.
- The local helper `chrono_now()` in `src/project.rs` is misnamed: it actually uses `std::time::SystemTime` and does not touch chrono. Out of scope for this PR.

## Test plan

- [x] `cargo check -p surge-ui` passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)