### PR TITLE
Apply M5.1 unsafe-set_var fix to remaining engine tests

### DIFF
--- a/crates/surge-orchestrator/tests/engine_concurrent_runs.rs
+++ b/crates/surge-orchestrator/tests/engine_concurrent_runs.rs
@@ -28,26 +28,32 @@ use surge_persistence::runs::Storage;
 
 /// Resolve the `mock_acp_agent` binary path.
 ///
-/// `CARGO_BIN_EXE_mock_acp_agent` is set by Cargo only when the test binary
-/// and the `[[bin]]` live in the same package — they don't here. Fall back to
-/// an absolute path derived from `CARGO_MANIFEST_DIR` (compile-time constant),
-/// which is always `<workspace_root>/crates/surge-orchestrator`.
+/// During `cargo test` the `CARGO_BIN_EXE_mock_acp_agent` env var is set by
+/// Cargo to the exact binary path. Outside of `cargo test` (e.g. manual `cargo
+/// run --test`), fall back to `<CARGO_TARGET_DIR>/debug/mock_acp_agent[.exe]`.
 fn mock_agent_path() -> PathBuf {
-    if let Ok(path) = std::env::var("CARGO_BIN_EXE_mock_acp_agent") {
-        return PathBuf::from(path);
-    }
-    // CARGO_MANIFEST_DIR = …/crates/surge-orchestrator; workspace root is ../../
-    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    let workspace_root = manifest_dir.parent().unwrap().parent().unwrap();
-    let target = std::env::var("CARGO_TARGET_DIR")
-        .map(PathBuf::from)
-        .unwrap_or_else(|_| workspace_root.join("target"));
+    // Cargo sets CARGO_BIN_EXE_<name> only for the binary's own crate's tests,
+    // not for cross-crate consumers — so we always fall through to discovery.
     let bin = if cfg!(windows) {
         "mock_acp_agent.exe"
     } else {
         "mock_acp_agent"
     };
-    target.join("debug").join(bin)
+    if let Ok(target) = std::env::var("CARGO_TARGET_DIR") {
+        return PathBuf::from(target).join("debug").join(bin);
+    }
+    // Walk up from this test crate's manifest dir to the workspace root
+    // (where Cargo.lock lives), then target/debug/<bin>.
+    let mut cur = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    loop {
+        if cur.join("Cargo.lock").exists() {
+            return cur.join("target").join("debug").join(bin);
+        }
+        if !cur.pop() {
+            // Last resort: relative path (will fail-loud below).
+            return PathBuf::from("target").join("debug").join(bin);
+        }
+    }
 }
 
 /// Build an agent `Node` with a single `"done"` outcome.
@@ -76,124 +82,157 @@ fn agent_node(id: &str) -> Node {
     }
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+/// Integration test: three concurrent runs share a single engine + bridge and
+/// each completes independently. The mock's default scenario is `report_done`,
+/// so each run advances `agent_<i>` → end and the spawned tasks join with
+/// `RunOutcome::Completed`.
+///
+/// **Test layout note.** Written as a synchronous `#[test]` rather than
+/// `#[tokio::test]` so that `set_var` for `CARGO_BIN_EXE_mock_acp_agent`
+/// runs in single-threaded context **before** any tokio runtime starts.
+/// Under `#[tokio::test(flavor = "multi_thread")]` the runtime worker
+/// threads are already alive when the test body executes, so calling
+/// `set_var` would race against any thread reading the environment —
+/// `unsafe` would be unsound regardless of the safety comment.
+#[test]
 #[ignore = "requires mock_acp_agent binary built; enable with --ignored"]
-async fn three_concurrent_real_runs_complete_independently() {
+fn three_concurrent_real_runs_complete_independently() {
+    // Guard: fail fast with a clear message if the binary isn't built yet.
+    let bin_raw = mock_agent_path();
     assert!(
-        mock_agent_path().exists(),
+        bin_raw.exists(),
         "mock_acp_agent binary missing at {} — run `cargo build -p surge-acp` first",
-        mock_agent_path().display()
+        bin_raw.display()
     );
+    // Canonicalize so the env var is always absolute and CWD-independent;
+    // `mock_agent_path` has a last-resort relative fallback that would
+    // silently break the bridge worker's `Command::spawn` if it leaked.
+    let bin = bin_raw.canonicalize().unwrap_or_else(|e| {
+        panic!(
+            "canonicalize {} failed: {e} (build the binary with `cargo build -p surge-acp` first)",
+            bin_raw.display()
+        )
+    });
 
     // Inject the absolute binary path so the AcpBridge worker can find
-    // mock_acp_agent regardless of the process CWD. The worker uses the
-    // CARGO_BIN_EXE_mock_acp_agent env var (set by Cargo only in surge-acp
-    // tests); we backfill it here from our already-resolved absolute path.
+    // mock_acp_agent regardless of the process CWD. Cargo only sets
+    // CARGO_BIN_EXE_<name> for tests in the same crate as the binary;
+    // surge-orchestrator is a different crate, so we backfill it here.
     if std::env::var("CARGO_BIN_EXE_mock_acp_agent").is_err() {
-        // SAFETY: single-threaded at this point in the test setup; no other
-        // threads read this variable before we set it. Rustc 2024 requires
-        // unsafe for set_var due to POSIX thread-safety concerns.
+        // SAFETY: this runs before we construct any tokio runtime, so the
+        // process is single-threaded at this point — no other thread can
+        // observe a concurrent read/write of the environment. Rustc 2024
+        // requires `unsafe` for `set_var` due to POSIX `setenv` not being
+        // thread-safe; the single-threaded prelude makes that sound here.
         unsafe {
-            std::env::set_var("CARGO_BIN_EXE_mock_acp_agent", mock_agent_path());
+            std::env::set_var("CARGO_BIN_EXE_mock_acp_agent", &bin);
         }
     }
 
-    let dir = tempfile::tempdir().unwrap();
-    let storage = Storage::open(dir.path()).await.unwrap();
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(4)
+        .enable_all()
+        .build()
+        .expect("build multi_thread tokio runtime");
 
-    // Keep a typed Arc<AcpBridge> so we can call shutdown() after the engine
-    // drops its clone. Dropping AcpBridge from within an async context blocks
-    // the tokio thread (Drop::join on the bridge OS thread); calling shutdown()
-    // explicitly avoids that.
-    let bridge_owned = Arc::new(AcpBridge::with_defaults().unwrap());
-    let bridge: Arc<dyn BridgeFacade> = bridge_owned.clone();
-    let dispatcher =
-        Arc::new(WorktreeToolDispatcher::new(dir.path().to_path_buf())) as Arc<dyn ToolDispatcher>;
+    rt.block_on(async {
+        let dir = tempfile::tempdir().unwrap();
+        let storage = Storage::open(dir.path()).await.unwrap();
 
-    let engine = Arc::new(Engine::new(
-        bridge,
-        storage.clone(),
-        dispatcher,
-        EngineConfig::default(),
-    ));
+        // Keep a typed Arc<AcpBridge> so we can call shutdown() after the engine
+        // drops its clone. Dropping AcpBridge from within an async context blocks
+        // the tokio thread (Drop::join on the bridge OS thread); calling shutdown()
+        // explicitly avoids that.
+        let bridge_owned = Arc::new(AcpBridge::with_defaults().unwrap());
+        let bridge: Arc<dyn BridgeFacade> = bridge_owned.clone();
+        let dispatcher = Arc::new(WorktreeToolDispatcher::new(dir.path().to_path_buf()))
+            as Arc<dyn ToolDispatcher>;
 
-    let mut handles = vec![];
-    for i in 0..3usize {
-        let eng = engine.clone();
-        let dir_path = dir.path().to_path_buf();
-        handles.push(tokio::spawn(async move {
-            // Single-stage agent + terminal — keeps the test fast.
-            let agent_id = format!("agent_{i}");
-            let agent_key = NodeKey::try_from(agent_id.as_str()).unwrap();
-            let end = NodeKey::try_from("end").unwrap();
+        let engine = Arc::new(Engine::new(
+            bridge,
+            storage.clone(),
+            dispatcher,
+            EngineConfig::default(),
+        ));
 
-            let mut nodes = BTreeMap::new();
-            nodes.insert(agent_key.clone(), agent_node(&agent_id));
-            nodes.insert(
-                end.clone(),
-                Node {
-                    id: end.clone(),
-                    position: Position::default(),
-                    declared_outcomes: vec![],
-                    config: NodeConfig::Terminal(TerminalConfig {
-                        kind: TerminalKind::Success,
-                        message: None,
-                    }),
-                },
+        let mut handles = vec![];
+        for i in 0..3usize {
+            let eng = engine.clone();
+            let dir_path = dir.path().to_path_buf();
+            handles.push(tokio::spawn(async move {
+                // Single-stage agent + terminal — keeps the test fast.
+                let agent_id = format!("agent_{i}");
+                let agent_key = NodeKey::try_from(agent_id.as_str()).unwrap();
+                let end = NodeKey::try_from("end").unwrap();
+
+                let mut nodes = BTreeMap::new();
+                nodes.insert(agent_key.clone(), agent_node(&agent_id));
+                nodes.insert(
+                    end.clone(),
+                    Node {
+                        id: end.clone(),
+                        position: Position::default(),
+                        declared_outcomes: vec![],
+                        config: NodeConfig::Terminal(TerminalConfig {
+                            kind: TerminalKind::Success,
+                            message: None,
+                        }),
+                    },
+                );
+
+                let edges = vec![Edge {
+                    id: EdgeKey::try_from(format!("e_{i}").as_str()).unwrap(),
+                    from: PortRef {
+                        node: agent_key.clone(),
+                        outcome: OutcomeKey::try_from("done").unwrap(),
+                    },
+                    to: end.clone(),
+                    kind: EdgeKind::Forward,
+                    policy: EdgePolicy::default(),
+                }];
+
+                let graph = Graph {
+                    schema_version: SCHEMA_VERSION,
+                    metadata: GraphMetadata {
+                        name: format!("run-{i}"),
+                        description: None,
+                        template_origin: None,
+                        created_at: chrono::Utc::now(),
+                        author: None,
+                    },
+                    start: agent_key,
+                    nodes,
+                    edges,
+                    subgraphs: BTreeMap::new(),
+                };
+
+                let h = eng
+                    .start_run(RunId::new(), graph, dir_path, EngineRunConfig::default())
+                    .await
+                    .unwrap();
+                tokio::time::timeout(Duration::from_secs(60), h.await_completion())
+                    .await
+                    .expect("run timed out after 60s")
+                    .unwrap()
+            }));
+        }
+
+        for h in handles {
+            let outcome = h.await.unwrap();
+            assert!(
+                matches!(outcome, RunOutcome::Completed { .. }),
+                "expected Completed, got {outcome:?}"
             );
+        }
 
-            let edges = vec![Edge {
-                id: EdgeKey::try_from(format!("e_{i}").as_str()).unwrap(),
-                from: PortRef {
-                    node: agent_key.clone(),
-                    outcome: OutcomeKey::try_from("done").unwrap(),
-                },
-                to: end.clone(),
-                kind: EdgeKind::Forward,
-                policy: EdgePolicy::default(),
-            }];
+        // Drop the engine Arc so the bridge's refcount can reach 1 (only bridge_owned).
+        drop(engine);
 
-            let graph = Graph {
-                schema_version: SCHEMA_VERSION,
-                metadata: GraphMetadata {
-                    name: format!("run-{i}"),
-                    description: None,
-                    template_origin: None,
-                    created_at: chrono::Utc::now(),
-                    author: None,
-                },
-                start: agent_key,
-                nodes,
-                edges,
-                subgraphs: BTreeMap::new(),
-            };
-
-            let h = eng
-                .start_run(RunId::new(), graph, dir_path, EngineRunConfig::default())
-                .await
-                .unwrap();
-            tokio::time::timeout(Duration::from_secs(60), h.await_completion())
-                .await
-                .expect("run timed out after 60s")
-                .unwrap()
-        }));
-    }
-
-    for h in handles {
-        let outcome = h.await.unwrap();
-        assert!(
-            matches!(outcome, RunOutcome::Completed { .. }),
-            "expected Completed, got {outcome:?}"
-        );
-    }
-
-    // Drop the engine Arc so the bridge's refcount can reach 1 (only bridge_owned).
-    drop(engine);
-
-    // Explicitly shut down the bridge via the async path so the OS thread
-    // exits cleanly without blocking a tokio worker thread in Drop::join.
-    // Arc::into_inner returns Some because the engine (last other holder) is dropped.
-    if let Some(bridge_for_shutdown) = Arc::into_inner(bridge_owned) {
-        let _ = bridge_for_shutdown.shutdown().await;
-    }
+        // Explicitly shut down the bridge via the async path so the OS thread
+        // exits cleanly without blocking a tokio worker thread in Drop::join.
+        // Arc::into_inner returns Some because the engine (last other holder) is dropped.
+        if let Some(bridge_for_shutdown) = Arc::into_inner(bridge_owned) {
+            let _ = bridge_for_shutdown.shutdown().await;
+        }
+    });
 }

--- a/crates/surge-orchestrator/tests/engine_resume_after_crash.rs
+++ b/crates/surge-orchestrator/tests/engine_resume_after_crash.rs
@@ -28,26 +28,32 @@ use surge_persistence::runs::Storage;
 
 /// Resolve the `mock_acp_agent` binary path.
 ///
-/// `CARGO_BIN_EXE_mock_acp_agent` is set by Cargo only when the test binary
-/// and the `[[bin]]` live in the same package — they don't here. Fall back to
-/// an absolute path derived from `CARGO_MANIFEST_DIR` (compile-time constant),
-/// which is always `<workspace_root>/crates/surge-orchestrator`.
+/// During `cargo test` the `CARGO_BIN_EXE_mock_acp_agent` env var is set by
+/// Cargo to the exact binary path. Outside of `cargo test` (e.g. manual `cargo
+/// run --test`), fall back to `<CARGO_TARGET_DIR>/debug/mock_acp_agent[.exe]`.
 fn mock_agent_path() -> PathBuf {
-    if let Ok(path) = std::env::var("CARGO_BIN_EXE_mock_acp_agent") {
-        return PathBuf::from(path);
-    }
-    // CARGO_MANIFEST_DIR = …/crates/surge-orchestrator; workspace root is ../../
-    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    let workspace_root = manifest_dir.parent().unwrap().parent().unwrap();
-    let target = std::env::var("CARGO_TARGET_DIR")
-        .map(PathBuf::from)
-        .unwrap_or_else(|_| workspace_root.join("target"));
+    // Cargo sets CARGO_BIN_EXE_<name> only for the binary's own crate's tests,
+    // not for cross-crate consumers — so we always fall through to discovery.
     let bin = if cfg!(windows) {
         "mock_acp_agent.exe"
     } else {
         "mock_acp_agent"
     };
-    target.join("debug").join(bin)
+    if let Ok(target) = std::env::var("CARGO_TARGET_DIR") {
+        return PathBuf::from(target).join("debug").join(bin);
+    }
+    // Walk up from this test crate's manifest dir to the workspace root
+    // (where Cargo.lock lives), then target/debug/<bin>.
+    let mut cur = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    loop {
+        if cur.join("Cargo.lock").exists() {
+            return cur.join("target").join("debug").join(bin);
+        }
+        if !cur.pop() {
+            // Last resort: relative path (will fail-loud below).
+            return PathBuf::from("target").join("debug").join(bin);
+        }
+    }
 }
 
 /// Build an agent `Node` with a single `"done"` outcome.
@@ -89,146 +95,179 @@ fn edge_done(id: &str, from: &NodeKey, to: &NodeKey) -> Edge {
     }
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+/// Integration test: stop a 5-stage run mid-flight, then resume it from the
+/// persisted snapshot. The mock's default scenario is `report_done`, so each
+/// stage emits `report_stage_outcome { outcome: "done" }` and the pipeline
+/// advances s1 → s2 → s3 → s4 → s5 → end.
+///
+/// **Test layout note.** Written as a synchronous `#[test]` rather than
+/// `#[tokio::test]` so that `set_var` for `CARGO_BIN_EXE_mock_acp_agent`
+/// runs in single-threaded context **before** any tokio runtime starts.
+/// Under `#[tokio::test(flavor = "multi_thread")]` the runtime worker
+/// threads are already alive when the test body executes, so calling
+/// `set_var` would race against any thread reading the environment —
+/// `unsafe` would be unsound regardless of the safety comment.
+#[test]
 #[ignore = "requires mock_acp_agent binary built; enable with --ignored"]
-async fn resume_after_partial_progress() {
+fn resume_after_partial_progress() {
+    // Guard: fail fast with a clear message if the binary isn't built yet.
+    let bin_raw = mock_agent_path();
     assert!(
-        mock_agent_path().exists(),
+        bin_raw.exists(),
         "mock_acp_agent binary missing at {} — run `cargo build -p surge-acp` first",
-        mock_agent_path().display()
+        bin_raw.display()
     );
+    // Canonicalize so the env var is always absolute and CWD-independent;
+    // `mock_agent_path` has a last-resort relative fallback that would
+    // silently break the bridge worker's `Command::spawn` if it leaked.
+    let bin = bin_raw.canonicalize().unwrap_or_else(|e| {
+        panic!(
+            "canonicalize {} failed: {e} (build the binary with `cargo build -p surge-acp` first)",
+            bin_raw.display()
+        )
+    });
 
     // Inject the absolute binary path so the AcpBridge worker can find
-    // mock_acp_agent regardless of the process CWD. The worker uses the
-    // CARGO_BIN_EXE_mock_acp_agent env var (set by Cargo only in surge-acp
-    // tests); we backfill it here from our already-resolved absolute path.
+    // mock_acp_agent regardless of the process CWD. Cargo only sets
+    // CARGO_BIN_EXE_<name> for tests in the same crate as the binary;
+    // surge-orchestrator is a different crate, so we backfill it here.
     if std::env::var("CARGO_BIN_EXE_mock_acp_agent").is_err() {
-        // SAFETY: single-threaded at this point in the test setup; no other
-        // threads read this variable before we set it. Rustc 2024 requires
-        // unsafe for set_var due to POSIX thread-safety concerns.
+        // SAFETY: this runs before we construct any tokio runtime, so the
+        // process is single-threaded at this point — no other thread can
+        // observe a concurrent read/write of the environment. Rustc 2024
+        // requires `unsafe` for `set_var` due to POSIX `setenv` not being
+        // thread-safe; the single-threaded prelude makes that sound here.
         unsafe {
-            std::env::set_var("CARGO_BIN_EXE_mock_acp_agent", mock_agent_path());
+            std::env::set_var("CARGO_BIN_EXE_mock_acp_agent", &bin);
         }
     }
 
-    let dir = tempfile::tempdir().unwrap();
-    let storage = Storage::open(dir.path()).await.unwrap();
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(4)
+        .enable_all()
+        .build()
+        .expect("build multi_thread tokio runtime");
 
-    // Keep a typed Arc<AcpBridge> so we can call shutdown() after the engine
-    // drops its clone. Dropping AcpBridge from within an async context blocks
-    // the tokio thread (Drop::join on the bridge OS thread); calling shutdown()
-    // explicitly avoids that.
-    let bridge_owned = Arc::new(AcpBridge::with_defaults().unwrap());
-    let bridge: Arc<dyn BridgeFacade> = bridge_owned.clone();
-    let dispatcher =
-        Arc::new(WorktreeToolDispatcher::new(dir.path().to_path_buf())) as Arc<dyn ToolDispatcher>;
+    rt.block_on(async {
+        let dir = tempfile::tempdir().unwrap();
+        let storage = Storage::open(dir.path()).await.unwrap();
 
-    let engine = Engine::new(bridge, storage.clone(), dispatcher, EngineConfig::default());
+        // Keep a typed Arc<AcpBridge> so we can call shutdown() after the engine
+        // drops its clone. Dropping AcpBridge from within an async context blocks
+        // the tokio thread (Drop::join on the bridge OS thread); calling shutdown()
+        // explicitly avoids that.
+        let bridge_owned = Arc::new(AcpBridge::with_defaults().unwrap());
+        let bridge: Arc<dyn BridgeFacade> = bridge_owned.clone();
+        let dispatcher = Arc::new(WorktreeToolDispatcher::new(dir.path().to_path_buf()))
+            as Arc<dyn ToolDispatcher>;
 
-    // 5-stage linear pipeline.
-    let s1 = NodeKey::try_from("s1").unwrap();
-    let s2 = NodeKey::try_from("s2").unwrap();
-    let s3 = NodeKey::try_from("s3").unwrap();
-    let s4 = NodeKey::try_from("s4").unwrap();
-    let s5 = NodeKey::try_from("s5").unwrap();
-    let end = NodeKey::try_from("end").unwrap();
+        let engine = Engine::new(bridge, storage.clone(), dispatcher, EngineConfig::default());
 
-    let mut nodes = BTreeMap::new();
-    for key in [&s1, &s2, &s3, &s4, &s5] {
-        let id_str = key.as_ref();
-        nodes.insert((*key).clone(), agent_node(id_str));
-    }
-    nodes.insert(
-        end.clone(),
-        Node {
-            id: end.clone(),
-            position: Position::default(),
-            declared_outcomes: vec![],
-            config: NodeConfig::Terminal(TerminalConfig {
-                kind: TerminalKind::Success,
-                message: None,
-            }),
-        },
-    );
+        // 5-stage linear pipeline.
+        let s1 = NodeKey::try_from("s1").unwrap();
+        let s2 = NodeKey::try_from("s2").unwrap();
+        let s3 = NodeKey::try_from("s3").unwrap();
+        let s4 = NodeKey::try_from("s4").unwrap();
+        let s5 = NodeKey::try_from("s5").unwrap();
+        let end = NodeKey::try_from("end").unwrap();
 
-    let edges = vec![
-        edge_done("e12", &s1, &s2),
-        edge_done("e23", &s2, &s3),
-        edge_done("e34", &s3, &s4),
-        edge_done("e45", &s4, &s5),
-        edge_done("e5end", &s5, &end),
-    ];
+        let mut nodes = BTreeMap::new();
+        for key in [&s1, &s2, &s3, &s4, &s5] {
+            let id_str = key.as_ref();
+            nodes.insert((*key).clone(), agent_node(id_str));
+        }
+        nodes.insert(
+            end.clone(),
+            Node {
+                id: end.clone(),
+                position: Position::default(),
+                declared_outcomes: vec![],
+                config: NodeConfig::Terminal(TerminalConfig {
+                    kind: TerminalKind::Success,
+                    message: None,
+                }),
+            },
+        );
 
-    let graph = Graph {
-        schema_version: SCHEMA_VERSION,
-        metadata: GraphMetadata {
-            name: "5-stage".into(),
-            description: None,
-            template_origin: None,
-            created_at: chrono::Utc::now(),
-            author: None,
-        },
-        start: s1,
-        nodes,
-        edges,
-        subgraphs: BTreeMap::new(),
-    };
+        let edges = vec![
+            edge_done("e12", &s1, &s2),
+            edge_done("e23", &s2, &s3),
+            edge_done("e34", &s3, &s4),
+            edge_done("e45", &s4, &s5),
+            edge_done("e5end", &s5, &end),
+        ];
 
-    let run_id = RunId::new();
+        let graph = Graph {
+            schema_version: SCHEMA_VERSION,
+            metadata: GraphMetadata {
+                name: "5-stage".into(),
+                description: None,
+                template_origin: None,
+                created_at: chrono::Utc::now(),
+                author: None,
+            },
+            start: s1,
+            nodes,
+            edges,
+            subgraphs: BTreeMap::new(),
+        };
 
-    // Start the run.
-    let h = engine
-        .start_run(
-            run_id,
-            graph,
-            dir.path().to_path_buf(),
-            EngineRunConfig::default(),
-        )
-        .await
-        .unwrap();
+        let run_id = RunId::new();
 
-    // Wait briefly for some stages to complete, then stop to simulate crash.
-    tokio::time::sleep(Duration::from_millis(500)).await;
-    let _ = engine.stop_run(run_id, "simulated crash".into()).await;
-    let outcome1 = h.await_completion().await.unwrap();
-    assert!(
-        matches!(
-            outcome1,
-            RunOutcome::Aborted { .. } | RunOutcome::Completed { .. }
-        ),
-        "unexpected first-run outcome: {outcome1:?}"
-    );
+        // Start the run.
+        let h = engine
+            .start_run(
+                run_id,
+                graph,
+                dir.path().to_path_buf(),
+                EngineRunConfig::default(),
+            )
+            .await
+            .unwrap();
 
-    // If the run already completed (mock too fast), nothing to resume —
-    // accept either outcome since the test is exercising the resume code
-    // path more than enforcing a specific cursor position.
+        // Wait briefly for some stages to complete, then stop to simulate crash.
+        tokio::time::sleep(Duration::from_millis(500)).await;
+        let _ = engine.stop_run(run_id, "simulated crash".into()).await;
+        let outcome1 = h.await_completion().await.unwrap();
+        assert!(
+            matches!(
+                outcome1,
+                RunOutcome::Aborted { .. } | RunOutcome::Completed { .. }
+            ),
+            "unexpected first-run outcome: {outcome1:?}"
+        );
 
-    // Resume.
-    let h2 = engine
-        .resume_run(run_id, dir.path().to_path_buf())
-        .await
-        .unwrap();
-    let outcome2 = tokio::time::timeout(Duration::from_secs(60), h2.await_completion())
-        .await
-        .expect("resumed run timed out after 60s")
-        .unwrap();
+        // If the run already completed (mock too fast), nothing to resume —
+        // accept either outcome since the test is exercising the resume code
+        // path more than enforcing a specific cursor position.
 
-    // Resume should reach Completed eventually (even if first attempt already did).
-    assert!(
-        matches!(
-            outcome2,
-            RunOutcome::Completed { .. } | RunOutcome::Aborted { .. }
-        ),
-        "unexpected resumed-run outcome: {outcome2:?}"
-    );
+        // Resume.
+        let h2 = engine
+            .resume_run(run_id, dir.path().to_path_buf())
+            .await
+            .unwrap();
+        let outcome2 = tokio::time::timeout(Duration::from_secs(60), h2.await_completion())
+            .await
+            .expect("resumed run timed out after 60s")
+            .unwrap();
 
-    // Drop the engine so the bridge's refcount can reach 1 (only bridge_owned).
-    drop(engine);
+        // Resume should reach Completed eventually (even if first attempt already did).
+        assert!(
+            matches!(
+                outcome2,
+                RunOutcome::Completed { .. } | RunOutcome::Aborted { .. }
+            ),
+            "unexpected resumed-run outcome: {outcome2:?}"
+        );
 
-    // Explicitly shut down the bridge via the async path so the OS thread
-    // exits cleanly without blocking a tokio worker thread in Drop::join.
-    // Arc::into_inner returns Some because the engine (last other holder) is dropped.
-    if let Some(bridge_for_shutdown) = Arc::into_inner(bridge_owned) {
-        let _ = bridge_for_shutdown.shutdown().await;
-    }
+        // Drop the engine so the bridge's refcount can reach 1 (only bridge_owned).
+        drop(engine);
+
+        // Explicitly shut down the bridge via the async path so the OS thread
+        // exits cleanly without blocking a tokio worker thread in Drop::join.
+        // Arc::into_inner returns Some because the engine (last other holder) is dropped.
+        if let Some(bridge_for_shutdown) = Arc::into_inner(bridge_owned) {
+            let _ = bridge_for_shutdown.shutdown().await;
+        }
+    });
 }


### PR DESCRIPTION
## Summary

Apply the same `set_var` race-fix from [#12](https://github.com/vanyastaff/surge/pull/12) (M5.1) to the two engine integration tests that were left out of that PR's scope:

- `crates/surge-orchestrator/tests/engine_resume_after_crash.rs` — `resume_after_partial_progress`
- `crates/surge-orchestrator/tests/engine_concurrent_runs.rs` — `three_concurrent_real_runs_complete_independently`

Both tests previously used `#[tokio::test(flavor = "multi_thread", worker_threads = 4)]` and called `unsafe { std::env::set_var("CARGO_BIN_EXE_mock_acp_agent", ...) }` *inside* the async body. Under `#[tokio::test]` the runtime worker threads are already alive when the test body runs, so the `set_var` could race against any thread reading the environment — `unsafe` is unsound regardless of the SAFETY comment.

## Changes

For each file, mirror the `engine_e2e_linear_pipeline.rs` reference from #12:

1. Convert `#[tokio::test(flavor = "multi_thread", worker_threads = 4)] async fn` → `#[test] fn` + an explicit `tokio::runtime::Builder::new_multi_thread().worker_threads(4).enable_all().build()` followed by `rt.block_on(async { ... })` wrapping the original async body.
2. Move the env-var guard above runtime construction, so `set_var` runs in single-threaded sync context — making the `unsafe` actually sound.
3. Canonicalize the binary path with a fail-loud panic so a leaked relative-path fallback can't silently break `Command::spawn`.
4. Align `mock_agent_path()` with the reference (no `CARGO_BIN_EXE_*` lookup — Cargo doesn't set it for cross-crate consumers — fall back to `$CARGO_TARGET_DIR/debug/<bin>` or walk up to the workspace `Cargo.lock`).
5. Update the SAFETY comment to state the actual invariant (runs before any tokio runtime is constructed → process is single-threaded → no concurrent env access).

## Test plan

- [x] `cargo build -p surge-acp --bin mock_acp_agent`
- [x] `cargo test -p surge-orchestrator --test engine_resume_after_crash --test engine_concurrent_runs -- --ignored` — both tests pass
- [x] `cargo fmt --all` — no diff
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)