### PR TITLE
M6 P5 + P6: Loop and Subgraph stage execution

### DIFF
--- a/crates/surge-orchestrator/src/engine/engine.rs
+++ b/crates/surge-orchestrator/src/engine/engine.rs
@@ -67,7 +67,7 @@ impl Engine {
     ) -> Result<RunHandle, EngineError> {
         use crate::engine::handle::RunHandle;
         use crate::engine::run_task::{RunTaskParams, execute};
-        use crate::engine::validate::validate_for_m5;
+        use crate::engine::validate::validate_for_m6;
         use surge_core::approvals::ApprovalPolicy;
         use surge_core::content_hash::ContentHash;
         use surge_core::run_event::{
@@ -77,7 +77,7 @@ impl Engine {
         use tokio::sync::broadcast;
         use tokio_util::sync::CancellationToken;
 
-        validate_for_m5(&graph)?;
+        validate_for_m6(&graph)?;
 
         if self.runs.read().await.contains_key(&run_id) {
             return Err(EngineError::RunAlreadyActive(run_id));

--- a/crates/surge-orchestrator/src/engine/error.rs
+++ b/crates/surge-orchestrator/src/engine/error.rs
@@ -42,6 +42,14 @@ pub enum EngineError {
     /// An unexpected internal condition occurred.
     #[error("internal engine error: {0}")]
     Internal(String),
+
+    /// A Loop node references a body subgraph that is not in `graph.subgraphs`.
+    #[error("loop body reference {0} not found in graph.subgraphs")]
+    LoopBodyMissing(surge_core::keys::SubgraphKey),
+
+    /// A Subgraph node references an inner subgraph that is not in `graph.subgraphs`.
+    #[error("subgraph reference {0} not found in graph.subgraphs")]
+    SubgraphMissing(surge_core::keys::SubgraphKey),
 }
 
 #[cfg(test)]

--- a/crates/surge-orchestrator/src/engine/routing.rs
+++ b/crates/surge-orchestrator/src/engine/routing.rs
@@ -125,6 +125,26 @@ pub fn next_node_after_with_counters(
     Ok(edge_to)
 }
 
+/// Find the outgoing edge target for `(node, outcome)`. If no edge
+/// matches, error out. Used at frame-push time to compute `return_to`
+/// for Loop/Subgraph frames — they need to know where to advance the
+/// outer cursor when the inner subgraph terminates.
+pub fn edge_target_after_outcome_or_default(
+    graph: &Graph,
+    node: &NodeKey,
+    outcome: &OutcomeKey,
+) -> Result<NodeKey, RoutingError> {
+    graph
+        .edges
+        .iter()
+        .find(|e| &e.from.node == node && &e.from.outcome == outcome)
+        .map(|e| e.to.clone())
+        .ok_or_else(|| RoutingError::NoMatchingEdge {
+            from: node.clone(),
+            outcome: outcome.clone(),
+        })
+}
+
 fn active_edge_set<'a>(graph: &'a Graph, frames: &[crate::engine::frames::Frame]) -> &'a [Edge] {
     use crate::engine::frames::Frame;
     match frames.last() {

--- a/crates/surge-orchestrator/src/engine/run_task.rs
+++ b/crates/surge-orchestrator/src/engine/run_task.rs
@@ -162,7 +162,31 @@ pub(crate) async fn execute(params: RunTaskParams) -> RunOutcome {
                         r.map(StageOutcome::Terminal)
                     },
                     TerminalSignal::LoopIterDone => {
-                        unimplemented!("M6 phase 5: execute_loop_iteration_done")
+                        // The most recent OutcomeReported event drives the iteration's outcome.
+                        let just_completed = memory
+                            .outcomes
+                            .get(&cursor.node)
+                            .and_then(|recs| recs.last())
+                            .map_or_else(
+                                || {
+                                    surge_core::keys::OutcomeKey::try_from("completed")
+                                        .expect("'completed' is valid OutcomeKey")
+                                },
+                                |r| r.outcome.clone(),
+                            );
+
+                        if let Err(e) = crate::engine::stage::loop_stage::on_loop_iteration_done(
+                            &just_completed,
+                            &params.graph,
+                            &mut frames,
+                            &mut cursor,
+                            &params.writer,
+                        )
+                        .await
+                        {
+                            return failed(&params, format!("loop iter done: {e}")).await;
+                        }
+                        continue;
                     },
                     TerminalSignal::SubgraphDone => {
                         unimplemented!("M6 phase 6: on_subgraph_done")
@@ -188,8 +212,51 @@ pub(crate) async fn execute(params: RunTaskParams) -> RunOutcome {
                 params.gate_resolutions.lock().await.remove(&cursor.node);
                 r.map(StageOutcome::Routed)
             },
-            NodeConfig::Loop(_) | NodeConfig::Subgraph(_) => Err(StageError::Internal(format!(
-                "node kind {:?} not supported in M5",
+            NodeConfig::Loop(cfg) => {
+                // Compute return_to (outer-graph node to advance to when loop completes).
+                let completed_outcome = match surge_core::keys::OutcomeKey::try_from("completed") {
+                    Ok(o) => o,
+                    Err(e) => return failed(&params, format!("'completed' outcome: {e}")).await,
+                };
+                let return_to = match crate::engine::routing::edge_target_after_outcome_or_default(
+                    &params.graph,
+                    &cursor.node,
+                    &completed_outcome,
+                ) {
+                    Ok(n) => n,
+                    Err(e) => return failed(&params, format!("loop return_to: {e}")).await,
+                };
+
+                let effect = match crate::engine::stage::loop_stage::execute_loop_entry(
+                    crate::engine::stage::loop_stage::LoopStageParams {
+                        node: &cursor.node,
+                        loop_config: cfg,
+                        graph: &params.graph,
+                        run_memory: &memory,
+                        writer: &params.writer,
+                        frames: &mut frames,
+                        return_to,
+                    },
+                )
+                .await
+                {
+                    Ok(e) => e,
+                    Err(e) => return failed(&params, format!("loop entry: {e}")).await,
+                };
+
+                match effect {
+                    crate::engine::stage::loop_stage::LoopEntryEffect::Skipped(outcome) => {
+                        Ok(StageOutcome::Routed(outcome))
+                    },
+                    crate::engine::stage::loop_stage::LoopEntryEffect::Entered(body_start) => {
+                        cursor.node = body_start;
+                        cursor.attempt = 1;
+                        continue; // Skip the routing block below — we're in a fresh frame's body.
+                    },
+                }
+            },
+            NodeConfig::Subgraph(_) => Err(StageError::Internal(format!(
+                "node kind {:?} not supported until M6 P6.3",
                 node.kind()
             ))),
         };

--- a/crates/surge-orchestrator/src/engine/run_task.rs
+++ b/crates/surge-orchestrator/src/engine/run_task.rs
@@ -189,7 +189,47 @@ pub(crate) async fn execute(params: RunTaskParams) -> RunOutcome {
                         continue;
                     },
                     TerminalSignal::SubgraphDone => {
-                        unimplemented!("M6 phase 6: on_subgraph_done")
+                        // Look up the outer SubgraphConfig::outputs by walking back to the
+                        // outer node referenced by the top frame.
+                        let outputs = match frames.last() {
+                            Some(crate::engine::frames::Frame::Subgraph(sf)) => {
+                                match params.graph.nodes.get(&sf.outer_node).map(|n| &n.config) {
+                                    Some(surge_core::node::NodeConfig::Subgraph(cfg)) => {
+                                        cfg.outputs.clone()
+                                    },
+                                    _ => {
+                                        return failed(
+                                            &params,
+                                            format!(
+                                                "outer subgraph node {} missing or wrong kind",
+                                                sf.outer_node
+                                            ),
+                                        )
+                                        .await;
+                                    },
+                                }
+                            },
+                            _ => {
+                                return failed(
+                                    &params,
+                                    "SubgraphDone signal but no Subgraph frame on top".into(),
+                                )
+                                .await;
+                            },
+                        };
+
+                        if let Err(e) = crate::engine::stage::subgraph_stage::on_subgraph_done(
+                            &outputs,
+                            &memory,
+                            &mut frames,
+                            &mut cursor,
+                            &params.writer,
+                        )
+                        .await
+                        {
+                            return failed(&params, format!("subgraph done: {e}")).await;
+                        }
+                        continue;
                     },
                 }
             },
@@ -255,10 +295,41 @@ pub(crate) async fn execute(params: RunTaskParams) -> RunOutcome {
                     },
                 }
             },
-            NodeConfig::Subgraph(_) => Err(StageError::Internal(format!(
-                "node kind {:?} not supported until M6 P6.3",
-                node.kind()
-            ))),
+            NodeConfig::Subgraph(cfg) => {
+                let completed_outcome = match surge_core::keys::OutcomeKey::try_from("completed") {
+                    Ok(o) => o,
+                    Err(e) => return failed(&params, format!("'completed' outcome: {e}")).await,
+                };
+                let return_to = match crate::engine::routing::edge_target_after_outcome_or_default(
+                    &params.graph,
+                    &cursor.node,
+                    &completed_outcome,
+                ) {
+                    Ok(n) => n,
+                    Err(e) => return failed(&params, format!("subgraph return_to: {e}")).await,
+                };
+
+                let effect = match crate::engine::stage::subgraph_stage::execute_subgraph_entry(
+                    crate::engine::stage::subgraph_stage::SubgraphStageParams {
+                        node: &cursor.node,
+                        subgraph_config: cfg,
+                        graph: &params.graph,
+                        run_memory: &memory,
+                        writer: &params.writer,
+                        frames: &mut frames,
+                        return_to,
+                    },
+                )
+                .await
+                {
+                    Ok(e) => e,
+                    Err(e) => return failed(&params, format!("subgraph entry: {e}")).await,
+                };
+
+                cursor.node = effect.inner_start;
+                cursor.attempt = 1;
+                continue; // Skip routing block — we're now in the inner subgraph's body.
+            },
         };
 
         let outcome: OutcomeKey = match stage_result {

--- a/crates/surge-orchestrator/src/engine/stage/loop_stage.rs
+++ b/crates/surge-orchestrator/src/engine/stage/loop_stage.rs
@@ -49,7 +49,7 @@ pub async fn execute_loop_entry(p: LoopStageParams<'_>) -> Result<LoopEntryEffec
         .get(&p.loop_config.body)
         .ok_or_else(|| StageError::LoopBodyMissing(p.loop_config.body.clone()))?;
 
-    let items = resolve_iterable(&p.loop_config.iterates_over, p.run_memory)?;
+    let items = resolve_iterable(&p.loop_config.iterates_over, p.run_memory).await?;
 
     if items.len() > MAX_LOOP_ITEMS_RESOLVED {
         return Err(StageError::LoopItemsTooLarge {
@@ -100,7 +100,7 @@ pub async fn execute_loop_entry(p: LoopStageParams<'_>) -> Result<LoopEntryEffec
     Ok(LoopEntryEffect::Entered(body_start))
 }
 
-fn resolve_iterable(
+async fn resolve_iterable(
     src: &IterableSource,
     memory: &RunMemory,
 ) -> Result<Vec<toml::Value>, StageError> {
@@ -108,14 +108,46 @@ fn resolve_iterable(
         IterableSource::Static(items) => Ok(items.clone()),
         IterableSource::Artifact {
             node: _,
-            name: _,
-            jsonpath: _,
+            name,
+            jsonpath,
         } => {
-            let _ = memory;
-            // M6 P5.2 will implement Artifact resolution.
-            Err(StageError::Internal(
-                "IterableSource::Artifact resolution not yet implemented (M6 P5.2)".into(),
-            ))
+            let artifact = memory.artifacts.get(name).ok_or_else(|| {
+                StageError::Internal(format!("artifact '{name}' not in RunMemory"))
+            })?;
+
+            let bytes = tokio::fs::read(&artifact.path).await.map_err(|e| {
+                StageError::Internal(format!("read artifact {}: {e}", artifact.path.display()))
+            })?;
+
+            // M6 supports TOML artifacts with a simple dotted path.
+            // (JSON support could be added later; current vibe-flow artifacts
+            // are TOML by convention — see CLAUDE.md.)
+            let content = std::str::from_utf8(&bytes).map_err(|e| {
+                StageError::Internal(format!(
+                    "artifact {} not utf8: {e}",
+                    artifact.path.display()
+                ))
+            })?;
+            let parsed: toml::Value = toml::from_str(content).map_err(|e| {
+                StageError::Internal(format!("toml parse {}: {e}", artifact.path.display()))
+            })?;
+
+            // Walk the dotted path.
+            let mut cursor = &parsed;
+            for segment in jsonpath.split('.') {
+                cursor = cursor.get(segment).ok_or_else(|| {
+                    StageError::Internal(format!(
+                        "path segment '{segment}' not found in {jsonpath}"
+                    ))
+                })?;
+            }
+
+            match cursor {
+                toml::Value::Array(arr) => Ok(arr.clone()),
+                other => Err(StageError::Internal(format!(
+                    "path {jsonpath} resolved to non-array: {other:?}"
+                ))),
+            }
         },
     }
 }
@@ -317,5 +349,41 @@ mod tests {
             },
             other => panic!("expected LoopItemsTooLarge, got {other:?}"),
         }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn artifact_iterable_resolves_dotted_path() {
+        let dir = tempfile::tempdir().unwrap();
+
+        // Write an artifact with a TOML array under "tasks".
+        let artifact_content = r#"
+tasks = ["task1", "task2", "task3"]
+"#;
+        let artifact_path = dir.path().join("plan.toml");
+        std::fs::write(&artifact_path, artifact_content).unwrap();
+
+        // Build RunMemory with the artifact registered.
+        let mut memory = RunMemory::default();
+        memory.artifacts.insert(
+            "plan.toml".into(),
+            surge_core::run_state::ArtifactRef {
+                hash: surge_core::content_hash::ContentHash::compute(artifact_content.as_bytes()),
+                path: artifact_path,
+                name: "plan.toml".into(),
+                produced_by: NodeKey::try_from("planner").unwrap(),
+                produced_at_seq: 1,
+            },
+        );
+
+        let src = IterableSource::Artifact {
+            node: NodeKey::try_from("planner").unwrap(),
+            name: "plan.toml".into(),
+            jsonpath: "tasks".into(),
+        };
+
+        let items = resolve_iterable(&src, &memory).await.unwrap();
+        assert_eq!(items.len(), 3);
+        assert_eq!(items[0], toml::Value::String("task1".into()));
+        assert_eq!(items[2], toml::Value::String("task3".into()));
     }
 }

--- a/crates/surge-orchestrator/src/engine/stage/loop_stage.rs
+++ b/crates/surge-orchestrator/src/engine/stage/loop_stage.rs
@@ -1,0 +1,321 @@
+//! `NodeKind::Loop` stage execution — frame-push, iteration boundary,
+//! exit-condition handling. Single-threaded per spec §6.3-6.4.
+
+use crate::engine::frames::{
+    Frame, LoopFrame, MAX_LOOP_ITEMS_RESOLVED, initial_attempts_remaining,
+};
+use crate::engine::stage::StageError;
+use std::collections::HashMap;
+use surge_core::graph::Graph;
+use surge_core::keys::{NodeKey, OutcomeKey};
+use surge_core::loop_config::{IterableSource, LoopConfig};
+use surge_core::run_event::{EventPayload, VersionedEventPayload};
+use surge_core::run_state::RunMemory;
+use surge_persistence::runs::run_writer::RunWriter;
+
+/// Parameters for `execute_loop_entry`.
+pub struct LoopStageParams<'a> {
+    /// `NodeKey` of the Loop node being entered.
+    pub node: &'a NodeKey,
+    /// Loop configuration from the node.
+    pub loop_config: &'a LoopConfig,
+    /// Frozen pipeline graph (used for body subgraph lookup).
+    pub graph: &'a Graph,
+    /// In-progress run memory (artifacts / outcomes used to resolve `IterableSource::Artifact`).
+    pub run_memory: &'a RunMemory,
+    /// Run writer for persisting events.
+    pub writer: &'a RunWriter,
+    /// Mutable frame stack — frame pushed on non-empty entry.
+    pub frames: &'a mut Vec<Frame>,
+    /// Outer-graph node to advance to when the loop completes.
+    /// Caller computes via routing's `edge_target_after_outcome_or_default`.
+    pub return_to: NodeKey,
+}
+
+/// Outcome of executing a Loop entry stage.
+#[derive(Debug)]
+pub enum LoopEntryEffect {
+    /// Empty iterable — frame NOT pushed; run loop routes via this outcome.
+    Skipped(OutcomeKey),
+    /// Frame pushed; run loop must advance cursor to this body-subgraph start.
+    Entered(NodeKey),
+}
+
+/// Resolve the iterable + push a `LoopFrame` if non-empty. See task description.
+pub async fn execute_loop_entry(p: LoopStageParams<'_>) -> Result<LoopEntryEffect, StageError> {
+    let body_subgraph = p
+        .graph
+        .subgraphs
+        .get(&p.loop_config.body)
+        .ok_or_else(|| StageError::LoopBodyMissing(p.loop_config.body.clone()))?;
+
+    let items = resolve_iterable(&p.loop_config.iterates_over, p.run_memory)?;
+
+    if items.len() > MAX_LOOP_ITEMS_RESOLVED {
+        return Err(StageError::LoopItemsTooLarge {
+            count: u32::try_from(items.len()).unwrap_or(u32::MAX),
+            // MAX_LOOP_ITEMS_RESOLVED = 1000 always fits in u32.
+            #[allow(clippy::cast_possible_truncation)]
+            max: MAX_LOOP_ITEMS_RESOLVED as u32,
+        });
+    }
+
+    if items.is_empty() {
+        let outcome = OutcomeKey::try_from("loop_empty")
+            .map_err(|e| StageError::Internal(format!("'loop_empty' key: {e}")))?;
+        p.writer
+            .append_event(VersionedEventPayload::new(EventPayload::LoopCompleted {
+                loop_id: p.node.clone(),
+                completed_iterations: 0,
+                final_outcome: outcome.clone(),
+            }))
+            .await
+            .map_err(|e| StageError::Storage(e.to_string()))?;
+        return Ok(LoopEntryEffect::Skipped(outcome));
+    }
+
+    let body_start = body_subgraph.start.clone();
+
+    p.frames.push(Frame::Loop(LoopFrame {
+        loop_node: p.node.clone(),
+        config: p.loop_config.clone(),
+        items: items.clone(),
+        current_index: 0,
+        attempts_remaining: initial_attempts_remaining(&p.loop_config.on_iteration_failure),
+        return_to: p.return_to,
+        traversal_counts: HashMap::new(),
+    }));
+
+    p.writer
+        .append_event(VersionedEventPayload::new(
+            EventPayload::LoopIterationStarted {
+                loop_id: p.node.clone(),
+                item: items[0].clone(),
+                index: 0,
+            },
+        ))
+        .await
+        .map_err(|e| StageError::Storage(e.to_string()))?;
+
+    Ok(LoopEntryEffect::Entered(body_start))
+}
+
+fn resolve_iterable(
+    src: &IterableSource,
+    memory: &RunMemory,
+) -> Result<Vec<toml::Value>, StageError> {
+    match src {
+        IterableSource::Static(items) => Ok(items.clone()),
+        IterableSource::Artifact {
+            node: _,
+            name: _,
+            jsonpath: _,
+        } => {
+            let _ = memory;
+            // M6 P5.2 will implement Artifact resolution.
+            Err(StageError::Internal(
+                "IterableSource::Artifact resolution not yet implemented (M6 P5.2)".into(),
+            ))
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use surge_core::graph::{GraphMetadata, SCHEMA_VERSION, Subgraph};
+    use surge_core::keys::{NodeKey, SubgraphKey};
+    use surge_core::loop_config::{ExitCondition, FailurePolicy, ParallelismMode};
+    use surge_core::node::{Node, NodeConfig, OutcomeDecl, Position};
+    use surge_core::terminal_config::{TerminalConfig, TerminalKind};
+    use surge_persistence::runs::Storage;
+
+    fn graph_with_loop_body(items: Vec<toml::Value>) -> (Graph, LoopConfig, NodeKey) {
+        let loop_key = NodeKey::try_from("loop_1").unwrap();
+        let body_key = SubgraphKey::try_from("body").unwrap();
+        let body_start = NodeKey::try_from("body_start").unwrap();
+
+        let body_node = Node {
+            id: body_start.clone(),
+            position: Position::default(),
+            declared_outcomes: vec![],
+            config: NodeConfig::Terminal(TerminalConfig {
+                kind: TerminalKind::Success,
+                message: None,
+            }),
+        };
+
+        let cfg = LoopConfig {
+            iterates_over: IterableSource::Static(items),
+            body: body_key.clone(),
+            iteration_var_name: "item".into(),
+            exit_condition: ExitCondition::AllItems,
+            on_iteration_failure: FailurePolicy::Abort,
+            parallelism: ParallelismMode::Sequential,
+            gate_after_each: false,
+        };
+
+        let mut nodes = std::collections::BTreeMap::new();
+        nodes.insert(
+            loop_key.clone(),
+            Node {
+                id: loop_key.clone(),
+                position: Position::default(),
+                declared_outcomes: vec![OutcomeDecl {
+                    id: OutcomeKey::try_from("completed").unwrap(),
+                    description: "ok".into(),
+                    edge_kind_hint: surge_core::edge::EdgeKind::Forward,
+                    is_terminal: false,
+                }],
+                config: NodeConfig::Loop(cfg.clone()),
+            },
+        );
+
+        let mut body_nodes = std::collections::BTreeMap::new();
+        body_nodes.insert(body_start.clone(), body_node);
+
+        let mut subgraphs = std::collections::BTreeMap::new();
+        subgraphs.insert(
+            body_key,
+            Subgraph {
+                start: body_start,
+                nodes: body_nodes,
+                edges: vec![],
+            },
+        );
+
+        let graph = Graph {
+            schema_version: SCHEMA_VERSION,
+            metadata: GraphMetadata {
+                name: "t".into(),
+                description: None,
+                template_origin: None,
+                created_at: chrono::Utc::now(),
+                author: None,
+            },
+            start: loop_key.clone(),
+            nodes,
+            edges: vec![],
+            subgraphs,
+        };
+
+        (graph, cfg, loop_key)
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn empty_iterable_skips_frame_push() {
+        let dir = tempfile::tempdir().unwrap();
+        let storage = Storage::open(dir.path()).await.unwrap();
+        let writer = storage
+            .create_run(surge_core::id::RunId::new(), dir.path(), None)
+            .await
+            .unwrap();
+
+        let (graph, cfg, loop_key) = graph_with_loop_body(vec![]);
+        let memory = RunMemory::default();
+        let mut frames: Vec<Frame> = vec![];
+
+        let effect = execute_loop_entry(LoopStageParams {
+            node: &loop_key,
+            loop_config: &cfg,
+            graph: &graph,
+            run_memory: &memory,
+            writer: &writer,
+            frames: &mut frames,
+            return_to: NodeKey::try_from("after").unwrap(),
+        })
+        .await
+        .unwrap();
+
+        match effect {
+            LoopEntryEffect::Skipped(o) => assert_eq!(o.as_ref(), "loop_empty"),
+            LoopEntryEffect::Entered(_) => panic!("expected Skipped for empty iterable"),
+        }
+        assert!(frames.is_empty(), "frame stack should remain empty");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn three_items_pushes_frame_and_advances_to_body_start() {
+        let dir = tempfile::tempdir().unwrap();
+        let storage = Storage::open(dir.path()).await.unwrap();
+        let writer = storage
+            .create_run(surge_core::id::RunId::new(), dir.path(), None)
+            .await
+            .unwrap();
+
+        let items = vec![
+            toml::Value::Integer(1),
+            toml::Value::Integer(2),
+            toml::Value::Integer(3),
+        ];
+        let (graph, cfg, loop_key) = graph_with_loop_body(items);
+        let memory = RunMemory::default();
+        let mut frames: Vec<Frame> = vec![];
+
+        let effect = execute_loop_entry(LoopStageParams {
+            node: &loop_key,
+            loop_config: &cfg,
+            graph: &graph,
+            run_memory: &memory,
+            writer: &writer,
+            frames: &mut frames,
+            return_to: NodeKey::try_from("after").unwrap(),
+        })
+        .await
+        .unwrap();
+
+        match effect {
+            LoopEntryEffect::Entered(node) => {
+                assert_eq!(node, NodeKey::try_from("body_start").unwrap());
+            },
+            LoopEntryEffect::Skipped(_) => panic!("expected Entered for non-empty iterable"),
+        }
+        assert_eq!(frames.len(), 1);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn items_above_resolved_cap_returns_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let storage = Storage::open(dir.path()).await.unwrap();
+        let writer = storage
+            .create_run(surge_core::id::RunId::new(), dir.path(), None)
+            .await
+            .unwrap();
+
+        // Note: surge-core validation rejects Static lists > MAX_LOOP_ITEMS_STATIC
+        // at TOML load — so we bypass core validation by constructing the
+        // graph in-memory and calling execute_loop_entry directly. This
+        // exercises the engine-side defensive cap (MAX_LOOP_ITEMS_RESOLVED).
+        #[allow(clippy::cast_possible_wrap)]
+        let items: Vec<toml::Value> = (0..=MAX_LOOP_ITEMS_RESOLVED)
+            .map(|i| toml::Value::Integer(i as i64))
+            .collect();
+        let (graph, cfg, loop_key) = graph_with_loop_body(items);
+        let memory = RunMemory::default();
+        let mut frames: Vec<Frame> = vec![];
+
+        let result = execute_loop_entry(LoopStageParams {
+            node: &loop_key,
+            loop_config: &cfg,
+            graph: &graph,
+            run_memory: &memory,
+            writer: &writer,
+            frames: &mut frames,
+            return_to: NodeKey::try_from("after").unwrap(),
+        })
+        .await;
+
+        match result {
+            Err(StageError::LoopItemsTooLarge { count, max }) => {
+                // MAX_LOOP_ITEMS_RESOLVED = 1000 always fits in u32.
+                #[allow(clippy::cast_possible_truncation)]
+                let expected_count = MAX_LOOP_ITEMS_RESOLVED as u32 + 1;
+                #[allow(clippy::cast_possible_truncation)]
+                let expected_max = MAX_LOOP_ITEMS_RESOLVED as u32;
+                assert_eq!(count, expected_count);
+                assert_eq!(max, expected_max);
+            },
+            other => panic!("expected LoopItemsTooLarge, got {other:?}"),
+        }
+    }
+}

--- a/crates/surge-orchestrator/src/engine/stage/loop_stage.rs
+++ b/crates/surge-orchestrator/src/engine/stage/loop_stage.rs
@@ -152,6 +152,243 @@ async fn resolve_iterable(
     }
 }
 
+/// Called by `run_task::execute` when the cursor reaches a `Terminal`
+/// node and the top frame is a `LoopFrame` (`TerminalSignal::LoopIterDone`).
+/// Decides whether to advance to the next iteration, retry the same
+/// iteration (per `FailurePolicy`), or pop the frame and return to the
+/// outer cursor.
+#[allow(clippy::too_many_lines)]
+pub async fn on_loop_iteration_done(
+    just_completed_outcome: &OutcomeKey,
+    graph: &Graph,
+    frames: &mut Vec<Frame>,
+    cursor: &mut surge_core::run_state::Cursor,
+    writer: &RunWriter,
+) -> Result<(), StageError> {
+    let Some(Frame::Loop(lf)) = frames.last_mut() else {
+        return Err(StageError::Internal(
+            "on_loop_iteration_done called without Loop frame on top".into(),
+        ));
+    };
+
+    // Persist the per-iteration completion event.
+    writer
+        .append_event(VersionedEventPayload::new(
+            EventPayload::LoopIterationCompleted {
+                loop_id: lf.loop_node.clone(),
+                index: lf.current_index,
+                outcome: just_completed_outcome.clone(),
+            },
+        ))
+        .await
+        .map_err(|e| StageError::Storage(e.to_string()))?;
+
+    // 1. Iteration-failure handling.
+    if is_failure_outcome(just_completed_outcome) {
+        match lf.config.on_iteration_failure.clone() {
+            surge_core::loop_config::FailurePolicy::Abort => {
+                let loop_node = lf.loop_node.clone();
+                let completed_iterations = lf.current_index + 1;
+                let return_to = lf.return_to.clone();
+                exit_loop(
+                    loop_node,
+                    completed_iterations,
+                    return_to,
+                    frames,
+                    cursor,
+                    "aborted",
+                    writer,
+                )
+                .await?;
+                return Ok(());
+            },
+            surge_core::loop_config::FailurePolicy::Skip => {
+                // fall through to advance-index
+            },
+            surge_core::loop_config::FailurePolicy::Retry { .. } if lf.attempts_remaining > 0 => {
+                lf.attempts_remaining -= 1;
+                let body_start = body_subgraph_start(graph, lf)?;
+                let item = lf.items[lf.current_index as usize].clone();
+                let loop_id = lf.loop_node.clone();
+                let index = lf.current_index;
+                cursor.node = body_start;
+                cursor.attempt += 1;
+                writer
+                    .append_event(VersionedEventPayload::new(
+                        EventPayload::LoopIterationStarted {
+                            loop_id,
+                            item,
+                            index,
+                        },
+                    ))
+                    .await
+                    .map_err(|e| StageError::Storage(e.to_string()))?;
+                return Ok(());
+            },
+            surge_core::loop_config::FailurePolicy::Retry { .. } => {
+                // attempts exhausted — treat as Abort
+                let loop_node = lf.loop_node.clone();
+                let completed_iterations = lf.current_index + 1;
+                let return_to = lf.return_to.clone();
+                exit_loop(
+                    loop_node,
+                    completed_iterations,
+                    return_to,
+                    frames,
+                    cursor,
+                    "aborted",
+                    writer,
+                )
+                .await?;
+                return Ok(());
+            },
+            surge_core::loop_config::FailurePolicy::Replan => {
+                tracing::warn!(
+                    loop_id = %lf.loop_node,
+                    "FailurePolicy::Replan not implemented in M6 — treating as Abort (Replan needs bootstrap from M8)"
+                );
+                let loop_node = lf.loop_node.clone();
+                let completed_iterations = lf.current_index + 1;
+                let return_to = lf.return_to.clone();
+                exit_loop(
+                    loop_node,
+                    completed_iterations,
+                    return_to,
+                    frames,
+                    cursor,
+                    "aborted",
+                    writer,
+                )
+                .await?;
+                return Ok(());
+            },
+        }
+    }
+
+    // 2. Exit-condition check (only reached on success or Skip path).
+    {
+        let Some(Frame::Loop(lf)) = frames.last() else {
+            unreachable!("frame was on stack at failure check")
+        };
+        if exit_condition_met(lf, just_completed_outcome) {
+            let loop_node = lf.loop_node.clone();
+            let completed_iterations = lf.current_index + 1;
+            let return_to = lf.return_to.clone();
+            exit_loop(
+                loop_node,
+                completed_iterations,
+                return_to,
+                frames,
+                cursor,
+                "completed",
+                writer,
+            )
+            .await?;
+            return Ok(());
+        }
+    }
+
+    // 3. Advance to next iteration.
+    let Some(Frame::Loop(lf)) = frames.last_mut() else {
+        unreachable!("frame was on stack at exit-condition check")
+    };
+    lf.current_index += 1;
+
+    #[allow(clippy::cast_possible_truncation)] // items bounded by MAX_LOOP_ITEMS_RESOLVED (1000)
+    if lf.current_index >= lf.items.len() as u32 {
+        let loop_node = lf.loop_node.clone();
+        let completed_iterations = lf.current_index + 1;
+        let return_to = lf.return_to.clone();
+        exit_loop(
+            loop_node,
+            completed_iterations,
+            return_to,
+            frames,
+            cursor,
+            "completed",
+            writer,
+        )
+        .await?;
+        return Ok(());
+    }
+
+    let body_start = body_subgraph_start(graph, lf)?;
+    let item = lf.items[lf.current_index as usize].clone();
+    let loop_id = lf.loop_node.clone();
+    let index = lf.current_index;
+    cursor.node = body_start;
+    cursor.attempt = 1;
+
+    writer
+        .append_event(VersionedEventPayload::new(
+            EventPayload::LoopIterationStarted {
+                loop_id,
+                item,
+                index,
+            },
+        ))
+        .await
+        .map_err(|e| StageError::Storage(e.to_string()))?;
+
+    Ok(())
+}
+
+/// Returns `true` for outcomes that count as iteration failures for
+/// `FailurePolicy` purposes. Conservative literal match — authors who
+/// want richer failure semantics declare an explicit `Branch` node
+/// before the loop.
+fn is_failure_outcome(outcome: &OutcomeKey) -> bool {
+    matches!(outcome.as_ref(), "failed" | "fail" | "error")
+}
+
+fn exit_condition_met(lf: &LoopFrame, just_completed: &OutcomeKey) -> bool {
+    use surge_core::loop_config::ExitCondition;
+    match &lf.config.exit_condition {
+        #[allow(clippy::cast_possible_truncation)]
+        // items bounded by MAX_LOOP_ITEMS_RESOLVED (1000)
+        ExitCondition::AllItems => lf.current_index + 1 >= lf.items.len() as u32,
+        ExitCondition::UntilOutcome {
+            from_node: _,
+            outcome,
+        } => just_completed == outcome,
+        ExitCondition::MaxIterations { n } => lf.current_index + 1 >= *n,
+    }
+}
+
+async fn exit_loop(
+    loop_node: NodeKey,
+    completed_iterations: u32,
+    return_to: NodeKey,
+    frames: &mut Vec<Frame>,
+    cursor: &mut surge_core::run_state::Cursor,
+    final_outcome_str: &str,
+    writer: &RunWriter,
+) -> Result<(), StageError> {
+    let final_outcome = OutcomeKey::try_from(final_outcome_str)
+        .map_err(|e| StageError::Internal(format!("'{final_outcome_str}' outcome key: {e}")))?;
+    writer
+        .append_event(VersionedEventPayload::new(EventPayload::LoopCompleted {
+            loop_id: loop_node,
+            completed_iterations,
+            final_outcome,
+        }))
+        .await
+        .map_err(|e| StageError::Storage(e.to_string()))?;
+    frames.pop();
+    cursor.node = return_to;
+    cursor.attempt = 1;
+    Ok(())
+}
+
+fn body_subgraph_start(graph: &Graph, lf: &LoopFrame) -> Result<NodeKey, StageError> {
+    Ok(graph
+        .subgraphs
+        .get(&lf.config.body)
+        .ok_or_else(|| StageError::LoopBodyMissing(lf.config.body.clone()))?
+        .start
+        .clone())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -349,6 +586,85 @@ mod tests {
             },
             other => panic!("expected LoopItemsTooLarge, got {other:?}"),
         }
+    }
+
+    use surge_core::run_state::Cursor;
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn iteration_advance_increments_index() {
+        let dir = tempfile::tempdir().unwrap();
+        let storage = Storage::open(dir.path()).await.unwrap();
+        let writer = storage
+            .create_run(surge_core::id::RunId::new(), dir.path(), None)
+            .await
+            .unwrap();
+
+        let items = vec![toml::Value::Integer(1), toml::Value::Integer(2)];
+        let (graph, cfg, loop_key) = graph_with_loop_body(items.clone());
+        let return_to = NodeKey::try_from("after").unwrap();
+        let mut frames: Vec<Frame> = vec![Frame::Loop(LoopFrame {
+            loop_node: loop_key.clone(),
+            config: cfg,
+            items,
+            current_index: 0,
+            attempts_remaining: 0,
+            return_to: return_to.clone(),
+            traversal_counts: HashMap::new(),
+        })];
+        let mut cursor = Cursor {
+            node: NodeKey::try_from("body_start").unwrap(),
+            attempt: 1,
+        };
+
+        let just_completed = OutcomeKey::try_from("done").unwrap();
+        on_loop_iteration_done(&just_completed, &graph, &mut frames, &mut cursor, &writer)
+            .await
+            .unwrap();
+
+        let Frame::Loop(lf) = &frames[0] else {
+            panic!("expected Loop frame")
+        };
+        assert_eq!(lf.current_index, 1, "advanced to next iteration");
+        assert_eq!(
+            cursor.node,
+            NodeKey::try_from("body_start").unwrap(),
+            "cursor reset to body start"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn iteration_done_at_last_index_pops_frame() {
+        let dir = tempfile::tempdir().unwrap();
+        let storage = Storage::open(dir.path()).await.unwrap();
+        let writer = storage
+            .create_run(surge_core::id::RunId::new(), dir.path(), None)
+            .await
+            .unwrap();
+
+        let items = vec![toml::Value::Integer(1)];
+        let (graph, cfg, loop_key) = graph_with_loop_body(items.clone());
+        let return_to = NodeKey::try_from("after").unwrap();
+        let mut frames: Vec<Frame> = vec![Frame::Loop(LoopFrame {
+            loop_node: loop_key,
+            config: cfg,
+            items,
+            current_index: 0,
+            attempts_remaining: 0,
+            return_to: return_to.clone(),
+            traversal_counts: HashMap::new(),
+        })];
+        let mut cursor = Cursor {
+            node: NodeKey::try_from("body_start").unwrap(),
+            attempt: 1,
+        };
+
+        let just_completed = OutcomeKey::try_from("done").unwrap();
+        on_loop_iteration_done(&just_completed, &graph, &mut frames, &mut cursor, &writer)
+            .await
+            .unwrap();
+
+        assert!(frames.is_empty(), "frame popped after last iteration");
+        assert_eq!(cursor.node, return_to, "cursor restored to return_to");
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/surge-orchestrator/src/engine/stage/mod.rs
+++ b/crates/surge-orchestrator/src/engine/stage/mod.rs
@@ -6,6 +6,7 @@ pub mod branch;
 pub mod human_gate;
 pub mod loop_stage;
 pub mod notify;
+pub mod subgraph_stage;
 pub mod terminal;
 
 use crate::engine::error::EngineError;

--- a/crates/surge-orchestrator/src/engine/stage/mod.rs
+++ b/crates/surge-orchestrator/src/engine/stage/mod.rs
@@ -4,6 +4,7 @@ pub mod agent;
 pub mod bindings;
 pub mod branch;
 pub mod human_gate;
+pub mod loop_stage;
 pub mod notify;
 pub mod terminal;
 
@@ -49,6 +50,27 @@ pub enum StageError {
     /// An unexpected internal condition occurred within the stage executor.
     #[error("internal: {0}")]
     Internal(String),
+
+    /// Loop body subgraph not found in `Graph::subgraphs`.
+    #[error("loop body subgraph not found: {0}")]
+    LoopBodyMissing(surge_core::keys::SubgraphKey),
+
+    /// Loop iterable resolved to more items than `MAX_LOOP_ITEMS_RESOLVED`.
+    #[error("loop iterable too large: {count}/{max}")]
+    LoopItemsTooLarge {
+        /// Actual number of items resolved.
+        count: u32,
+        /// Maximum permitted (`MAX_LOOP_ITEMS_RESOLVED`).
+        max: u32,
+    },
+
+    /// Subgraph reference not found in `Graph::subgraphs`. (Reserved for Task 6.1.)
+    #[error("subgraph reference not found: {0}")]
+    SubgraphMissing(surge_core::keys::SubgraphKey),
+
+    /// Notify channel delivery failed and `on_failure: Fail` is configured. (Reserved for Phase 8.)
+    #[error("notify delivery error: {0}")]
+    NotifyDelivery(String),
 }
 
 impl From<StageError> for EngineError {

--- a/crates/surge-orchestrator/src/engine/stage/subgraph_stage.rs
+++ b/crates/surge-orchestrator/src/engine/stage/subgraph_stage.rs
@@ -1,0 +1,346 @@
+//! `NodeKind::Subgraph` stage execution — frame push at entry, output
+//! projection at exit. Single-threaded per spec §6.5-6.6.
+
+use crate::engine::frames::{Frame, ResolvedSubgraphInput, SubgraphFrame};
+use crate::engine::stage::StageError;
+use surge_core::graph::Graph;
+use surge_core::keys::NodeKey;
+use surge_core::run_event::{EventPayload, VersionedEventPayload};
+use surge_core::run_state::RunMemory;
+use surge_core::subgraph_config::SubgraphConfig;
+use surge_persistence::runs::run_writer::RunWriter;
+
+/// Parameters for `execute_subgraph_entry`.
+pub struct SubgraphStageParams<'a> {
+    /// `NodeKey` of the outer Subgraph node.
+    pub node: &'a NodeKey,
+    /// Subgraph configuration from the node.
+    pub subgraph_config: &'a SubgraphConfig,
+    /// Frozen pipeline graph (used for inner subgraph lookup).
+    pub graph: &'a Graph,
+    /// Run memory (used for input binding resolution).
+    pub run_memory: &'a RunMemory,
+    /// Run writer for persisting events.
+    pub writer: &'a RunWriter,
+    /// Mutable frame stack — `SubgraphFrame` pushed.
+    pub frames: &'a mut Vec<Frame>,
+    /// Outer-graph node to advance to when the subgraph exits.
+    pub return_to: NodeKey,
+}
+
+/// Outcome of `execute_subgraph_entry`. The cursor must advance to `inner_start`.
+pub struct SubgraphEntryEffect {
+    /// Inner subgraph's `start` `NodeKey` — caller sets cursor to this.
+    pub inner_start: NodeKey,
+}
+
+/// Resolve subgraph input bindings, push a `SubgraphFrame`, emit
+/// `SubgraphEntered`, and return the inner subgraph's start node.
+pub async fn execute_subgraph_entry(
+    p: SubgraphStageParams<'_>,
+) -> Result<SubgraphEntryEffect, StageError> {
+    let inner = p
+        .graph
+        .subgraphs
+        .get(&p.subgraph_config.inner)
+        .ok_or_else(|| StageError::SubgraphMissing(p.subgraph_config.inner.clone()))?;
+
+    let bound_inputs = resolve_subgraph_inputs(&p.subgraph_config.inputs, p.run_memory)?;
+
+    p.frames.push(Frame::Subgraph(SubgraphFrame {
+        outer_node: p.node.clone(),
+        inner_subgraph: p.subgraph_config.inner.clone(),
+        bound_inputs,
+        return_to: p.return_to,
+    }));
+
+    p.writer
+        .append_event(VersionedEventPayload::new(EventPayload::SubgraphEntered {
+            outer: p.node.clone(),
+            inner: p.subgraph_config.inner.clone(),
+        }))
+        .await
+        .map_err(|e| StageError::Storage(e.to_string()))?;
+
+    Ok(SubgraphEntryEffect {
+        inner_start: inner.start.clone(),
+    })
+}
+
+fn resolve_subgraph_inputs(
+    inputs: &[surge_core::subgraph_config::SubgraphInput],
+    memory: &RunMemory,
+) -> Result<Vec<ResolvedSubgraphInput>, StageError> {
+    inputs
+        .iter()
+        .map(|i| {
+            let value = resolve_artifact_source(&i.outer_binding.source, memory)?;
+            Ok(ResolvedSubgraphInput {
+                inner_var: i.inner_var.clone(),
+                value,
+            })
+        })
+        .collect()
+}
+
+fn resolve_artifact_source(
+    src: &surge_core::agent_config::ArtifactSource,
+    memory: &RunMemory,
+) -> Result<serde_json::Value, StageError> {
+    use surge_core::agent_config::ArtifactSource;
+    match src {
+        ArtifactSource::NodeOutput { node, artifact } => {
+            let aref = memory
+                .artifacts_by_node
+                .get(node)
+                .and_then(|list| list.iter().find(|a| a.name == *artifact))
+                .ok_or_else(|| {
+                    StageError::Internal(format!(
+                        "artifact '{artifact}' not produced by node '{node}'"
+                    ))
+                })?;
+            Ok(serde_json::json!({
+                "path": aref.path.to_string_lossy(),
+                "hash": aref.hash.to_string(),
+            }))
+        },
+        ArtifactSource::RunArtifact { name } => {
+            let aref = memory.artifacts.get(name).ok_or_else(|| {
+                StageError::Internal(format!("run artifact '{name}' not in RunMemory"))
+            })?;
+            Ok(serde_json::json!({
+                "path": aref.path.to_string_lossy(),
+                "hash": aref.hash.to_string(),
+            }))
+        },
+        ArtifactSource::GlobPattern {
+            node: _,
+            pattern: _,
+        } => Err(StageError::Internal(
+            "ArtifactSource::GlobPattern not yet implemented in M6 (M7+)".into(),
+        )),
+        ArtifactSource::Static { content } => Ok(serde_json::Value::String(content.clone())),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use surge_core::agent_config::{ArtifactSource, TemplateVar};
+    use surge_core::graph::{GraphMetadata, SCHEMA_VERSION, Subgraph};
+    use surge_core::keys::{NodeKey, OutcomeKey, SubgraphKey};
+    use surge_core::node::{Node, NodeConfig, OutcomeDecl, Position};
+    use surge_core::subgraph_config::{SubgraphInput, SubgraphOutput};
+    use surge_core::terminal_config::{TerminalConfig, TerminalKind};
+    use surge_persistence::runs::Storage;
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn entry_pushes_subgraph_frame_and_advances_to_inner_start() {
+        let dir = tempfile::tempdir().unwrap();
+        let storage = Storage::open(dir.path()).await.unwrap();
+        let writer = storage
+            .create_run(surge_core::id::RunId::new(), dir.path(), None)
+            .await
+            .unwrap();
+
+        let outer_key = NodeKey::try_from("sg_1").unwrap();
+        let inner_key = SubgraphKey::try_from("review_block").unwrap();
+        let inner_start = NodeKey::try_from("inner_start").unwrap();
+
+        let inner_node = Node {
+            id: inner_start.clone(),
+            position: Position::default(),
+            declared_outcomes: vec![],
+            config: NodeConfig::Terminal(TerminalConfig {
+                kind: TerminalKind::Success,
+                message: None,
+            }),
+        };
+        let mut inner_nodes = std::collections::BTreeMap::new();
+        inner_nodes.insert(inner_start.clone(), inner_node);
+
+        let mut subgraphs = std::collections::BTreeMap::new();
+        subgraphs.insert(
+            inner_key.clone(),
+            Subgraph {
+                start: inner_start.clone(),
+                nodes: inner_nodes,
+                edges: vec![],
+            },
+        );
+
+        let outer_node = Node {
+            id: outer_key.clone(),
+            position: Position::default(),
+            declared_outcomes: vec![OutcomeDecl {
+                id: OutcomeKey::try_from("done").unwrap(),
+                description: "ok".into(),
+                edge_kind_hint: surge_core::edge::EdgeKind::Forward,
+                is_terminal: false,
+            }],
+            config: NodeConfig::Subgraph(SubgraphConfig {
+                inner: inner_key.clone(),
+                inputs: vec![],
+                outputs: vec![SubgraphOutput {
+                    inner_artifact: ArtifactSource::Static {
+                        content: "ok".into(),
+                    },
+                    outer_outcome: OutcomeKey::try_from("done").unwrap(),
+                }],
+            }),
+        };
+        let mut nodes = std::collections::BTreeMap::new();
+        nodes.insert(outer_key.clone(), outer_node);
+
+        let graph = surge_core::graph::Graph {
+            schema_version: SCHEMA_VERSION,
+            metadata: GraphMetadata {
+                name: "t".into(),
+                description: None,
+                template_origin: None,
+                created_at: chrono::Utc::now(),
+                author: None,
+            },
+            start: outer_key.clone(),
+            nodes,
+            edges: vec![],
+            subgraphs,
+        };
+
+        let cfg = match &graph.nodes[&outer_key].config {
+            NodeConfig::Subgraph(c) => c.clone(),
+            _ => unreachable!(),
+        };
+        let memory = RunMemory::default();
+        let mut frames: Vec<Frame> = vec![];
+
+        let effect = execute_subgraph_entry(SubgraphStageParams {
+            node: &outer_key,
+            subgraph_config: &cfg,
+            graph: &graph,
+            run_memory: &memory,
+            writer: &writer,
+            frames: &mut frames,
+            return_to: NodeKey::try_from("after").unwrap(),
+        })
+        .await
+        .unwrap();
+
+        assert_eq!(effect.inner_start, inner_start);
+        assert_eq!(frames.len(), 1);
+        match &frames[0] {
+            Frame::Subgraph(sf) => {
+                assert_eq!(sf.outer_node, outer_key);
+                assert_eq!(sf.inner_subgraph, inner_key);
+            },
+            Frame::Loop(_) => panic!("expected Subgraph frame"),
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn missing_subgraph_reference_returns_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let storage = Storage::open(dir.path()).await.unwrap();
+        let writer = storage
+            .create_run(surge_core::id::RunId::new(), dir.path(), None)
+            .await
+            .unwrap();
+
+        let outer_key = NodeKey::try_from("sg_1").unwrap();
+        let missing_inner = SubgraphKey::try_from("does_not_exist").unwrap();
+
+        let cfg = SubgraphConfig {
+            inner: missing_inner.clone(),
+            inputs: vec![],
+            outputs: vec![],
+        };
+
+        let mut nodes = std::collections::BTreeMap::new();
+        nodes.insert(
+            outer_key.clone(),
+            Node {
+                id: outer_key.clone(),
+                position: Position::default(),
+                declared_outcomes: vec![],
+                config: NodeConfig::Subgraph(cfg.clone()),
+            },
+        );
+
+        let graph = surge_core::graph::Graph {
+            schema_version: SCHEMA_VERSION,
+            metadata: GraphMetadata {
+                name: "t".into(),
+                description: None,
+                template_origin: None,
+                created_at: chrono::Utc::now(),
+                author: None,
+            },
+            start: outer_key.clone(),
+            nodes,
+            edges: vec![],
+            subgraphs: std::collections::BTreeMap::new(),
+        };
+
+        let memory = RunMemory::default();
+        let mut frames: Vec<Frame> = vec![];
+
+        let result = execute_subgraph_entry(SubgraphStageParams {
+            node: &outer_key,
+            subgraph_config: &cfg,
+            graph: &graph,
+            run_memory: &memory,
+            writer: &writer,
+            frames: &mut frames,
+            return_to: NodeKey::try_from("after").unwrap(),
+        })
+        .await;
+
+        assert!(matches!(result, Err(StageError::SubgraphMissing(k)) if k == missing_inner));
+    }
+
+    #[test]
+    fn resolve_artifact_source_static_returns_string_value() {
+        let memory = RunMemory::default();
+        let src = surge_core::agent_config::ArtifactSource::Static {
+            content: "hello".into(),
+        };
+        let result = resolve_artifact_source(&src, &memory).unwrap();
+        assert_eq!(result, serde_json::Value::String("hello".into()));
+    }
+
+    #[test]
+    fn resolve_artifact_source_glob_pattern_returns_error() {
+        let memory = RunMemory::default();
+        let src = surge_core::agent_config::ArtifactSource::GlobPattern {
+            node: NodeKey::try_from("n1").unwrap(),
+            pattern: "*.md".into(),
+        };
+        let result = resolve_artifact_source(&src, &memory);
+        assert!(matches!(result, Err(StageError::Internal(_))));
+    }
+
+    #[test]
+    fn resolve_subgraph_inputs_empty_slice_returns_empty_vec() {
+        let memory = RunMemory::default();
+        let result = resolve_subgraph_inputs(&[], &memory).unwrap();
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn resolve_subgraph_inputs_static_binding_succeeds() {
+        let memory = RunMemory::default();
+        let inputs = vec![SubgraphInput {
+            outer_binding: surge_core::agent_config::Binding {
+                source: ArtifactSource::Static {
+                    content: "val".into(),
+                },
+                target: TemplateVar("unused".into()),
+            },
+            inner_var: TemplateVar("x".into()),
+        }];
+        let result = resolve_subgraph_inputs(&inputs, &memory).unwrap();
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].inner_var, TemplateVar("x".into()));
+        assert_eq!(result[0].value, serde_json::Value::String("val".into()));
+    }
+}

--- a/crates/surge-orchestrator/src/engine/stage/subgraph_stage.rs
+++ b/crates/surge-orchestrator/src/engine/stage/subgraph_stage.rs
@@ -123,6 +123,78 @@ fn resolve_artifact_source(
     }
 }
 
+/// Called by `run_task::execute` when the cursor reaches a `Terminal`
+/// node and the top frame is a `SubgraphFrame` (`TerminalSignal::SubgraphDone`).
+/// Projects the inner outcome to an outer outcome via
+/// `SubgraphConfig::outputs` (first match wins), pops the frame, and
+/// resumes the outer cursor at the frame's `return_to`.
+pub async fn on_subgraph_done(
+    outputs: &[surge_core::subgraph_config::SubgraphOutput],
+    memory: &RunMemory,
+    frames: &mut Vec<Frame>,
+    cursor: &mut surge_core::run_state::Cursor,
+    writer: &RunWriter,
+) -> Result<(), StageError> {
+    // Snapshot frame fields BEFORE the mutable pop (avoid double-borrow).
+    let (outer_node, inner_subgraph, return_to) = match frames.last() {
+        Some(Frame::Subgraph(sf)) => (
+            sf.outer_node.clone(),
+            sf.inner_subgraph.clone(),
+            sf.return_to.clone(),
+        ),
+        _ => {
+            return Err(StageError::Internal(
+                "on_subgraph_done called without Subgraph frame on top".into(),
+            ));
+        },
+    };
+
+    // First-match output projection.
+    let outcome = outputs
+        .iter()
+        .find_map(|o| project_output(o, memory).ok())
+        .ok_or_else(|| {
+            StageError::Internal(format!(
+                "no SubgraphConfig::outputs entry resolved successfully for subgraph \
+                 {inner_subgraph}"
+            ))
+        })?;
+
+    writer
+        .append_event(VersionedEventPayload::new(EventPayload::SubgraphExited {
+            outer: outer_node.clone(),
+            inner: inner_subgraph.clone(),
+            outcome: outcome.clone(),
+        }))
+        .await
+        .map_err(|e| StageError::Storage(e.to_string()))?;
+
+    writer
+        .append_event(VersionedEventPayload::new(EventPayload::OutcomeReported {
+            node: outer_node,
+            outcome,
+            summary: format!("subgraph {inner_subgraph} completed"),
+        }))
+        .await
+        .map_err(|e| StageError::Storage(e.to_string()))?;
+
+    frames.pop();
+    cursor.node = return_to;
+    cursor.attempt = 1;
+
+    Ok(())
+}
+
+fn project_output(
+    out: &surge_core::subgraph_config::SubgraphOutput,
+    memory: &RunMemory,
+) -> Result<surge_core::keys::OutcomeKey, StageError> {
+    // Resolve the inner_artifact to verify it exists. If yes, the
+    // configured outer_outcome is the projection.
+    let _ = resolve_artifact_source(&out.inner_artifact, memory)?;
+    Ok(out.outer_outcome.clone())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -342,5 +414,68 @@ mod tests {
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].inner_var, TemplateVar("x".into()));
         assert_eq!(result[0].value, serde_json::Value::String("val".into()));
+    }
+
+    use surge_core::run_state::Cursor;
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn exit_pops_frame_and_projects_first_matching_output() {
+        let dir = tempfile::tempdir().unwrap();
+        let storage = Storage::open(dir.path()).await.unwrap();
+        let writer = storage
+            .create_run(surge_core::id::RunId::new(), dir.path(), None)
+            .await
+            .unwrap();
+
+        let outer_key = NodeKey::try_from("sg_1").unwrap();
+        let inner_key = SubgraphKey::try_from("review_block").unwrap();
+        let return_to = NodeKey::try_from("after").unwrap();
+
+        // RunMemory has the inner artifact registered.
+        let inner_artifact_path = dir.path().join("review.md");
+        std::fs::write(&inner_artifact_path, "approved").unwrap();
+        let mut memory = RunMemory::default();
+        let aref = surge_core::run_state::ArtifactRef {
+            hash: surge_core::content_hash::ContentHash::compute(b"approved"),
+            path: inner_artifact_path,
+            name: "review.md".into(),
+            produced_by: NodeKey::try_from("review_inner").unwrap(),
+            produced_at_seq: 1,
+        };
+        memory.artifacts.insert("review.md".into(), aref.clone());
+        memory
+            .artifacts_by_node
+            .entry(NodeKey::try_from("review_inner").unwrap())
+            .or_default()
+            .push(aref);
+
+        // Frame stack with one Subgraph frame.
+        let mut frames: Vec<Frame> = vec![Frame::Subgraph(SubgraphFrame {
+            outer_node: outer_key.clone(),
+            inner_subgraph: inner_key.clone(),
+            bound_inputs: vec![],
+            return_to: return_to.clone(),
+        })];
+
+        // Outputs: first match wins. Configure a single matching output.
+        let outputs = vec![SubgraphOutput {
+            inner_artifact: ArtifactSource::NodeOutput {
+                node: NodeKey::try_from("review_inner").unwrap(),
+                artifact: "review.md".into(),
+            },
+            outer_outcome: OutcomeKey::try_from("approved").unwrap(),
+        }];
+
+        let mut cursor = Cursor {
+            node: NodeKey::try_from("inner_terminal").unwrap(),
+            attempt: 1,
+        };
+
+        on_subgraph_done(&outputs, &memory, &mut frames, &mut cursor, &writer)
+            .await
+            .unwrap();
+
+        assert!(frames.is_empty(), "frame popped");
+        assert_eq!(cursor.node, return_to, "cursor restored to return_to");
     }
 }

--- a/crates/surge-orchestrator/src/engine/validate.rs
+++ b/crates/surge-orchestrator/src/engine/validate.rs
@@ -1,12 +1,14 @@
-//! Pre-execution graph validation: rejects M6+ features and structural
-//! errors (start node missing, edges referencing unknown nodes).
+//! Pre-execution graph validation for M6: allows Loop and Subgraph nodes,
+//! rejects `gate_after_each: true` (M7) and multi-edge fanout from the same
+//! `(node, outcome)` port (M8+), and validates subgraph references.
 
 use crate::engine::error::EngineError;
 use surge_core::graph::Graph;
-use surge_core::node::NodeKind;
 
-/// Validate the graph for M5 execution. Returns Ok(()) if it can run.
-pub fn validate_for_m5(graph: &Graph) -> Result<(), EngineError> {
+/// Validate the graph for M6 execution. Allows Loop and Subgraph nodes
+/// (M5 rejected them). Rejects multi-edge fanout (M8+) and
+/// `gate_after_each: true` (M7).
+pub fn validate_for_m6(graph: &Graph) -> Result<(), EngineError> {
     if !graph.nodes.contains_key(&graph.start) {
         return Err(EngineError::GraphInvalid(format!(
             "start node '{}' not present in nodes",
@@ -14,21 +16,43 @@ pub fn validate_for_m5(graph: &Graph) -> Result<(), EngineError> {
         )));
     }
 
+    // Per-node validation.
     for (key, node) in &graph.nodes {
-        match node.kind() {
-            NodeKind::Loop | NodeKind::Subgraph => {
-                return Err(EngineError::UnsupportedNodeKind { kind: node.kind() });
-            },
-            _ => {},
-        }
         if &node.id != key {
             return Err(EngineError::GraphInvalid(format!(
                 "node id {} differs from map key {}",
                 node.id, key
             )));
         }
+
+        // gate_after_each rejection (deferred to M7).
+        if let surge_core::node::NodeConfig::Loop(cfg) = &node.config {
+            if cfg.gate_after_each {
+                return Err(EngineError::GraphInvalid(format!(
+                    "node {key}: gate_after_each = true is not supported in M6 \
+                    (deferred to M7 alongside daemon's broadcast registry); \
+                    rewrite as an explicit HumanGate node inside the body subgraph"
+                )));
+            }
+            // Loop body subgraph must exist.
+            if !graph.subgraphs.contains_key(&cfg.body) {
+                return Err(EngineError::LoopBodyMissing(cfg.body.clone()));
+            }
+        }
+
+        // Subgraph reference must exist.
+        if let surge_core::node::NodeConfig::Subgraph(cfg) = &node.config {
+            if !graph.subgraphs.contains_key(&cfg.inner) {
+                return Err(EngineError::SubgraphMissing(cfg.inner.clone()));
+            }
+        }
     }
 
+    // Edge validation — outer graph.
+    let mut seen_ports: std::collections::HashSet<(
+        surge_core::keys::NodeKey,
+        surge_core::keys::OutcomeKey,
+    )> = std::collections::HashSet::new();
     for edge in &graph.edges {
         if !graph.nodes.contains_key(&edge.from.node) {
             return Err(EngineError::GraphInvalid(format!(
@@ -42,17 +66,68 @@ pub fn validate_for_m5(graph: &Graph) -> Result<(), EngineError> {
                 edge.id, edge.to
             )));
         }
+        if !seen_ports.insert((edge.from.node.clone(), edge.from.outcome.clone())) {
+            return Err(EngineError::GraphInvalid(format!(
+                "multiple edges from ({}, {}) — parallel fanout is M8+ scope (NodeKind::Parallel)",
+                edge.from.node, edge.from.outcome
+            )));
+        }
+    }
+
+    // Recursively validate inner subgraphs.
+    for (key, sg) in &graph.subgraphs {
+        if !sg.nodes.contains_key(&sg.start) {
+            return Err(EngineError::GraphInvalid(format!(
+                "subgraph '{key}' start '{}' not in subgraph nodes",
+                sg.start
+            )));
+        }
+        // Inner-subgraph edge port-uniqueness.
+        let mut inner_ports: std::collections::HashSet<(
+            surge_core::keys::NodeKey,
+            surge_core::keys::OutcomeKey,
+        )> = std::collections::HashSet::new();
+        for edge in &sg.edges {
+            if !inner_ports.insert((edge.from.node.clone(), edge.from.outcome.clone())) {
+                return Err(EngineError::GraphInvalid(format!(
+                    "subgraph '{key}': multiple edges from ({}, {}) — M8+",
+                    edge.from.node, edge.from.outcome
+                )));
+            }
+        }
+        // Per-node validation inside subgraphs (gate_after_each etc).
+        for (node_key, node) in &sg.nodes {
+            if let surge_core::node::NodeConfig::Loop(cfg) = &node.config {
+                if cfg.gate_after_each {
+                    return Err(EngineError::GraphInvalid(format!(
+                        "subgraph '{key}' node {node_key}: gate_after_each = true is not supported in M6 (M7)"
+                    )));
+                }
+                if !graph.subgraphs.contains_key(&cfg.body) {
+                    return Err(EngineError::LoopBodyMissing(cfg.body.clone()));
+                }
+            }
+            if let surge_core::node::NodeConfig::Subgraph(cfg) = &node.config {
+                if !graph.subgraphs.contains_key(&cfg.inner) {
+                    return Err(EngineError::SubgraphMissing(cfg.inner.clone()));
+                }
+            }
+        }
     }
 
     Ok(())
 }
+
+// Back-compat alias for any internal caller still using the M5 name.
+#[allow(dead_code)]
+pub use validate_for_m6 as validate_for_m5;
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use std::collections::BTreeMap;
     use surge_core::graph::{Graph, GraphMetadata, SCHEMA_VERSION};
-    use surge_core::keys::NodeKey;
+    use surge_core::keys::{NodeKey, OutcomeKey};
     use surge_core::node::{Node, NodeConfig, Position};
     use surge_core::terminal_config::{TerminalConfig, TerminalKind};
 
@@ -90,14 +165,14 @@ mod tests {
     #[test]
     fn minimal_terminal_graph_is_valid() {
         let g = graph_with_one_terminal("end");
-        assert!(validate_for_m5(&g).is_ok());
+        assert!(validate_for_m6(&g).is_ok());
     }
 
     #[test]
     fn missing_start_node_rejected() {
         let mut g = graph_with_one_terminal("end");
         g.start = NodeKey::try_from("nonexistent").unwrap();
-        let err = validate_for_m5(&g).unwrap_err();
+        let err = validate_for_m6(&g).unwrap_err();
         match err {
             EngineError::GraphInvalid(msg) => assert!(msg.contains("nonexistent")),
             other => panic!("expected GraphInvalid, got {other:?}"),
@@ -105,31 +180,60 @@ mod tests {
     }
 
     #[test]
-    fn loop_node_rejected_as_unsupported() {
+    fn loop_node_no_longer_rejected() {
+        use surge_core::graph::Subgraph;
         use surge_core::keys::SubgraphKey;
         use surge_core::loop_config::{
             ExitCondition, FailurePolicy, IterableSource, LoopConfig, ParallelismMode,
         };
 
-        let key = NodeKey::try_from("loop1").unwrap();
+        let loop_key = NodeKey::try_from("loop_1").unwrap();
+        let body_key = SubgraphKey::try_from("body").unwrap();
+        let body_start = NodeKey::try_from("body_start").unwrap();
+
         let mut nodes = BTreeMap::new();
         nodes.insert(
-            key.clone(),
+            loop_key.clone(),
             Node {
-                id: key.clone(),
+                id: loop_key.clone(),
                 position: Position::default(),
                 declared_outcomes: vec![],
                 config: NodeConfig::Loop(LoopConfig {
                     iterates_over: IterableSource::Static(vec![]),
-                    body: SubgraphKey::try_from("body").unwrap(),
+                    body: body_key.clone(),
                     iteration_var_name: "item".into(),
                     exit_condition: ExitCondition::AllItems,
-                    on_iteration_failure: FailurePolicy::default(),
-                    parallelism: ParallelismMode::default(),
+                    on_iteration_failure: FailurePolicy::Abort,
+                    parallelism: ParallelismMode::Sequential,
                     gate_after_each: false,
                 }),
             },
         );
+
+        let mut body_nodes = BTreeMap::new();
+        body_nodes.insert(
+            body_start.clone(),
+            Node {
+                id: body_start.clone(),
+                position: Position::default(),
+                declared_outcomes: vec![],
+                config: NodeConfig::Terminal(TerminalConfig {
+                    kind: TerminalKind::Success,
+                    message: None,
+                }),
+            },
+        );
+
+        let mut subgraphs = BTreeMap::new();
+        subgraphs.insert(
+            body_key,
+            Subgraph {
+                start: body_start,
+                nodes: body_nodes,
+                edges: vec![],
+            },
+        );
+
         let g = Graph {
             schema_version: SCHEMA_VERSION,
             metadata: GraphMetadata {
@@ -139,17 +243,169 @@ mod tests {
                 created_at: chrono::Utc::now(),
                 author: None,
             },
-            start: key,
+            start: loop_key,
             nodes,
             edges: vec![],
+            subgraphs,
+        };
+
+        assert!(validate_for_m6(&g).is_ok(), "Loop nodes are allowed in M6");
+    }
+
+    #[test]
+    fn gate_after_each_true_is_rejected() {
+        use surge_core::graph::Subgraph;
+        use surge_core::keys::SubgraphKey;
+        use surge_core::loop_config::{
+            ExitCondition, FailurePolicy, IterableSource, LoopConfig, ParallelismMode,
+        };
+
+        let loop_key = NodeKey::try_from("loop_1").unwrap();
+        let body_key = SubgraphKey::try_from("body").unwrap();
+        let body_start = NodeKey::try_from("body_start").unwrap();
+
+        let mut nodes = BTreeMap::new();
+        nodes.insert(
+            loop_key.clone(),
+            Node {
+                id: loop_key.clone(),
+                position: Position::default(),
+                declared_outcomes: vec![],
+                config: NodeConfig::Loop(LoopConfig {
+                    iterates_over: IterableSource::Static(vec![]),
+                    body: body_key.clone(),
+                    iteration_var_name: "item".into(),
+                    exit_condition: ExitCondition::AllItems,
+                    on_iteration_failure: FailurePolicy::Abort,
+                    parallelism: ParallelismMode::Sequential,
+                    gate_after_each: true,
+                }),
+            },
+        );
+
+        let mut body_nodes = BTreeMap::new();
+        body_nodes.insert(
+            body_start.clone(),
+            Node {
+                id: body_start.clone(),
+                position: Position::default(),
+                declared_outcomes: vec![],
+                config: NodeConfig::Terminal(TerminalConfig {
+                    kind: TerminalKind::Success,
+                    message: None,
+                }),
+            },
+        );
+
+        let mut subgraphs = BTreeMap::new();
+        subgraphs.insert(
+            body_key,
+            Subgraph {
+                start: body_start,
+                nodes: body_nodes,
+                edges: vec![],
+            },
+        );
+
+        let g = Graph {
+            schema_version: SCHEMA_VERSION,
+            metadata: GraphMetadata {
+                name: "t".into(),
+                description: None,
+                template_origin: None,
+                created_at: chrono::Utc::now(),
+                author: None,
+            },
+            start: loop_key,
+            nodes,
+            edges: vec![],
+            subgraphs,
+        };
+
+        let err = validate_for_m6(&g).unwrap_err();
+        let msg = match err {
+            EngineError::GraphInvalid(s) => s,
+            other => panic!("expected GraphInvalid, got {other:?}"),
+        };
+        assert!(
+            msg.contains("gate_after_each"),
+            "error mentions gate_after_each: {msg}"
+        );
+        assert!(msg.contains("M7"), "error mentions M7 pointer: {msg}");
+    }
+
+    #[test]
+    fn multi_edge_same_port_rejected_with_m8_pointer() {
+        use surge_core::edge::{Edge, EdgeKind, EdgePolicy, PortRef};
+        use surge_core::keys::EdgeKey;
+
+        let n_a = NodeKey::try_from("a").unwrap();
+        let n_b = NodeKey::try_from("b").unwrap();
+        let n_c = NodeKey::try_from("c").unwrap();
+        let mut nodes = BTreeMap::new();
+        for k in [&n_a, &n_b, &n_c] {
+            nodes.insert(
+                k.clone(),
+                Node {
+                    id: k.clone(),
+                    position: Position::default(),
+                    declared_outcomes: vec![],
+                    config: NodeConfig::Terminal(TerminalConfig {
+                        kind: TerminalKind::Success,
+                        message: None,
+                    }),
+                },
+            );
+        }
+
+        let port = PortRef {
+            node: n_a.clone(),
+            outcome: OutcomeKey::try_from("done").unwrap(),
+        };
+        let edges = vec![
+            Edge {
+                id: EdgeKey::try_from("e1").unwrap(),
+                from: port.clone(),
+                to: n_b,
+                kind: EdgeKind::Forward,
+                policy: EdgePolicy::default(),
+            },
+            Edge {
+                id: EdgeKey::try_from("e2").unwrap(),
+                from: port,
+                to: n_c,
+                kind: EdgeKind::Forward,
+                policy: EdgePolicy::default(),
+            },
+        ];
+
+        let g = Graph {
+            schema_version: SCHEMA_VERSION,
+            metadata: GraphMetadata {
+                name: "t".into(),
+                description: None,
+                template_origin: None,
+                created_at: chrono::Utc::now(),
+                author: None,
+            },
+            start: n_a,
+            nodes,
+            edges,
             subgraphs: BTreeMap::new(),
         };
-        let err = validate_for_m5(&g).unwrap_err();
-        assert!(matches!(
-            err,
-            EngineError::UnsupportedNodeKind {
-                kind: NodeKind::Loop
-            }
-        ));
+
+        let err = validate_for_m6(&g).unwrap_err();
+        let msg = match err {
+            EngineError::GraphInvalid(s) => s,
+            other => panic!("expected GraphInvalid, got {other:?}"),
+        };
+        assert!(
+            msg.contains("multiple edges"),
+            "error mentions multi-edge: {msg}"
+        );
+        assert!(
+            msg.contains("M8") || msg.contains("NodeKind::Parallel"),
+            "error mentions M8/Parallel: {msg}"
+        );
     }
 }


### PR DESCRIPTION
## Summary

PR-3 of the M6 milestone series. Implements the actual `Loop` and `Subgraph` stage handlers that the previous PRs prepared the infrastructure for. After this PR, the engine fully supports both `NodeKind::Loop` and `NodeKind::Subgraph` execution — frames push at entry, terminal-inside-frame triggers iteration-advance / output-projection, frames pop on completion.

This replaces the `unimplemented!()` stubs from PR-2 (Phase 3.2 + 4) with real implementations.

## Phase 5 (Loop)

- **`execute_loop_entry`** ([commit `0dde1b9`](https://github.com/vanyastaff/surge/commit/0dde1b9)) — resolves iterable items, checks cap, empty → `loop_empty` outcome; non-empty pushes `LoopFrame` and returns `body_subgraph.start`.
- **`IterableSource::Artifact` resolution** ([commit `411c7b2`](https://github.com/vanyastaff/surge/commit/411c7b2)) — reads artifact bytes from disk, parses TOML, walks dotted `jsonpath`. Static and Artifact iterables both supported.
- **`on_loop_iteration_done`** ([commit `ae16ab9`](https://github.com/vanyastaff/surge/commit/ae16ab9)) — full iteration-boundary decision tree:
  - `FailurePolicy::Abort` / `Skip` / `Retry { max }` (with `attempts_remaining` decrement) / `Replan` (M8 deferred, treated as Abort with warning log).
  - `ExitCondition::AllItems` / `UntilOutcome { from_node, outcome }` / `MaxIterations { n }`.
  - Helper `is_failure_outcome` uses conservative literal match (`failed | fail | error`).
- **Wired into `run_task::execute`** ([commit `3cd5e44`](https://github.com/vanyastaff/surge/commit/3cd5e44)) — Loop dispatch arm + LoopIterDone branch. New `routing::edge_target_after_outcome_or_default` helper computes `return_to` at frame-push time.
- **`validate_for_m6`** ([commit `1cb1e2a`](https://github.com/vanyastaff/surge/commit/1cb1e2a)) — renamed from `validate_for_m5`, allows Loop/Subgraph nodes (M5 rejected them), rejects `gate_after_each: true` with M7 pointer, rejects multi-edge same-port with M8+ pointer to future `NodeKind::Parallel`. Validates Loop/Subgraph subgraph references at both outer and inner levels. New `EngineError::LoopBodyMissing`/`SubgraphMissing` variants.

## Phase 6 (Subgraph)

- **`execute_subgraph_entry`** ([commit `cadde99`](https://github.com/vanyastaff/surge/commit/cadde99)) — resolves `SubgraphConfig::inputs` against `RunMemory` artifacts (`NodeOutput`/`RunArtifact`/`Static`; `GlobPattern` deferred to M7+), pushes `SubgraphFrame`, emits `SubgraphEntered`, advances cursor to inner subgraph's start.
- **`on_subgraph_done`** ([commit `65cd58f`](https://github.com/vanyastaff/surge/commit/65cd58f)) — first-match-wins across `SubgraphConfig::outputs`, projects inner artifact existence to outer outcome, emits `SubgraphExited` + `OutcomeReported`, pops frame, restores outer cursor.
- **Wired into `run_task::execute`** ([commit `fca44a2`](https://github.com/vanyastaff/surge/commit/fca44a2)) — Subgraph dispatch arm + SubgraphDone branch. Identical structural pattern to the Loop wiring.

## Test plan

- [x] `cargo build --workspace` clean
- [x] `cargo test --workspace --lib` — 188+ surge-orchestrator tests pass; full M5 suite preserved
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] M5 fixtures don't use Loop or Subgraph → behavior unchanged
- [x] New unit tests:
  - Loop: empty iterable → `loop_empty`; 3 items → frame push; cap exceeded → error; iteration advance increments index; last iteration pops frame; Artifact iterable resolves dotted path; gate_after_each rejected; multi-edge rejected; Loop allowed (no longer rejected).
  - Subgraph: entry pushes frame + advances; missing reference errors; first-match output projection; exit pops frame.
- [ ] End-to-end integration tests with real Loop/Subgraph nodes — deferred to PR-6 (Phase 10) when the integration test fixtures are built.

## Acceptance criteria advanced (from M6 spec §21)

- ✅ Loop and Subgraph stage handlers implemented (foundation for #7-#13 integration tests in PR-6)
- ✅ `validate_for_m6` enforces M6 rules (gate_after_each, multi-edge, subgraph references) with clear M7/M8 pointers
- ✅ `MAX_LOOP_ITEMS_RESOLVED` engine-side cap enforced at frame push (paired with PR-1's `MAX_LOOP_ITEMS_STATIC` core cap)
- ✅ Snapshot v2 frame stack now actually receives push/pop traffic (was infrastructure-only in PR-1)

Still deferred:
- Notify channel impls (Phase 7-8 → PR-4)
- CLI engine subtree (Phase 9 → PR-5)
- Integration tests + rustdoc + clippy + README (Phase 10-11 → PR-6)

## Follow-up PRs

| PR | Scope | Estimate |
|---|---|---|
| PR-4 (next) | Phase 7 + 8 — surge-notify channel impls + notify stage rewrite | ~1 week |
| PR-5 | Phase 9 — CLI engine subtree | ~3 days |
| PR-6 | Phase 10 + 11 — integration tests + rustdoc + clippy + README | ~3-5 days |

🤖 Generated with [Claude Code](https://claude.com/claude-code)