### PR TITLE
chore(repo): add .gitattributes to normalize line endings to LF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -19,6 +19,7 @@
 *.yaml  text eol=lf
 *.sql   text eol=lf
 *.snap  text eol=lf
+*.svg   text eol=lf
 
 # Unix shell scripts: must be LF or they break on Linux/macOS
 *.sh    text eol=lf
@@ -34,7 +35,6 @@
 *.jpeg  binary
 *.gif   binary
 *.ico   binary
-*.svg   binary
 *.pdf   binary
 *.zip   binary
 *.gz    binary

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,42 @@
+# Normalize line endings to LF on commit, regardless of platform.
+# This makes the repository consistent across Linux, macOS, and Windows
+# (where developers may have core.autocrlf=true). Rustfmt produces LF,
+# so without this file Windows checkouts re-introduce CRLF and create
+# noisy diffs after `cargo fmt`.
+
+# Default: auto-detect text files, store with LF in repo
+* text=auto eol=lf
+
+# Rust sources and project config
+*.rs    text eol=lf
+*.toml  text eol=lf
+*.lock  text eol=lf
+
+# Documentation and data formats
+*.md    text eol=lf
+*.json  text eol=lf
+*.yml   text eol=lf
+*.yaml  text eol=lf
+*.sql   text eol=lf
+*.snap  text eol=lf
+
+# Unix shell scripts: must be LF or they break on Linux/macOS
+*.sh    text eol=lf
+
+# Windows scripts: must be CRLF
+*.bat   text eol=crlf
+*.cmd   text eol=crlf
+*.ps1   text eol=crlf
+
+# Common binary formats — never normalize
+*.png   binary
+*.jpg   binary
+*.jpeg  binary
+*.gif   binary
+*.ico   binary
+*.svg   binary
+*.pdf   binary
+*.zip   binary
+*.gz    binary
+*.tar   binary
+*.wasm  binary


### PR DESCRIPTION
## Summary

- Add `.gitattributes` pinning all text files (especially `*.rs`, `*.toml`) to LF in the repo.
- Force Windows scripts (`*.bat`, `*.cmd`, `*.ps1`) to CRLF, mark common binary formats explicitly.
- Existing files keep their current line endings — renormalization (`git add --renormalize .`) is intentionally left for a follow-up commit to keep this change reviewable.

## Why

Without `.gitattributes`, Windows clones with `core.autocrlf=true` re-introduce CRLF on checkout, while `cargo fmt` always writes LF. Running `cargo fmt --all` on Windows then produces ~200 spurious LF→CRLF diffs unrelated to any actual change. The recent M5(engine) fix-up commit had to work around this by hand-picking files to `git add` rather than using `git add -A`. With this file in place, all platforms produce the same bytes in the index regardless of `core.autocrlf` setting.

## Notes for reviewer

- Verified locally: `git check-attr -a Cargo.toml crates/surge-core/src/lib.rs` reports `text: set, eol: lf`.
- This is a no-op for current files until someone runs `git add --renormalize .` (or touches each file). CI is unaffected because it already sees LF on Linux.
- Repo currently uses these extensions: `rs`, `toml`, `md`, `json`, `yml`, `sql`, `snap`. All covered.

## Test plan

- [ ] CI green on this branch.
- [ ] On a fresh Windows clone with `core.autocrlf=true`, `cargo fmt --all && git status` reports clean working tree (after the follow-up renormalize commit lands).

🤖 Generated with [Claude Code](https://claude.com/claude-code)