### PR TITLE
M6 P3.2 + P4: wire frame stack + traversal counters into run_task

### DIFF
--- a/crates/surge-orchestrator/src/engine/engine.rs
+++ b/crates/surge-orchestrator/src/engine/engine.rs
@@ -145,6 +145,8 @@ impl Engine {
             cancel,
             resume_cursor: None,
             resume_memory: None,
+            resume_frames: None,
+            resume_root_traversal_counts: None,
             gate_resolutions,
             tool_resolutions,
         };
@@ -243,6 +245,8 @@ impl Engine {
             cancel,
             resume_cursor: Some(replayed.cursor),
             resume_memory: Some(replayed.memory),
+            resume_frames: None,
+            resume_root_traversal_counts: None,
             gate_resolutions,
             tool_resolutions,
         };

--- a/crates/surge-orchestrator/src/engine/routing.rs
+++ b/crates/surge-orchestrator/src/engine/routing.rs
@@ -1,8 +1,8 @@
 //! Edge selection given (current node, outcome).
 
-use surge_core::edge::Edge;
+use surge_core::edge::{Edge, ExceededAction};
 use surge_core::graph::Graph;
-use surge_core::keys::{NodeKey, OutcomeKey};
+use surge_core::keys::{EdgeKey, NodeKey, OutcomeKey};
 use thiserror::Error;
 
 /// Errors that can occur when determining the next node after a stage outcome.
@@ -23,6 +23,21 @@ pub enum RoutingError {
         from: NodeKey,
         /// Outcome key that matched multiple edges.
         outcome: OutcomeKey,
+    },
+    /// Edge traversal limit (`EdgePolicy::max_traversals`) exceeded.
+    /// `action` reports which branch the routing path follows next:
+    /// `Escalate` (synthesise a `max_traversals_exceeded` outcome and
+    /// re-route) or `Fail` (halt the run).
+    #[error("edge {edge} max_traversals exceeded ({count}/{max}) — action: {action:?}")]
+    ExceededTraversal {
+        /// `EdgeKey` of the edge that exceeded the limit.
+        edge: EdgeKey,
+        /// Current traversal counter value (post-increment).
+        count: u32,
+        /// Configured maximum from `EdgePolicy::max_traversals`.
+        max: u32,
+        /// Action determined by `EdgePolicy::on_max_exceeded`.
+        action: ExceededAction,
     },
 }
 
@@ -53,11 +68,83 @@ pub fn next_node_after(
     }
 }
 
+/// Edge selection with traversal-counter enforcement. Mutates the
+/// counter map; returns `Err(RoutingError::ExceededTraversal)` when
+/// the policy threshold is breached.
+///
+/// `frames` decides which counter scope to use: a top `Frame::Loop`
+/// uses its own `traversal_counts` (so loop body edges are isolated
+/// per loop), otherwise the `root_counts` map is used.
+///
+/// `frames` also decides which edge set to search — body subgraph
+/// edges if inside a frame, outer graph edges otherwise.
+#[allow(clippy::implicit_hasher)] // root_counts must match LoopFrame::traversal_counts (RandomState)
+pub fn next_node_after_with_counters(
+    graph: &Graph,
+    current: &NodeKey,
+    outcome: &OutcomeKey,
+    frames: &mut [crate::engine::frames::Frame],
+    root_counts: &mut std::collections::HashMap<EdgeKey, u32>,
+) -> Result<NodeKey, RoutingError> {
+    let edges = active_edge_set(graph, frames);
+
+    let edge = edges
+        .iter()
+        .find(|e| &e.from.node == current && &e.from.outcome == outcome)
+        .ok_or_else(|| RoutingError::NoMatchingEdge {
+            from: current.clone(),
+            outcome: outcome.clone(),
+        })?;
+
+    // Clone edge metadata before dropping the immutable borrow on `edges`/`frames`,
+    // so that we can take a mutable borrow on `frames` (via `top_loop_mut`) next.
+    let edge_id = edge.id.clone();
+    let edge_to = edge.to.clone();
+    let max_traversals = edge.policy.max_traversals;
+    let on_max_exceeded = edge.policy.on_max_exceeded;
+
+    let counts = match crate::engine::frames::top_loop_mut(frames) {
+        Some(lf) => &mut lf.traversal_counts,
+        None => root_counts,
+    };
+    let count = counts.entry(edge_id.clone()).or_insert(0);
+    *count += 1;
+
+    // No let-chains (workspace MSRV is 1.85; let-chains stable in 1.88).
+    if let Some(max) = max_traversals {
+        if *count > max {
+            return Err(RoutingError::ExceededTraversal {
+                edge: edge_id,
+                count: *count,
+                max,
+                action: on_max_exceeded,
+            });
+        }
+    }
+
+    Ok(edge_to)
+}
+
+fn active_edge_set<'a>(graph: &'a Graph, frames: &[crate::engine::frames::Frame]) -> &'a [Edge] {
+    use crate::engine::frames::Frame;
+    match frames.last() {
+        None => &graph.edges,
+        Some(Frame::Loop(lf)) => graph
+            .subgraphs
+            .get(&lf.config.body)
+            .map_or(&[] as &[Edge], |sg| sg.edges.as_slice()),
+        Some(Frame::Subgraph(sf)) => graph
+            .subgraphs
+            .get(&sf.inner_subgraph)
+            .map_or(&[] as &[Edge], |sg| sg.edges.as_slice()),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use std::collections::BTreeMap;
-    use surge_core::edge::{Edge, EdgeKind, EdgePolicy, PortRef};
+    use surge_core::edge::{Edge, EdgeKind, EdgePolicy, ExceededAction, PortRef};
     use surge_core::graph::{Graph, GraphMetadata, SCHEMA_VERSION};
     use surge_core::keys::EdgeKey;
 
@@ -126,5 +213,112 @@ mod tests {
             &OutcomeKey::try_from("done").unwrap(),
         );
         assert!(matches!(result, Err(RoutingError::MultipleMatches { .. })));
+    }
+
+    // --- next_node_after_with_counters tests ---
+
+    fn edge_with_max(
+        id: &str,
+        from_node: &str,
+        from_outcome: &str,
+        to: &str,
+        max: Option<u32>,
+    ) -> Edge {
+        let mut e = edge(id, from_node, from_outcome, to);
+        e.policy.max_traversals = max;
+        e
+    }
+
+    fn edge_with_max_and_fail(
+        id: &str,
+        from_node: &str,
+        from_outcome: &str,
+        to: &str,
+        max: u32,
+    ) -> Edge {
+        let mut e = edge(id, from_node, from_outcome, to);
+        e.policy.max_traversals = Some(max);
+        e.policy.on_max_exceeded = ExceededAction::Fail;
+        e
+    }
+
+    #[test]
+    fn traversal_counter_increments_on_each_call() {
+        let g = graph_with_edges(vec![edge_with_max("e1", "a", "done", "b", Some(2))]);
+        let mut frames: Vec<crate::engine::frames::Frame> = vec![];
+        let mut counts: std::collections::HashMap<EdgeKey, u32> = std::collections::HashMap::new();
+
+        let result = next_node_after_with_counters(
+            &g,
+            &NodeKey::try_from("a").unwrap(),
+            &OutcomeKey::try_from("done").unwrap(),
+            &mut frames,
+            &mut counts,
+        );
+        assert_eq!(result.unwrap(), NodeKey::try_from("b").unwrap());
+        assert_eq!(
+            counts.get(&EdgeKey::try_from("e1").unwrap()).copied(),
+            Some(1)
+        );
+    }
+
+    #[test]
+    fn max_traversals_exceeded_with_escalate_returns_error() {
+        let g = graph_with_edges(vec![edge_with_max("e1", "a", "done", "b", Some(1))]);
+        let mut frames: Vec<crate::engine::frames::Frame> = vec![];
+        let mut counts: std::collections::HashMap<EdgeKey, u32> = std::collections::HashMap::new();
+
+        // First call: ok (count = 1, max = 1, count > max is FALSE).
+        let _ = next_node_after_with_counters(
+            &g,
+            &NodeKey::try_from("a").unwrap(),
+            &OutcomeKey::try_from("done").unwrap(),
+            &mut frames,
+            &mut counts,
+        );
+        // Second call: count goes to 2, > max (1), exceeded.
+        let result = next_node_after_with_counters(
+            &g,
+            &NodeKey::try_from("a").unwrap(),
+            &OutcomeKey::try_from("done").unwrap(),
+            &mut frames,
+            &mut counts,
+        );
+        match result {
+            Err(RoutingError::ExceededTraversal {
+                action: ExceededAction::Escalate,
+                ..
+            }) => {},
+            other => panic!("expected ExceededTraversal::Escalate, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn max_traversals_exceeded_with_fail_returns_error() {
+        let g = graph_with_edges(vec![edge_with_max_and_fail("e1", "a", "done", "b", 1)]);
+        let mut frames: Vec<crate::engine::frames::Frame> = vec![];
+        let mut counts: std::collections::HashMap<EdgeKey, u32> = std::collections::HashMap::new();
+
+        let _ = next_node_after_with_counters(
+            &g,
+            &NodeKey::try_from("a").unwrap(),
+            &OutcomeKey::try_from("done").unwrap(),
+            &mut frames,
+            &mut counts,
+        );
+        let result = next_node_after_with_counters(
+            &g,
+            &NodeKey::try_from("a").unwrap(),
+            &OutcomeKey::try_from("done").unwrap(),
+            &mut frames,
+            &mut counts,
+        );
+        match result {
+            Err(RoutingError::ExceededTraversal {
+                action: ExceededAction::Fail,
+                ..
+            }) => {},
+            other => panic!("expected ExceededTraversal::Fail, got {other:?}"),
+        }
     }
 }

--- a/crates/surge-orchestrator/src/engine/run_task.rs
+++ b/crates/surge-orchestrator/src/engine/run_task.rs
@@ -3,7 +3,6 @@
 
 use crate::engine::config::EngineRunConfig;
 use crate::engine::handle::{EngineRunEvent, RunOutcome};
-use crate::engine::routing::next_node_after;
 use crate::engine::stage::StageError;
 use crate::engine::stage::agent::{AgentStageParams, execute_agent_stage};
 use crate::engine::stage::branch::{BranchStageParams, execute_branch_stage};
@@ -72,12 +71,13 @@ pub(crate) async fn execute(params: RunTaskParams) -> RunOutcome {
         attempt: 1,
     });
     let mut memory = params.resume_memory.clone().unwrap_or_default();
-    let frames: Vec<crate::engine::frames::Frame> =
+    let mut frames: Vec<crate::engine::frames::Frame> =
         params.resume_frames.clone().unwrap_or_default();
-    let _root_traversal_counts: std::collections::HashMap<surge_core::keys::EdgeKey, u32> = params
-        .resume_root_traversal_counts
-        .clone()
-        .unwrap_or_default();
+    let mut root_traversal_counts: std::collections::HashMap<surge_core::keys::EdgeKey, u32> =
+        params
+            .resume_root_traversal_counts
+            .clone()
+            .unwrap_or_default();
 
     loop {
         if params.cancel.is_cancelled() {
@@ -234,8 +234,61 @@ pub(crate) async fn execute(params: RunTaskParams) -> RunOutcome {
             });
 
         // Route to next node.
-        let next = match next_node_after(&params.graph, &cursor.node, &outcome) {
+        let next = match crate::engine::routing::next_node_after_with_counters(
+            &params.graph,
+            &cursor.node,
+            &outcome,
+            &mut frames,
+            &mut root_traversal_counts,
+        ) {
             Ok(n) => n,
+            Err(crate::engine::routing::RoutingError::ExceededTraversal {
+                edge,
+                action,
+                count: _,
+                max: _,
+            }) => {
+                use surge_core::edge::ExceededAction;
+                match action {
+                    ExceededAction::Escalate => {
+                        // Synthesise a max_traversals_exceeded outcome and re-route.
+                        let synthetic =
+                            match surge_core::keys::OutcomeKey::try_from("max_traversals_exceeded")
+                            {
+                                Ok(o) => o,
+                                Err(e) => {
+                                    return failed(&params, format!("synthetic outcome: {e}"))
+                                        .await;
+                                },
+                            };
+                        match crate::engine::routing::next_node_after_with_counters(
+                            &params.graph,
+                            &cursor.node,
+                            &synthetic,
+                            &mut frames,
+                            &mut root_traversal_counts,
+                        ) {
+                            Ok(n) => n,
+                            Err(_) => {
+                                return failed(
+                                    &params,
+                                    format!(
+                                        "max_traversals exceeded on edge {edge} and no escalate route declared"
+                                    ),
+                                )
+                                .await;
+                            },
+                        }
+                    },
+                    ExceededAction::Fail => {
+                        return failed(
+                            &params,
+                            format!("max_traversals exceeded on edge {edge} (action: Fail)"),
+                        )
+                        .await;
+                    },
+                }
+            },
             Err(e) => return failed(&params, format!("routing: {e}")).await,
         };
 

--- a/crates/surge-orchestrator/src/engine/run_task.rs
+++ b/crates/surge-orchestrator/src/engine/run_task.rs
@@ -40,6 +40,11 @@ pub(crate) struct RunTaskParams {
     pub resume_cursor: Option<Cursor>,
     /// Resume from existing memory; if None, start fresh.
     pub resume_memory: Option<RunMemory>,
+    /// Resume from an existing frame stack; if None, start with an empty stack.
+    pub resume_frames: Option<Vec<crate::engine::frames::Frame>>,
+    /// Resume from existing root traversal counts; if None, start fresh.
+    pub resume_root_traversal_counts:
+        Option<std::collections::HashMap<surge_core::keys::EdgeKey, u32>>,
     /// Map of `node_key → oneshot::Sender<HumanGateResolution>`.
     /// Engine's `resolve_human_input` finds the sender and fires it.
     pub gate_resolutions: std::sync::Arc<
@@ -67,6 +72,12 @@ pub(crate) async fn execute(params: RunTaskParams) -> RunOutcome {
         attempt: 1,
     });
     let mut memory = params.resume_memory.clone().unwrap_or_default();
+    let frames: Vec<crate::engine::frames::Frame> =
+        params.resume_frames.clone().unwrap_or_default();
+    let _root_traversal_counts: std::collections::HashMap<surge_core::keys::EdgeKey, u32> = params
+        .resume_root_traversal_counts
+        .clone()
+        .unwrap_or_default();
 
     loop {
         if params.cancel.is_cancelled() {
@@ -84,7 +95,7 @@ pub(crate) async fn execute(params: RunTaskParams) -> RunOutcome {
             return outcome;
         }
 
-        let node = if let Some(n) = params.graph.nodes.get(&cursor.node) {
+        let node = if let Some(n) = lookup_in_active_frame(&params.graph, &cursor.node, &frames) {
             n.clone()
         } else {
             let err = format!("cursor at unknown node {}", cursor.node);
@@ -139,13 +150,24 @@ pub(crate) async fn execute(params: RunTaskParams) -> RunOutcome {
             .await
             .map(StageOutcome::Routed),
             NodeConfig::Terminal(cfg) => {
-                let r = execute_terminal_stage(TerminalStageParams {
-                    node: &cursor.node,
-                    terminal_config: cfg,
-                    writer: &params.writer,
-                })
-                .await;
-                r.map(StageOutcome::Terminal)
+                use crate::engine::frames::TerminalSignal;
+                match crate::engine::frames::on_terminal_decision(&frames, &cursor) {
+                    TerminalSignal::OuterComplete => {
+                        let r = execute_terminal_stage(TerminalStageParams {
+                            node: &cursor.node,
+                            terminal_config: cfg,
+                            writer: &params.writer,
+                        })
+                        .await;
+                        r.map(StageOutcome::Terminal)
+                    },
+                    TerminalSignal::LoopIterDone => {
+                        unimplemented!("M6 phase 5: execute_loop_iteration_done")
+                    },
+                    TerminalSignal::SubgraphDone => {
+                        unimplemented!("M6 phase 6: on_subgraph_done")
+                    },
+                }
             },
             NodeConfig::HumanGate(cfg) => {
                 let (tx, rx) = tokio::sync::oneshot::channel();
@@ -279,6 +301,25 @@ pub(crate) async fn execute(params: RunTaskParams) -> RunOutcome {
 enum StageOutcome {
     Routed(OutcomeKey),
     Terminal(TerminalOutcome),
+}
+
+fn lookup_in_active_frame<'a>(
+    graph: &'a surge_core::graph::Graph,
+    node_key: &surge_core::keys::NodeKey,
+    frames: &[crate::engine::frames::Frame],
+) -> Option<&'a surge_core::node::Node> {
+    use crate::engine::frames::Frame;
+    match frames.last() {
+        None => graph.nodes.get(node_key),
+        Some(Frame::Loop(lf)) => graph
+            .subgraphs
+            .get(&lf.config.body)
+            .and_then(|sg| sg.nodes.get(node_key)),
+        Some(Frame::Subgraph(sf)) => graph
+            .subgraphs
+            .get(&sf.inner_subgraph)
+            .and_then(|sg| sg.nodes.get(node_key)),
+    }
 }
 
 async fn failed(params: &RunTaskParams, error: String) -> RunOutcome {


### PR DESCRIPTION
## Summary

PR-2 of the M6 milestone series. Builds on PR #14 (foundations) by wiring the frame stack and traversal-aware routing into the per-run executor (`run_task::execute`). M5 acceptance preserved bit-for-bit — no fixture uses `max_traversals` or pushes frames, so the new code paths are unreachable from M5-shaped graphs.

After this PR, the engine has:
- `Frame` stack threaded through `RunTaskParams` and `execute`
- `lookup_in_active_frame` resolving node lookups against the active frame's body subgraph (or root graph)
- `Terminal` arm dispatching via `on_terminal_decision` — `OuterComplete` preserves the M5 path; `LoopIterDone` and `SubgraphDone` are `unimplemented!()` stubs awaiting Phase 5/6
- `next_node_after_with_counters` enforcing `EdgePolicy::max_traversals` per loop frame or root scope
- `ExceededTraversal::Escalate` synthesizing a `max_traversals_exceeded` outcome and re-routing
- `ExceededTraversal::Fail` halting the run

PR-3 (Phase 5 + 6) will populate the `unimplemented!()` branches with real `loop_stage::execute_loop_entry` / `on_loop_iteration_done` and `subgraph_stage::execute_subgraph_entry` / `on_subgraph_done`.

## Changes

| Commit | Scope |
|---|---|
| `8bcc61a` | Frames + traversal counts in `RunTaskParams`; `lookup_in_active_frame`; Terminal-arm `on_terminal_decision` dispatch |
| `93fac86` | `RoutingError::ExceededTraversal` + `next_node_after_with_counters` + `active_edge_set` helper |
| `33f1695` | Wire `next_node_after_with_counters` into `run_task::execute`, handle `Escalate`/`Fail` |

## Test plan

- [x] `cargo build --workspace` clean
- [x] `cargo test --workspace --lib` — all M5 + M6 tests pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] M5 fixtures don't push frames → `frames` empty throughout → `OuterComplete` branch always taken → M5 path bit-for-bit preserved
- [x] M5 fixtures don't set `max_traversals` → `next_node_after_with_counters` increments counters but never breaches → identical to M5 routing
- [ ] Manual smoke: load M5-era flow, drive to terminal, verify event log matches pre-PR

## Acceptance criteria satisfied (delta from PR #14)

The M6 spec §21 acceptance items advanced by this PR:
- Run-level: still satisfies #1, #2, #3, #18, #19, #20 (preserved from PR #14)
- New: routing-level instrumentation lays the foundation for #9 (`engine_m6_loop_max_traversals` integration test in PR-6)

Acceptance items still deferred:
- #7-#15 (engine integration tests requiring loop/subgraph stage entry → PR-3)
- #21 (CLI `surge engine run --watch` end-to-end → PR-5)
- #25 (surge-notify README + channel impls → PR-4)

## Follow-up PRs

| PR | Scope | Estimate |
|---|---|---|
| PR-3 (next) | Phase 5 + 6 — loop_stage + subgraph_stage execution; replaces `unimplemented!()` branches in this PR | ~1 week |
| PR-4 | Phase 7 + 8 — surge-notify channel impls + notify stage rewrite | ~1 week |
| PR-5 | Phase 9 — CLI engine subtree | ~3 days |
| PR-6 | Phase 10 + 11 — integration tests + rustdoc + clippy + README | ~3-5 days |

🤖 Generated with [Claude Code](https://claude.com/claude-code)