### PR TITLE
M7 PR 3 — Daemon end-to-end (binary + CLI integration)

### DIFF
--- a/crates/surge-cli/Cargo.toml
+++ b/crates/surge-cli/Cargo.toml
@@ -28,6 +28,11 @@ serde_json = { workspace = true }
 owo-colors = { workspace = true }
 dirs = { workspace = true }
 chrono = { workspace = true }
+surge-daemon = { workspace = true }
+which = "6"
+
+[target.'cfg(unix)'.dependencies]
+nix = { workspace = true, features = ["signal"] }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/surge-cli/src/commands/daemon.rs
+++ b/crates/surge-cli/src/commands/daemon.rs
@@ -1,0 +1,173 @@
+//! `surge daemon` subtree — start / stop / status / restart for the
+//! long-running surge-daemon process.
+
+use anyhow::{Context, Result, anyhow};
+use clap::Subcommand;
+use std::path::PathBuf;
+use std::time::Duration;
+use surge_orchestrator::engine::daemon_facade::DaemonEngineFacade;
+
+/// Subcommands under `surge daemon`.
+#[derive(Subcommand, Debug)]
+pub enum DaemonCommands {
+    /// Start the daemon.
+    Start {
+        /// Detach from the controlling terminal.
+        #[arg(long)]
+        detached: bool,
+        /// Maximum concurrent runs.
+        #[arg(long, default_value_t = 8)]
+        max_active: usize,
+    },
+    /// Stop the daemon (graceful drain).
+    Stop {
+        /// Skip the drain — send SIGKILL after 1s.
+        #[arg(long)]
+        force: bool,
+    },
+    /// Print daemon status (pid, socket, ping ok/err).
+    Status,
+    /// Restart the daemon (stop + start).
+    Restart,
+}
+
+/// Top-level dispatcher for `surge daemon` invocations.
+pub async fn run(cmd: DaemonCommands) -> Result<()> {
+    match cmd {
+        DaemonCommands::Start {
+            detached,
+            max_active,
+        } => start(detached, max_active).await,
+        DaemonCommands::Stop { force } => stop(force).await,
+        DaemonCommands::Status => status().await,
+        DaemonCommands::Restart => {
+            stop(false).await.ok();
+            start(true, 8).await
+        },
+    }
+}
+
+async fn start(detached: bool, max_active: usize) -> Result<()> {
+    use surge_daemon::pidfile;
+
+    if let Some(pid) = pidfile::read_pid(&pidfile::pid_path()?)? {
+        if pidfile::is_alive(pid) {
+            return Err(anyhow!("daemon already running (pid {pid})"));
+        }
+        eprintln!("note: stale pid file (pid {pid} not alive); will overwrite");
+    }
+
+    let mut cmd = std::process::Command::new(daemon_binary_path()?);
+    cmd.arg("--max-active").arg(max_active.to_string());
+    if detached {
+        cmd.arg("--detached");
+        #[cfg(unix)]
+        {
+            use std::os::unix::process::CommandExt;
+            unsafe {
+                cmd.pre_exec(|| {
+                    nix::unistd::setsid().ok();
+                    Ok(())
+                });
+            }
+        }
+        #[cfg(windows)]
+        {
+            use std::os::windows::process::CommandExt;
+            // DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP
+            cmd.creation_flags(0x0000_0008 | 0x0000_0200);
+        }
+    }
+    let child = cmd.spawn().context("spawn surge-daemon")?;
+    println!("started surge-daemon (pid {})", child.id());
+
+    // Poll for socket readiness up to 5 s.
+    let socket_path = pidfile::socket_path()?;
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    while std::time::Instant::now() < deadline {
+        if socket_path.exists() {
+            println!("socket ready: {}", socket_path.display());
+            return Ok(());
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    Err(anyhow!(
+        "daemon socket {} did not become readable within 5s",
+        socket_path.display()
+    ))
+}
+
+async fn stop(force: bool) -> Result<()> {
+    use surge_daemon::pidfile;
+    let pid = pidfile::read_pid(&pidfile::pid_path()?)?
+        .ok_or_else(|| anyhow!("no daemon pid file; daemon not running?"))?;
+
+    #[cfg(unix)]
+    {
+        use nix::sys::signal::{Signal, kill};
+        use nix::unistd::Pid;
+        let signal = if force {
+            Signal::SIGKILL
+        } else {
+            Signal::SIGTERM
+        };
+        kill(Pid::from_raw(pid as i32), signal).context("kill daemon")?;
+    }
+    #[cfg(windows)]
+    {
+        let mut tk = std::process::Command::new("taskkill");
+        tk.arg("/pid").arg(pid.to_string());
+        if force {
+            tk.arg("/F");
+        }
+        let status = tk.status().context("taskkill")?;
+        if !status.success() {
+            return Err(anyhow!("taskkill exited with {status}"));
+        }
+    }
+
+    println!("requested daemon stop (pid {pid})");
+    Ok(())
+}
+
+async fn status() -> Result<()> {
+    use surge_daemon::pidfile;
+    let pid_path = pidfile::pid_path()?;
+    let socket_path = pidfile::socket_path()?;
+    let pid = pidfile::read_pid(&pid_path)?;
+    match pid {
+        Some(p) if pidfile::is_alive(p) => {
+            println!("status: running");
+            println!("pid:    {p}");
+            println!("socket: {}", socket_path.display());
+            // Try Ping for live confirmation by opening the facade.
+            match DaemonEngineFacade::connect(socket_path).await {
+                Ok(_) => println!("ping:   ok"),
+                Err(e) => println!("ping:   error ({e})"),
+            }
+        },
+        Some(p) => {
+            println!("status: stopped (stale pid file: {p})");
+        },
+        None => {
+            println!("status: not running");
+        },
+    }
+    Ok(())
+}
+
+fn daemon_binary_path() -> Result<PathBuf> {
+    if let Ok(my_exe) = std::env::current_exe() {
+        if let Some(parent) = my_exe.parent() {
+            let candidate = parent.join(if cfg!(windows) {
+                "surge-daemon.exe"
+            } else {
+                "surge-daemon"
+            });
+            if candidate.exists() {
+                return Ok(candidate);
+            }
+        }
+    }
+    which::which("surge-daemon").context("surge-daemon binary not found in PATH or alongside surge")
+}

--- a/crates/surge-cli/src/commands/daemon.rs
+++ b/crates/surge-cli/src/commands/daemon.rs
@@ -21,7 +21,8 @@ pub enum DaemonCommands {
     },
     /// Stop the daemon (graceful drain).
     Stop {
-        /// Skip the drain — send SIGKILL after 1s.
+        /// Skip the graceful drain and terminate the daemon
+        /// immediately (Unix: SIGKILL; Windows: `taskkill /F`).
         #[arg(long)]
         force: bool,
     },

--- a/crates/surge-cli/src/commands/daemon.rs
+++ b/crates/surge-cli/src/commands/daemon.rs
@@ -42,7 +42,11 @@ pub async fn run(cmd: DaemonCommands) -> Result<()> {
         DaemonCommands::Stop { force } => stop(force).await,
         DaemonCommands::Status => status().await,
         DaemonCommands::Restart => {
-            stop(false).await.ok();
+            if let Err(e) = stop(false).await {
+                eprintln!("note: stop failed during restart: {e}");
+            }
+            // Wait for the old daemon to actually exit before spawning the new one.
+            wait_for_daemon_exit(Duration::from_secs(10)).await?;
             start(true, 8).await
         },
     }
@@ -82,20 +86,29 @@ async fn start(detached: bool, max_active: usize) -> Result<()> {
     let child = cmd.spawn().context("spawn surge-daemon")?;
     println!("started surge-daemon (pid {})", child.id());
 
-    // Poll for socket readiness up to 5 s.
+    // Poll for daemon readiness via connect attempt.
+    // On Windows the named pipe lives in \\.\pipe\ namespace and has no
+    // filesystem entry, so socket_path.exists() would always be false.
+    // A successful DaemonEngineFacade::connect proves the listener is bound.
     let socket_path = pidfile::socket_path()?;
     let deadline = std::time::Instant::now() + Duration::from_secs(5);
-    while std::time::Instant::now() < deadline {
-        if socket_path.exists() {
-            println!("socket ready: {}", socket_path.display());
-            return Ok(());
+    loop {
+        if std::time::Instant::now() >= deadline {
+            return Err(anyhow!(
+                "daemon at {} did not become ready within 5s",
+                socket_path.display()
+            ));
         }
-        tokio::time::sleep(Duration::from_millis(100)).await;
+        match DaemonEngineFacade::connect(socket_path.clone()).await {
+            Ok(_) => {
+                println!("daemon ready: {}", socket_path.display());
+                return Ok(());
+            },
+            Err(_) => {
+                tokio::time::sleep(Duration::from_millis(100)).await;
+            },
+        }
     }
-    Err(anyhow!(
-        "daemon socket {} did not become readable within 5s",
-        socket_path.display()
-    ))
 }
 
 async fn stop(force: bool) -> Result<()> {
@@ -155,6 +168,28 @@ async fn status() -> Result<()> {
         },
     }
     Ok(())
+}
+
+/// Wait for the daemon's pid to no longer be alive. Used by
+/// `restart` to ensure the old daemon has exited before spawning
+/// a new one. Returns `Ok(())` when the pid is dead; `Err` after
+/// `max_wait` elapses.
+async fn wait_for_daemon_exit(max_wait: Duration) -> Result<()> {
+    use surge_daemon::pidfile;
+    let deadline = std::time::Instant::now() + max_wait;
+    loop {
+        let pid = pidfile::read_pid(&pidfile::pid_path()?)?;
+        match pid {
+            None => return Ok(()), // pid file gone — daemon exited cleanly
+            Some(p) if !pidfile::is_alive(p) => return Ok(()), // stale pid
+            Some(_) => {
+                if std::time::Instant::now() >= deadline {
+                    return Err(anyhow!("daemon did not exit within {max_wait:?}"));
+                }
+                tokio::time::sleep(Duration::from_millis(100)).await;
+            },
+        }
+    }
 }
 
 fn daemon_binary_path() -> Result<PathBuf> {

--- a/crates/surge-cli/src/commands/engine.rs
+++ b/crates/surge-cli/src/commands/engine.rs
@@ -30,7 +30,9 @@ pub enum EngineCommands {
     Watch {
         /// `RunId` (ULID).
         run_id: String,
-        /// Use the daemon's live event stream instead of disk-tail.
+        /// Ensure the daemon is running before tailing. (Live streaming
+        /// via Subscribe is M7+ polish; this currently still uses the
+        /// disk-tail mode.)
         #[arg(long)]
         daemon: bool,
     },

--- a/crates/surge-cli/src/commands/engine.rs
+++ b/crates/surge-cli/src/commands/engine.rs
@@ -22,28 +22,44 @@ pub enum EngineCommands {
         /// Worktree path. Default: current working directory.
         #[arg(long)]
         worktree: Option<PathBuf>,
+        /// Route through the long-running surge-daemon (auto-spawn if not running).
+        #[arg(long)]
+        daemon: bool,
     },
-    /// Tail events from an existing run by id (reads on-disk log).
+    /// Tail events from an existing run by id.
     Watch {
         /// `RunId` (ULID).
         run_id: String,
+        /// Use the daemon's live event stream instead of disk-tail.
+        #[arg(long)]
+        daemon: bool,
     },
-    /// Resume an interrupted run from its latest snapshot.
+    /// Resume an interrupted run.
     Resume {
         /// `RunId` (ULID).
         run_id: String,
+        /// Required — resume needs the engine to be alive (i.e., the daemon).
+        #[arg(long)]
+        daemon: bool,
     },
-    /// Cancel a run owned by the current process.
+    /// Cancel a run.
     Stop {
         /// `RunId` (ULID).
         run_id: String,
         /// Reason string recorded in the abort event.
         #[arg(long)]
         reason: Option<String>,
+        /// Required — cross-process stop needs the daemon.
+        #[arg(long)]
+        daemon: bool,
     },
-    /// List runs from the on-disk store.
-    Ls,
-    /// Print events for a run.
+    /// List runs.
+    Ls {
+        /// List runs the daemon currently hosts (default: list on-disk).
+        #[arg(long)]
+        daemon: bool,
+    },
+    /// Print events for a run (always reads from disk; daemon not required).
     Logs {
         /// `RunId` (ULID).
         run_id: String,
@@ -63,11 +79,16 @@ pub async fn run(command: EngineCommands) -> Result<()> {
             spec_path,
             watch,
             worktree,
-        } => run_command(spec_path, watch, worktree).await,
-        EngineCommands::Watch { run_id } => watch_command(run_id).await,
-        EngineCommands::Resume { run_id } => resume_command(run_id).await,
-        EngineCommands::Stop { run_id, reason } => stop_command(run_id, reason).await,
-        EngineCommands::Ls => ls_command().await,
+            daemon,
+        } => run_command(spec_path, watch, worktree, daemon).await,
+        EngineCommands::Watch { run_id, daemon } => watch_command(run_id, daemon).await,
+        EngineCommands::Resume { run_id, daemon } => resume_command(run_id, daemon).await,
+        EngineCommands::Stop {
+            run_id,
+            reason,
+            daemon,
+        } => stop_command(run_id, reason, daemon).await,
+        EngineCommands::Ls { daemon } => ls_command(daemon).await,
         EngineCommands::Logs {
             run_id,
             since,
@@ -76,9 +97,15 @@ pub async fn run(command: EngineCommands) -> Result<()> {
     }
 }
 
-async fn run_command(spec_path: PathBuf, watch: bool, worktree: Option<PathBuf>) -> Result<()> {
+async fn run_command(
+    spec_path: PathBuf,
+    watch: bool,
+    worktree: Option<PathBuf>,
+    daemon: bool,
+) -> Result<()> {
     use std::time::Duration;
     use surge_core::graph::Graph;
+    use surge_orchestrator::engine::facade::EngineFacade;
     use surge_orchestrator::engine::handle::EngineRunEvent;
 
     let toml_text = std::fs::read_to_string(&spec_path)
@@ -94,34 +121,45 @@ async fn run_command(spec_path: PathBuf, watch: bool, worktree: Option<PathBuf>)
         ));
     }
 
-    let storage = Storage::open(&surge_runs_dir()?)
-        .await
-        .context("open storage")?;
+    let facade: Arc<dyn EngineFacade> = if daemon {
+        ensure_daemon_running().await?;
+        let socket = surge_daemon::pidfile::socket_path()?;
+        Arc::new(
+            surge_orchestrator::engine::daemon_facade::DaemonEngineFacade::connect(socket).await?,
+        )
+    } else {
+        let storage = Storage::open(&surge_runs_dir()?)
+            .await
+            .context("open storage")?;
 
-    let bridge: Arc<dyn surge_acp::bridge::facade::BridgeFacade> = Arc::new(
-        surge_acp::bridge::AcpBridge::with_defaults().context("AcpBridge::with_defaults")?,
-    );
+        let bridge: Arc<dyn surge_acp::bridge::facade::BridgeFacade> = Arc::new(
+            surge_acp::bridge::AcpBridge::with_defaults().context("AcpBridge::with_defaults")?,
+        );
 
-    let tool_dispatcher: Arc<dyn surge_orchestrator::engine::tools::ToolDispatcher> = Arc::new(
-        surge_orchestrator::engine::tools::worktree::WorktreeToolDispatcher::new(
-            worktree_path.clone(),
-        ),
-    );
+        let tool_dispatcher: Arc<dyn surge_orchestrator::engine::tools::ToolDispatcher> = Arc::new(
+            surge_orchestrator::engine::tools::worktree::WorktreeToolDispatcher::new(
+                worktree_path.clone(),
+            ),
+        );
 
-    let notifier = build_default_notifier();
+        let notifier = build_default_notifier();
 
-    let engine = Engine::new_with_notifier(
-        bridge,
-        storage,
-        tool_dispatcher,
-        notifier,
-        EngineConfig::default(),
-    );
+        let engine = Arc::new(Engine::new_with_notifier(
+            bridge,
+            storage,
+            tool_dispatcher,
+            notifier,
+            EngineConfig::default(),
+        ));
+        Arc::new(surge_orchestrator::engine::facade::LocalEngineFacade::new(
+            engine,
+        ))
+    };
 
     let run_id = RunId::new();
     println!("{run_id}");
 
-    let handle = engine
+    let handle = facade
         .start_run(run_id, graph, worktree_path, EngineRunConfig::default())
         .await?;
 
@@ -144,29 +182,84 @@ async fn run_command(spec_path: PathBuf, watch: bool, worktree: Option<PathBuf>)
     Ok(())
 }
 
-async fn watch_command(run_id: String) -> Result<()> {
+async fn watch_command(run_id: String, daemon: bool) -> Result<()> {
     let id = parse_run_id(&run_id)?;
+    if !daemon {
+        // Existing M6 disk-tail behavior preserved.
+        follow_log_from(id, 0).await?;
+        return Ok(());
+    }
+    // M7 daemon path: full streaming subscribe is M7+ polish; for PR 3
+    // we fall back to disk-tail mode after ensuring the daemon is up so
+    // existing on-disk events are visible.
+    ensure_daemon_running().await?;
+    eprintln!("watching {id} (disk-tail mode; live streaming via daemon is M7+ polish)…");
     follow_log_from(id, 0).await?;
     Ok(())
 }
 
-async fn resume_command(run_id: String) -> Result<()> {
-    let _ = run_id;
-    Err(anyhow!(
-        "M6: resume requires the engine to be running in this process; \
-         use `surge engine run` instead, or wait for M7's daemon mode"
-    ))
+async fn resume_command(run_id: String, daemon: bool) -> Result<()> {
+    let id = parse_run_id(&run_id)?;
+    if !daemon {
+        return Err(anyhow!(
+            "resume requires --daemon (the engine must be alive to resume); \
+             use `surge engine resume {id} --daemon`"
+        ));
+    }
+    ensure_daemon_running().await?;
+    let socket = surge_daemon::pidfile::socket_path()?;
+    let facade =
+        surge_orchestrator::engine::daemon_facade::DaemonEngineFacade::connect(socket).await?;
+    let cwd = std::env::current_dir().context("cwd")?;
+    use surge_orchestrator::engine::facade::EngineFacade;
+    let _handle = facade.resume_run(id, cwd).await?;
+    println!("resumed {id}");
+    Ok(())
 }
 
-async fn stop_command(run_id: String, reason: Option<String>) -> Result<()> {
-    let _ = (run_id, reason);
-    Err(anyhow!(
-        "M6: stop requires the engine to be running in this process; \
-         M7's daemon mode adds out-of-process stop"
-    ))
+async fn stop_command(run_id: String, reason: Option<String>, daemon: bool) -> Result<()> {
+    let id = parse_run_id(&run_id)?;
+    if !daemon {
+        return Err(anyhow!(
+            "stop requires --daemon (cross-process cancel); \
+             use `surge engine stop {id} --daemon`"
+        ));
+    }
+    ensure_daemon_running().await?;
+    let socket = surge_daemon::pidfile::socket_path()?;
+    let facade =
+        surge_orchestrator::engine::daemon_facade::DaemonEngineFacade::connect(socket).await?;
+    use surge_orchestrator::engine::facade::EngineFacade;
+    facade
+        .stop_run(id, reason.unwrap_or_else(|| "user-requested".into()))
+        .await?;
+    println!("stopped {id}");
+    Ok(())
 }
 
-async fn ls_command() -> Result<()> {
+async fn ls_command(daemon: bool) -> Result<()> {
+    if daemon {
+        ensure_daemon_running().await?;
+        let socket = surge_daemon::pidfile::socket_path()?;
+        use surge_orchestrator::engine::facade::EngineFacade;
+        let facade =
+            surge_orchestrator::engine::daemon_facade::DaemonEngineFacade::connect(socket).await?;
+        let runs = facade.list_runs().await?;
+        println!("{:<32} {:<10} STARTED", "ID", "STATUS");
+        for r in runs {
+            println!(
+                "{:<32} {:<10} {}",
+                r.run_id,
+                format!("{:?}", r.status).to_lowercase(),
+                r.started_at.format("%Y-%m-%d %H:%M:%S")
+            );
+        }
+        return Ok(());
+    }
+    legacy_ls_command().await
+}
+
+async fn legacy_ls_command() -> Result<()> {
     let runs_dir = surge_runs_dir()?;
     // Use storage registry for accurate metadata when available; fall back to
     // raw directory listing if the registry isn't open.
@@ -308,4 +401,21 @@ fn print_event(event: &surge_orchestrator::engine::handle::EngineRunEvent) {
         },
         _ => {},
     }
+}
+
+/// If `--daemon` is requested but no daemon is running, auto-spawn
+/// one. Idempotent if a daemon is already alive.
+async fn ensure_daemon_running() -> Result<()> {
+    use surge_daemon::pidfile;
+    if let Some(p) = pidfile::read_pid(&pidfile::pid_path()?)? {
+        if pidfile::is_alive(p) {
+            return Ok(());
+        }
+    }
+    eprintln!("note: daemon not running; auto-spawning…");
+    crate::commands::daemon::run(crate::commands::daemon::DaemonCommands::Start {
+        detached: true,
+        max_active: 8,
+    })
+    .await
 }

--- a/crates/surge-cli/src/commands/mod.rs
+++ b/crates/surge-cli/src/commands/mod.rs
@@ -1,6 +1,7 @@
 pub mod agent;
 pub mod analytics;
 pub mod config;
+pub mod daemon;
 pub mod engine;
 pub mod format;
 pub mod git;

--- a/crates/surge-cli/src/main.rs
+++ b/crates/surge-cli/src/main.rs
@@ -196,6 +196,12 @@ enum Commands {
         #[command(subcommand)]
         command: commands::engine::EngineCommands,
     },
+
+    /// Manage the long-running surge-daemon process.
+    Daemon {
+        #[command(subcommand)]
+        command: commands::daemon::DaemonCommands,
+    },
 }
 
 /// Set up signal handlers for graceful shutdown.
@@ -315,7 +321,11 @@ async fn main() -> Result<()> {
     // Check for orphaned worktrees at startup (skip for certain commands)
     let should_check_orphans = !matches!(
         cli.command,
-        Commands::Init | Commands::Clean { .. } | Commands::Config { .. } | Commands::Engine { .. }
+        Commands::Init
+            | Commands::Clean { .. }
+            | Commands::Config { .. }
+            | Commands::Engine { .. }
+            | Commands::Daemon { .. }
     );
 
     if should_check_orphans {
@@ -513,6 +523,10 @@ async fn run_command(command: Commands) -> Result<()> {
 
         Commands::Engine { command } => {
             commands::engine::run(command).await?;
+        },
+
+        Commands::Daemon { command } => {
+            commands::daemon::run(command).await?;
         },
 
         Commands::Init => {

--- a/crates/surge-daemon/Cargo.toml
+++ b/crates/surge-daemon/Cargo.toml
@@ -14,6 +14,8 @@ name = "surge-daemon"
 path = "src/main.rs"
 
 [dependencies]
+clap.workspace = true
+humantime = "2"
 async-trait.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/surge-daemon/src/admission.rs
+++ b/crates/surge-daemon/src/admission.rs
@@ -82,6 +82,20 @@ impl AdmissionController {
         None
     }
 
+    /// Like [`try_admit`], but rejects (returns `false`) instead of
+    /// queueing when the cap is hit. Used by operations like
+    /// `resume_run` that don't want to be deferred — the caller
+    /// should propagate an error to the client and let them retry.
+    pub async fn try_admit_no_queue(&self, run_id: RunId) -> bool {
+        let mut inner = self.inner.lock().await;
+        if inner.active.len() < self.max_active {
+            inner.active.insert(run_id);
+            true
+        } else {
+            false
+        }
+    }
+
     /// Snapshot counts for `surge daemon status`.
     pub async fn snapshot(&self) -> AdmissionSnapshot {
         let inner = self.inner.lock().await;
@@ -152,6 +166,18 @@ mod tests {
         a.notify_completed(r1).await;
         let popped = a.pop_queued().await;
         assert_eq!(popped, Some(r2));
+    }
+
+    #[tokio::test]
+    async fn try_admit_no_queue_rejects_at_cap() {
+        let a = AdmissionController::new(1);
+        let r1 = RunId::new();
+        let r2 = RunId::new();
+        assert!(a.try_admit_no_queue(r1).await);
+        assert!(!a.try_admit_no_queue(r2).await);
+        // No queueing happened — snapshot.queued should be 0.
+        let s = a.snapshot().await;
+        assert_eq!(s.queued, 0);
     }
 
     #[tokio::test]

--- a/crates/surge-daemon/src/lib.rs
+++ b/crates/surge-daemon/src/lib.rs
@@ -14,5 +14,7 @@ pub mod admission;
 pub mod broadcast;
 pub mod error;
 pub mod pidfile;
+pub mod server;
 
 pub use error::DaemonError;
+pub use server::{ServerConfig, run as run_server};

--- a/crates/surge-daemon/src/lib.rs
+++ b/crates/surge-daemon/src/lib.rs
@@ -13,6 +13,7 @@
 pub mod admission;
 pub mod broadcast;
 pub mod error;
+pub mod lifecycle;
 pub mod pidfile;
 pub mod server;
 

--- a/crates/surge-daemon/src/lifecycle.rs
+++ b/crates/surge-daemon/src/lifecycle.rs
@@ -1,0 +1,42 @@
+//! Signal-handler installation and graceful-drain helpers. Cancels a
+//! [`CancellationToken`] on SIGTERM / SIGINT (Unix) or Ctrl+C
+//! (Windows).
+
+use std::time::Duration;
+use tokio_util::sync::CancellationToken;
+
+/// Spawn a task that listens for OS termination signals and cancels
+/// `token` when one fires. Returns immediately; the task lives for
+/// the daemon's lifetime.
+pub fn install_signal_handlers(token: CancellationToken) {
+    tokio::spawn(async move {
+        wait_for_termination().await;
+        tracing::info!("termination signal received; cancelling shutdown token");
+        token.cancel();
+    });
+}
+
+#[cfg(unix)]
+async fn wait_for_termination() {
+    use tokio::signal::unix::{SignalKind, signal};
+    let mut term = signal(SignalKind::terminate()).expect("install SIGTERM handler");
+    let mut int = signal(SignalKind::interrupt()).expect("install SIGINT handler");
+    tokio::select! {
+        _ = term.recv() => tracing::info!("SIGTERM received"),
+        _ = int.recv() => tracing::info!("SIGINT received"),
+    }
+}
+
+#[cfg(windows)]
+async fn wait_for_termination() {
+    let _ = tokio::signal::ctrl_c().await;
+    tracing::info!("Ctrl+C received");
+}
+
+/// Wait for `token` to be cancelled, then sleep up to `grace` for
+/// in-flight tasks to wind down. Used by `main.rs` after the server
+/// loop exits to give run forwarders time to publish final events.
+pub async fn drain(token: CancellationToken, grace: Duration) {
+    token.cancelled().await;
+    tokio::time::sleep(grace).await;
+}

--- a/crates/surge-daemon/src/main.rs
+++ b/crates/surge-daemon/src/main.rs
@@ -83,14 +83,30 @@ fn main() -> std::process::ExitCode {
                 },
             };
 
+        // F6: WorktreeToolDispatcher uses `self.worktree_root` (the constructor
+        // argument) for all path operations.  In the daemon, every run supplies
+        // its own isolated git worktree via `start_run`'s `worktree_path`
+        // argument, but the engine currently roots the dispatcher at the path
+        // provided here rather than at the per-run path.  This is an
+        // architectural gap: the dispatcher needs to be re-rooted per run
+        // (tracked as a follow-up TODO).  Passing `current_dir()` is the
+        // status-quo behaviour; it will produce incorrect paths for any run
+        // whose worktree differs from the daemon's cwd.
+        //
+        // TODO: per-run WorktreeToolDispatcher rooted at the run's worktree.
         let tool_dispatcher: Arc<dyn surge_orchestrator::engine::tools::ToolDispatcher> = Arc::new(
             surge_orchestrator::engine::tools::worktree::WorktreeToolDispatcher::new(
                 std::env::current_dir().unwrap_or_default(),
             ),
         );
 
-        let notifier: Arc<dyn surge_notify::NotifyDeliverer> =
-            Arc::new(surge_notify::MultiplexingNotifier::new());
+        // F3: match the CLI's default notifier — Desktop + Webhook deliverers wired.
+        // A bare MultiplexingNotifier silently drops all notifications.
+        let notifier: Arc<dyn surge_notify::NotifyDeliverer> = Arc::new(
+            surge_notify::MultiplexingNotifier::new()
+                .with_desktop(Arc::new(surge_notify::DesktopDeliverer::new()))
+                .with_webhook(Arc::new(surge_notify::WebhookDeliverer::new())),
+        );
 
         let engine = Arc::new(Engine::new_with_notifier(
             bridge,
@@ -112,12 +128,17 @@ fn main() -> std::process::ExitCode {
             max_active: args.max_active,
             socket_path: socket_path.clone(),
         };
-        let shutdown_for_server = shutdown.clone();
         let server_handle = tokio::spawn({
             let facade = facade.clone();
+            let shutdown_for_server = shutdown.clone();
+            // F1: keep a second clone so that a server error (e.g. bind failure)
+            // cancels the outer shutdown token — otherwise lifecycle::drain
+            // waits forever holding the pid lock.
+            let shutdown_for_cancel = shutdown.clone();
             async move {
                 if let Err(e) = run_server(server_cfg, facade, shutdown_for_server).await {
-                    tracing::error!(err = %e, "server exited with error");
+                    tracing::error!(err = %e, "server exited with error; cancelling shutdown token");
+                    shutdown_for_cancel.cancel();
                 }
             }
         });

--- a/crates/surge-daemon/src/main.rs
+++ b/crates/surge-daemon/src/main.rs
@@ -1,6 +1,140 @@
-//! `surge-daemon` binary. Phase 6 fills this in.
+//! `surge-daemon` binary entry point.
+
+use clap::Parser;
+use std::sync::Arc;
+use std::time::Duration;
+use surge_acp::bridge::AcpBridge;
+use surge_daemon::{ServerConfig, lifecycle, pidfile, run_server};
+use surge_orchestrator::engine::facade::LocalEngineFacade;
+use surge_orchestrator::engine::{Engine, EngineConfig};
+use surge_persistence::runs::Storage;
+use tokio_util::sync::CancellationToken;
+
+#[derive(Parser, Debug)]
+#[command(version, about = "surge-daemon — long-running engine host")]
+struct Args {
+    /// Maximum concurrent active runs.
+    #[arg(long, default_value_t = 8)]
+    max_active: usize,
+    /// Graceful-shutdown grace window.
+    #[arg(long, default_value = "30s", value_parser = parse_humantime)]
+    shutdown_grace: Duration,
+    /// Detach from the controlling terminal (Unix: `setsid` already
+    /// handled by the spawning CLI; this flag is currently a no-op
+    /// inside the daemon process itself but reserved for future use).
+    #[arg(long)]
+    detached: bool,
+}
+
+fn parse_humantime(s: &str) -> Result<Duration, String> {
+    humantime::parse_duration(s).map_err(|e| e.to_string())
+}
 
 fn main() -> std::process::ExitCode {
-    eprintln!("surge-daemon: scaffolded; runtime added in Phase 6");
-    std::process::ExitCode::from(2)
+    tracing_subscriber::fmt::init();
+    let args = Args::parse();
+
+    // Acquire PID lock before touching the runtime — failure exits cheaply.
+    if let Err(e) = pidfile::acquire_lock(std::process::id()) {
+        eprintln!("surge-daemon: {e}");
+        return std::process::ExitCode::from(2);
+    }
+
+    let socket_path = match pidfile::socket_path() {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("surge-daemon: socket_path: {e}");
+            let _ = pidfile::release_lock();
+            return std::process::ExitCode::from(2);
+        },
+    };
+
+    let rt = match tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+    {
+        Ok(rt) => rt,
+        Err(e) => {
+            eprintln!("surge-daemon: tokio runtime: {e}");
+            let _ = pidfile::release_lock();
+            return std::process::ExitCode::from(2);
+        },
+    };
+
+    let exit = rt.block_on(async {
+        let shutdown = CancellationToken::new();
+        lifecycle::install_signal_handlers(shutdown.clone());
+
+        // Storage::open returns Arc<Storage> directly.
+        let storage = match Storage::open(&surge_runs_dir()).await {
+            Ok(s) => s,
+            Err(e) => {
+                eprintln!("surge-daemon: storage: {e}");
+                return 2u8;
+            },
+        };
+
+        let bridge: Arc<dyn surge_acp::bridge::facade::BridgeFacade> =
+            match AcpBridge::with_defaults() {
+                Ok(b) => Arc::new(b),
+                Err(e) => {
+                    eprintln!("surge-daemon: bridge: {e}");
+                    return 2u8;
+                },
+            };
+
+        let tool_dispatcher: Arc<dyn surge_orchestrator::engine::tools::ToolDispatcher> = Arc::new(
+            surge_orchestrator::engine::tools::worktree::WorktreeToolDispatcher::new(
+                std::env::current_dir().unwrap_or_default(),
+            ),
+        );
+
+        let notifier: Arc<dyn surge_notify::NotifyDeliverer> =
+            Arc::new(surge_notify::MultiplexingNotifier::new());
+
+        let engine = Arc::new(Engine::new_with_notifier(
+            bridge,
+            storage,
+            tool_dispatcher,
+            notifier,
+            EngineConfig::default(),
+        ));
+
+        let facade: Arc<dyn surge_orchestrator::engine::facade::EngineFacade> =
+            Arc::new(LocalEngineFacade::new(engine));
+
+        // Write version file so the CLI can read the running daemon's version.
+        if let Ok(path) = pidfile::version_path() {
+            let _ = std::fs::write(path, env!("CARGO_PKG_VERSION"));
+        }
+
+        let server_cfg = ServerConfig {
+            max_active: args.max_active,
+            socket_path: socket_path.clone(),
+        };
+        let shutdown_for_server = shutdown.clone();
+        let server_handle = tokio::spawn({
+            let facade = facade.clone();
+            async move {
+                if let Err(e) = run_server(server_cfg, facade, shutdown_for_server).await {
+                    tracing::error!(err = %e, "server exited with error");
+                }
+            }
+        });
+
+        // Wait for shutdown signal, then give forwarders the grace window.
+        lifecycle::drain(shutdown, args.shutdown_grace).await;
+        server_handle.abort();
+        0u8
+    });
+
+    let _ = pidfile::release_lock();
+    let _ = std::fs::remove_file(&socket_path);
+    std::process::ExitCode::from(exit)
+}
+
+fn surge_runs_dir() -> std::path::PathBuf {
+    dirs::home_dir()
+        .map(|h| h.join(".surge"))
+        .unwrap_or_else(|| std::path::PathBuf::from(".surge"))
 }

--- a/crates/surge-daemon/src/main.rs
+++ b/crates/surge-daemon/src/main.rs
@@ -83,20 +83,12 @@ fn main() -> std::process::ExitCode {
                 },
             };
 
-        // F6: WorktreeToolDispatcher uses `self.worktree_root` (the constructor
-        // argument) for all path operations.  In the daemon, every run supplies
-        // its own isolated git worktree via `start_run`'s `worktree_path`
-        // argument, but the engine currently roots the dispatcher at the path
-        // provided here rather than at the per-run path.  This is an
-        // architectural gap: the dispatcher needs to be re-rooted per run
-        // (tracked as a follow-up TODO).  Passing `current_dir()` is the
-        // status-quo behaviour; it will produce incorrect paths for any run
-        // whose worktree differs from the daemon's cwd.
-        //
-        // TODO: per-run WorktreeToolDispatcher rooted at the run's worktree.
+        // The constructor argument is a historical hint; per-run worktree
+        // resolution happens in dispatch via ToolDispatchContext::worktree_root.
+        // A single dispatcher instance is safe to share across all runs.
         let tool_dispatcher: Arc<dyn surge_orchestrator::engine::tools::ToolDispatcher> = Arc::new(
             surge_orchestrator::engine::tools::worktree::WorktreeToolDispatcher::new(
-                std::env::current_dir().unwrap_or_default(),
+                std::path::PathBuf::new(),
             ),
         );
 

--- a/crates/surge-daemon/src/server.rs
+++ b/crates/surge-daemon/src/server.rs
@@ -10,7 +10,7 @@ use crate::broadcast::BroadcastRegistry;
 use crate::error::DaemonError;
 use interprocess::local_socket::tokio::prelude::*;
 use std::collections::HashSet;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::sync::Arc;
 use surge_core::id::RunId;
 use surge_orchestrator::engine::facade::EngineFacade;
@@ -43,7 +43,8 @@ pub async fn run(
     let admission = Arc::new(AdmissionController::new(cfg.max_active));
     let broadcast = Arc::new(BroadcastRegistry::new());
 
-    let name = path_to_socket_name(&cfg.socket_path)?;
+    let name = surge_orchestrator::engine::ipc::local_socket_name_from_path(&cfg.socket_path)
+        .map_err(DaemonError::Io)?;
     let listener = ListenerOptions::new()
         .name(name)
         .create_tokio()
@@ -86,12 +87,6 @@ pub async fn run(
         }
     }
     Ok(())
-}
-
-fn path_to_socket_name(path: &Path) -> Result<interprocess::local_socket::Name<'_>, DaemonError> {
-    use interprocess::local_socket::ToFsName;
-    path.to_fs_name::<interprocess::local_socket::GenericFilePath>()
-        .map_err(DaemonError::Io)
 }
 
 /// Per-connection state: tracks which runs the client subscribed to,

--- a/crates/surge-daemon/src/server.rs
+++ b/crates/surge-daemon/src/server.rs
@@ -335,7 +335,11 @@ async fn dispatch(
         // this server is updated.
         _ => {
             tracing::warn!("unrecognised DaemonRequest variant; returning error");
-            None
+            Some(DaemonResponse::Error {
+                request_id: 0,
+                code: ErrorCode::BadRequest,
+                message: "unsupported request method".into(),
+            })
         },
     }
 }

--- a/crates/surge-daemon/src/server.rs
+++ b/crates/surge-daemon/src/server.rs
@@ -253,6 +253,17 @@ async fn dispatch(
             run_id,
             worktree_path,
         } => {
+            // Resume must consume an admission slot just like a fresh
+            // StartRun, otherwise users can exceed max_active by replaying
+            // resumes. We do NOT queue resumes (the user expects the run to
+            // come back live); if the cap is hit, return AdmissionFull.
+            if !admission.try_admit_no_queue(run_id).await {
+                return Some(DaemonResponse::Error {
+                    request_id,
+                    code: ErrorCode::AdmissionFull,
+                    message: format!("admission cap reached; cannot resume {run_id} now"),
+                });
+            }
             let publisher = broadcast.register(run_id).await;
             let admission_for_completion = admission.clone();
             let broadcast_for_completion = broadcast.clone();
@@ -269,6 +280,7 @@ async fn dispatch(
                 },
                 Err(e) => {
                     broadcast.deregister(run_id).await;
+                    admission.notify_completed(run_id).await;
                     Some(DaemonResponse::Error {
                         request_id,
                         code: ErrorCode::EngineError,

--- a/crates/surge-daemon/src/server.rs
+++ b/crates/surge-daemon/src/server.rs
@@ -9,7 +9,7 @@ use crate::admission::{AdmissionController, AdmissionDecision};
 use crate::broadcast::BroadcastRegistry;
 use crate::error::DaemonError;
 use interprocess::local_socket::tokio::prelude::*;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::sync::Arc;
 use surge_core::id::RunId;
@@ -42,6 +42,15 @@ pub async fn run(
 
     let admission = Arc::new(AdmissionController::new(cfg.max_active));
     let broadcast = Arc::new(BroadcastRegistry::new());
+
+    // F2: Unlink any stale socket file from a previous unclean exit.
+    // On Windows, the named pipe doesn't live on the filesystem so this is a no-op.
+    #[cfg(unix)]
+    {
+        if cfg.socket_path.exists() {
+            let _ = std::fs::remove_file(&cfg.socket_path);
+        }
+    }
 
     let name = surge_orchestrator::engine::ipc::local_socket_name_from_path(&cfg.socket_path)
         .map_err(DaemonError::Io)?;
@@ -89,11 +98,14 @@ pub async fn run(
     Ok(())
 }
 
-/// Per-connection state: tracks which runs the client subscribed to,
-/// so we can identify subscriptions on disconnect (per-run forwarders
-/// terminate naturally when their write target closes).
+/// Per-connection state: tracks which runs the client subscribed to
+/// and the `JoinHandle` of each per-run forwarder task so that
+/// `Unsubscribe` (and disconnect cleanup) can abort them promptly.
 struct ConnState {
     subscriptions: HashSet<RunId>,
+    /// Per-run forwarder task handles. Populated by `Subscribe`;
+    /// removed (and aborted) by `Unsubscribe` or connection teardown.
+    forwarders: HashMap<RunId, tokio::task::JoinHandle<()>>,
 }
 
 async fn handle_connection(
@@ -108,6 +120,7 @@ async fn handle_connection(
     let writer: Arc<Mutex<_>> = Arc::new(Mutex::new(write_half));
     let state = Arc::new(Mutex::new(ConnState {
         subscriptions: HashSet::new(),
+        forwarders: HashMap::new(),
     }));
 
     loop {
@@ -133,6 +146,7 @@ async fn handle_connection(
                             &broadcast,
                             &state,
                             &writer,
+                            &shutdown,
                         )
                         .await;
                         if let Some(r) = resp {
@@ -152,6 +166,13 @@ async fn handle_connection(
             }
         }
     }
+
+    // F5: Cleanup — abort any forwarder tasks the client left open.
+    let mut s = state.lock().await;
+    for (_, h) in s.forwarders.drain() {
+        h.abort();
+    }
+
     Ok(())
 }
 
@@ -163,6 +184,7 @@ async fn dispatch(
     broadcast: &Arc<BroadcastRegistry>,
     state: &Arc<Mutex<ConnState>>,
     writer: &Arc<Mutex<interprocess::local_socket::tokio::SendHalf>>,
+    shutdown: &CancellationToken,
 ) -> Option<DaemonResponse> {
     match req {
         DaemonRequest::Ping { request_id } => Some(DaemonResponse::PingOk {
@@ -296,12 +318,15 @@ async fn dispatch(
             let rx = broadcast.subscribe(run_id).await;
             match rx {
                 Some(rx) => {
+                    let writer_for_task = writer.clone();
+                    // F5: store the JoinHandle so Unsubscribe can abort it.
+                    let handle =
+                        tokio::spawn(forward_per_run_to_client(run_id, rx, writer_for_task));
                     {
                         let mut s = state.lock().await;
                         s.subscriptions.insert(run_id);
+                        s.forwarders.insert(run_id, handle);
                     }
-                    let writer_for_task = writer.clone();
-                    tokio::spawn(forward_per_run_to_client(run_id, rx, writer_for_task));
                     Some(DaemonResponse::SubscribeOk { request_id })
                 },
                 None => Some(DaemonResponse::Error {
@@ -315,13 +340,17 @@ async fn dispatch(
         DaemonRequest::Unsubscribe { request_id, run_id } => {
             let mut s = state.lock().await;
             s.subscriptions.remove(&run_id);
+            // F5: abort the per-run forwarder task.
+            if let Some(h) = s.forwarders.remove(&run_id) {
+                h.abort();
+            }
             Some(DaemonResponse::UnsubscribeOk { request_id })
         },
 
         DaemonRequest::Shutdown { request_id } => {
-            // Lifecycle (Phase 6.2) handles the actual signal cancel;
-            // we just acknowledge here. The lifecycle drain closes
-            // connections shortly after.
+            // F4: actually cancel the shutdown token so the daemon exits.
+            tracing::info!("Shutdown IPC received; cancelling shutdown token");
+            shutdown.cancel();
             Some(DaemonResponse::ShutdownOk { request_id })
         },
 

--- a/crates/surge-daemon/src/server.rs
+++ b/crates/surge-daemon/src/server.rs
@@ -1,0 +1,409 @@
+//! IPC server: accept-and-dispatch loop. Each accepted connection
+//! gets a per-connection task that reads [`DaemonRequest`] frames
+//! from the socket and forwards them to the engine via the
+//! [`EngineFacade`]. Per-run subscriptions spawn forwarder
+//! tasks that pump [`EngineRunEvent`]s into the wire as
+//! [`DaemonEvent::PerRun`].
+
+use crate::admission::{AdmissionController, AdmissionDecision};
+use crate::broadcast::BroadcastRegistry;
+use crate::error::DaemonError;
+use interprocess::local_socket::tokio::prelude::*;
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use surge_core::id::RunId;
+use surge_orchestrator::engine::facade::EngineFacade;
+use surge_orchestrator::engine::handle::EngineRunEvent;
+use surge_orchestrator::engine::ipc::{
+    DaemonEvent, DaemonRequest, DaemonResponse, ErrorCode, GlobalDaemonEvent, read_request_frame,
+    write_frame,
+};
+use tokio::io::{AsyncWriteExt, BufReader};
+use tokio::sync::Mutex;
+use tokio_util::sync::CancellationToken;
+
+/// Top-level daemon-server config.
+pub struct ServerConfig {
+    /// Maximum concurrent active runs.
+    pub max_active: usize,
+    /// Path of the local socket to bind.
+    pub socket_path: PathBuf,
+}
+
+/// Wires together the engine facade, admission, broadcast registry,
+/// and the IPC listener. Called by `main.rs` (Phase 6.3).
+pub async fn run(
+    cfg: ServerConfig,
+    facade: Arc<dyn EngineFacade>,
+    shutdown: CancellationToken,
+) -> Result<(), DaemonError> {
+    use interprocess::local_socket::ListenerOptions;
+
+    let admission = Arc::new(AdmissionController::new(cfg.max_active));
+    let broadcast = Arc::new(BroadcastRegistry::new());
+
+    let name = path_to_socket_name(&cfg.socket_path)?;
+    let listener = ListenerOptions::new()
+        .name(name)
+        .create_tokio()
+        .map_err(DaemonError::Io)?;
+
+    tracing::info!(socket = %cfg.socket_path.display(), "daemon listening");
+
+    loop {
+        tokio::select! {
+            () = shutdown.cancelled() => {
+                tracing::info!("shutdown signal received; closing listener");
+                break;
+            }
+            conn = listener.accept() => {
+                match conn {
+                    Ok(stream) => {
+                        let facade = facade.clone();
+                        let admission = admission.clone();
+                        let broadcast = broadcast.clone();
+                        let shutdown_for_conn = shutdown.clone();
+                        tokio::spawn(async move {
+                            if let Err(e) = handle_connection(
+                                stream,
+                                facade,
+                                admission,
+                                broadcast,
+                                shutdown_for_conn,
+                            )
+                            .await
+                            {
+                                tracing::warn!(err = %e, "connection ended with error");
+                            }
+                        });
+                    }
+                    Err(e) => {
+                        tracing::warn!(err = %e, "accept failed");
+                    }
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+fn path_to_socket_name(path: &Path) -> Result<interprocess::local_socket::Name<'_>, DaemonError> {
+    use interprocess::local_socket::ToFsName;
+    path.to_fs_name::<interprocess::local_socket::GenericFilePath>()
+        .map_err(DaemonError::Io)
+}
+
+/// Per-connection state: tracks which runs the client subscribed to,
+/// so we can identify subscriptions on disconnect (per-run forwarders
+/// terminate naturally when their write target closes).
+struct ConnState {
+    subscriptions: HashSet<RunId>,
+}
+
+async fn handle_connection(
+    stream: LocalSocketStream,
+    facade: Arc<dyn EngineFacade>,
+    admission: Arc<AdmissionController>,
+    broadcast: Arc<BroadcastRegistry>,
+    shutdown: CancellationToken,
+) -> Result<(), DaemonError> {
+    let (read_half, write_half) = stream.split();
+    let mut reader = BufReader::new(read_half);
+    let writer: Arc<Mutex<_>> = Arc::new(Mutex::new(write_half));
+    let state = Arc::new(Mutex::new(ConnState {
+        subscriptions: HashSet::new(),
+    }));
+
+    loop {
+        tokio::select! {
+            () = shutdown.cancelled() => {
+                let err = DaemonResponse::Error {
+                    request_id: 0,
+                    code: ErrorCode::ShuttingDown,
+                    message: "daemon shutting down".into(),
+                };
+                let mut w = writer.lock().await;
+                let _ = write_frame(&mut *w, &err).await;
+                let _ = w.flush().await;
+                break;
+            }
+            frame = read_request_frame(&mut reader) => {
+                match frame {
+                    Ok(Some(req)) => {
+                        let resp = dispatch(
+                            req,
+                            &*facade,
+                            &admission,
+                            &broadcast,
+                            &state,
+                            &writer,
+                        )
+                        .await;
+                        if let Some(r) = resp {
+                            let mut w = writer.lock().await;
+                            if let Err(e) = write_frame(&mut *w, &r).await {
+                                tracing::warn!(err = %e, "write_frame failed; closing connection");
+                                break;
+                            }
+                        }
+                    }
+                    Ok(None) => break, // EOF
+                    Err(e) => {
+                        tracing::warn!(err = %e, "read_request_frame failed; closing connection");
+                        break;
+                    }
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+#[allow(clippy::too_many_lines)]
+async fn dispatch(
+    req: DaemonRequest,
+    facade: &dyn EngineFacade,
+    admission: &Arc<AdmissionController>,
+    broadcast: &Arc<BroadcastRegistry>,
+    state: &Arc<Mutex<ConnState>>,
+    writer: &Arc<Mutex<interprocess::local_socket::tokio::SendHalf>>,
+) -> Option<DaemonResponse> {
+    match req {
+        DaemonRequest::Ping { request_id } => Some(DaemonResponse::PingOk {
+            request_id,
+            version: env!("CARGO_PKG_VERSION").into(),
+        }),
+
+        DaemonRequest::StartRun {
+            request_id,
+            run_id,
+            graph,
+            worktree_path,
+            run_config,
+        } => {
+            let decision = admission.try_admit(run_id).await;
+            match decision {
+                AdmissionDecision::Admitted => {
+                    broadcast.publish_global(GlobalDaemonEvent::RunAccepted { run_id });
+                    let publisher = broadcast.register(run_id).await;
+                    let admission_for_completion = admission.clone();
+                    let broadcast_for_completion = broadcast.clone();
+                    match facade
+                        .start_run(run_id, *graph, worktree_path, run_config)
+                        .await
+                    {
+                        Ok(handle) => {
+                            spawn_forward_task(
+                                run_id,
+                                handle,
+                                publisher,
+                                admission_for_completion,
+                                broadcast_for_completion,
+                            );
+                            Some(DaemonResponse::StartRunOk { request_id, run_id })
+                        },
+                        Err(e) => {
+                            broadcast.deregister(run_id).await;
+                            admission.notify_completed(run_id).await;
+                            Some(DaemonResponse::Error {
+                                request_id,
+                                code: ErrorCode::EngineError,
+                                message: format!("{e}"),
+                            })
+                        },
+                    }
+                },
+                AdmissionDecision::Queued { position } => {
+                    // TODO M7: drain-queue task lands with Phase 9 or 10 polish.
+                    // Until that task exists, a queued run sits in the FIFO queue
+                    // and will only be admitted when an active run finishes AND
+                    // pop_queued() is called externally (e.g., a Phase 9 drain loop).
+                    // The client receives StartRunQueued and must poll or rely on
+                    // GlobalDaemonEvent::RunAccepted to know when its run eventually
+                    // starts.
+                    Some(DaemonResponse::StartRunQueued {
+                        request_id,
+                        run_id,
+                        position,
+                    })
+                },
+            }
+        },
+
+        DaemonRequest::ResumeRun {
+            request_id,
+            run_id,
+            worktree_path,
+        } => {
+            let publisher = broadcast.register(run_id).await;
+            let admission_for_completion = admission.clone();
+            let broadcast_for_completion = broadcast.clone();
+            match facade.resume_run(run_id, worktree_path).await {
+                Ok(handle) => {
+                    spawn_forward_task(
+                        run_id,
+                        handle,
+                        publisher,
+                        admission_for_completion,
+                        broadcast_for_completion,
+                    );
+                    Some(DaemonResponse::ResumeRunOk { request_id })
+                },
+                Err(e) => {
+                    broadcast.deregister(run_id).await;
+                    Some(DaemonResponse::Error {
+                        request_id,
+                        code: ErrorCode::EngineError,
+                        message: format!("{e}"),
+                    })
+                },
+            }
+        },
+
+        DaemonRequest::StopRun {
+            request_id,
+            run_id,
+            reason,
+        } => match facade.stop_run(run_id, reason).await {
+            Ok(()) => Some(DaemonResponse::StopRunOk { request_id }),
+            Err(e) => Some(DaemonResponse::Error {
+                request_id,
+                code: ErrorCode::EngineError,
+                message: format!("{e}"),
+            }),
+        },
+
+        DaemonRequest::ResolveHumanInput {
+            request_id,
+            run_id,
+            call_id,
+            response,
+        } => match facade.resolve_human_input(run_id, call_id, response).await {
+            Ok(()) => Some(DaemonResponse::ResolveHumanInputOk { request_id }),
+            Err(e) => Some(DaemonResponse::Error {
+                request_id,
+                code: ErrorCode::EngineError,
+                message: format!("{e}"),
+            }),
+        },
+
+        DaemonRequest::ListRuns { request_id } => match facade.list_runs().await {
+            Ok(runs) => Some(DaemonResponse::ListRunsOk { request_id, runs }),
+            Err(e) => Some(DaemonResponse::Error {
+                request_id,
+                code: ErrorCode::EngineError,
+                message: format!("{e}"),
+            }),
+        },
+
+        DaemonRequest::Subscribe { request_id, run_id } => {
+            let rx = broadcast.subscribe(run_id).await;
+            match rx {
+                Some(rx) => {
+                    {
+                        let mut s = state.lock().await;
+                        s.subscriptions.insert(run_id);
+                    }
+                    let writer_for_task = writer.clone();
+                    tokio::spawn(forward_per_run_to_client(run_id, rx, writer_for_task));
+                    Some(DaemonResponse::SubscribeOk { request_id })
+                },
+                None => Some(DaemonResponse::Error {
+                    request_id,
+                    code: ErrorCode::RunNotActive,
+                    message: format!("run {run_id} not active in this daemon"),
+                }),
+            }
+        },
+
+        DaemonRequest::Unsubscribe { request_id, run_id } => {
+            let mut s = state.lock().await;
+            s.subscriptions.remove(&run_id);
+            Some(DaemonResponse::UnsubscribeOk { request_id })
+        },
+
+        DaemonRequest::Shutdown { request_id } => {
+            // Lifecycle (Phase 6.2) handles the actual signal cancel;
+            // we just acknowledge here. The lifecycle drain closes
+            // connections shortly after.
+            Some(DaemonResponse::ShutdownOk { request_id })
+        },
+
+        // `DaemonRequest` is #[non_exhaustive]; new variants added in
+        // future milestones will fall here with a generic error until
+        // this server is updated.
+        _ => {
+            tracing::warn!("unrecognised DaemonRequest variant; returning error");
+            None
+        },
+    }
+}
+
+/// Spawn the task that forwards engine events into the broadcast
+/// registry and on terminal: publishes `RunFinished` + frees the
+/// admission slot.
+fn spawn_forward_task(
+    run_id: RunId,
+    handle: surge_orchestrator::engine::handle::RunHandle,
+    publisher: tokio::sync::broadcast::Sender<EngineRunEvent>,
+    admission: Arc<AdmissionController>,
+    broadcast: Arc<BroadcastRegistry>,
+) {
+    tokio::spawn(async move {
+        let mut rx = handle.events;
+        loop {
+            match rx.recv().await {
+                Ok(ev) => {
+                    let _ = publisher.send(ev);
+                },
+                Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
+                Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => {},
+            }
+        }
+        // The run task finished (engine event stream closed). Wait for
+        // the run-task JoinHandle to read the outcome, then notify.
+        let outcome = handle.completion.await.unwrap_or(
+            surge_orchestrator::engine::handle::RunOutcome::Aborted {
+                reason: "run task panicked".into(),
+            },
+        );
+        broadcast.publish_global(GlobalDaemonEvent::RunFinished { run_id, outcome });
+        broadcast.deregister(run_id).await;
+        admission.notify_completed(run_id).await;
+    });
+}
+
+/// Per-subscriber forwarder: pumps per-run broadcast → wire as
+/// [`DaemonEvent::PerRun`]. Exits when the broadcast closes, the
+/// writer fails, or the receiver lags too much.
+async fn forward_per_run_to_client(
+    run_id: RunId,
+    mut rx: tokio::sync::broadcast::Receiver<EngineRunEvent>,
+    writer: Arc<Mutex<interprocess::local_socket::tokio::SendHalf>>,
+) {
+    loop {
+        match rx.recv().await {
+            Ok(event) => {
+                let frame = DaemonEvent::PerRun { run_id, event };
+                let mut w = writer.lock().await;
+                if let Err(e) = write_frame(&mut *w, &frame).await {
+                    tracing::debug!(
+                        err = %e,
+                        run_id = %run_id,
+                        "subscriber write failed; ending forwarder"
+                    );
+                    break;
+                }
+            },
+            Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
+            Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
+                tracing::warn!(
+                    run_id = %run_id,
+                    dropped = n,
+                    "per-run forwarder lagged"
+                );
+            },
+        }
+    }
+}

--- a/crates/surge-orchestrator/src/engine/daemon_facade.rs
+++ b/crates/surge-orchestrator/src/engine/daemon_facade.rs
@@ -18,7 +18,7 @@ use crate::engine::ipc::{
 use async_trait::async_trait;
 use interprocess::local_socket::tokio::prelude::*;
 use std::collections::HashMap;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use surge_core::graph::Graph;
@@ -54,7 +54,7 @@ impl DaemonClient {
     /// recorded in `~/.surge/daemon/daemon.sock` (the discovery
     /// helper resolving the file→pipe-name lives in PR 3).
     pub async fn connect(socket_path: PathBuf) -> Result<Arc<Self>, EngineError> {
-        let name = socket_name_from_path(&socket_path)
+        let name = crate::engine::ipc::local_socket_name_from_path(&socket_path)
             .map_err(|e| EngineError::Internal(format!("socket name: {e}")))?;
         let stream = LocalSocketStream::connect(name).await.map_err(|e| {
             EngineError::Internal(format!("connect {}: {e}", socket_path.display()))
@@ -180,17 +180,6 @@ impl DaemonClient {
         rx.await
             .map_err(|_| EngineError::Internal("daemon dropped before response".into()))
     }
-}
-
-/// Helper to convert a filesystem path into the platform-specific
-/// [`interprocess::local_socket::Name`] that interprocess expects. Uses the
-/// `GenericFilePath` namespace (i.e., the path is interpreted as a
-/// filesystem entry on every platform).
-fn socket_name_from_path(
-    path: &Path,
-) -> Result<interprocess::local_socket::Name<'_>, std::io::Error> {
-    use interprocess::local_socket::ToFsName;
-    path.to_fs_name::<interprocess::local_socket::GenericFilePath>()
 }
 
 /// Public [`EngineFacade`] surface — wraps the [`DaemonClient`].

--- a/crates/surge-orchestrator/src/engine/ipc.rs
+++ b/crates/surge-orchestrator/src/engine/ipc.rs
@@ -463,6 +463,40 @@ where
     }
 }
 
+// ============================================================================
+// Cross-platform socket name resolution
+// ============================================================================
+
+/// Convert a filesystem path into the platform-appropriate
+/// `local_socket::Name`. On Unix the path is used directly as a
+/// filesystem socket path; on Windows the path's `file_name` is used
+/// as a namespaced pipe name (mapping to `\\.\pipe\<name>`).
+///
+/// This is the correct cross-platform handler for the daemon's
+/// IPC socket discovery. Both `surge-daemon::server` (listener)
+/// and `DaemonClient::connect` (client) call this function so the
+/// pipe name agrees on both ends.
+pub fn local_socket_name_from_path(
+    path: &std::path::Path,
+) -> std::io::Result<interprocess::local_socket::Name<'_>> {
+    #[cfg(unix)]
+    {
+        use interprocess::local_socket::{GenericFilePath, ToFsName};
+        path.to_fs_name::<GenericFilePath>()
+    }
+    #[cfg(windows)]
+    {
+        use interprocess::local_socket::{GenericNamespaced, ToNsName};
+        let name = path.file_name().and_then(|n| n.to_str()).ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "socket path has no valid file name",
+            )
+        })?;
+        name.to_ns_name::<GenericNamespaced>()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/surge-orchestrator/src/engine/tools/worktree.rs
+++ b/crates/surge-orchestrator/src/engine/tools/worktree.rs
@@ -2,7 +2,7 @@
 
 use crate::engine::tools::{ToolCall, ToolDispatchContext, ToolDispatcher, ToolResultPayload};
 use async_trait::async_trait;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 /// Maximum bytes of stdout/stderr to capture per shell command.
 /// Longer output is tail-truncated with a marker line.
@@ -25,293 +25,315 @@ fn truncate_with_marker(s: String, cap: usize) -> String {
 
 /// Tool dispatcher that constrains all file and shell operations to the run's
 /// isolated git worktree. Prevents path-traversal attacks.
+///
+/// Per-call worktree resolution comes from [`ToolDispatchContext::worktree_root`]
+/// at dispatch time, so a single dispatcher instance is safe to share across
+/// multiple runs (daemon mode) or agent stages with different worktrees.
 pub struct WorktreeToolDispatcher {
+    /// Historical: the constructor accepted a worktree path, but `dispatch`
+    /// now reads `ctx.worktree_root` per call. Kept for backwards
+    /// compatibility with M6 construction sites that call
+    /// `WorktreeToolDispatcher::new(cwd)`.
     worktree_root: PathBuf,
 }
 
 impl WorktreeToolDispatcher {
-    /// Create a new dispatcher rooted at `worktree_root`.
+    /// Create a new dispatcher.
     ///
-    /// The path is canonicalized on construction; if canonicalization fails
-    /// (e.g. the directory doesn't exist yet) the original path is kept.
+    /// The `worktree_root` argument is accepted for backwards compatibility
+    /// with M6 callers but is no longer load-bearing: per-call worktree
+    /// resolution happens in [`dispatch`][`ToolDispatcher::dispatch`] via
+    /// [`ToolDispatchContext::worktree_root`].
     #[must_use]
     pub fn new(worktree_root: PathBuf) -> Self {
-        let canonical = std::fs::canonicalize(&worktree_root).unwrap_or(worktree_root);
-        Self {
-            worktree_root: canonical,
-        }
+        Self { worktree_root }
     }
 
-    /// Return the canonicalized worktree root path.
+    /// Return the path stored at construction time.
+    ///
+    /// This path is no longer used by `dispatch` (which reads
+    /// `ctx.worktree_root` instead). It is exposed so that callers
+    /// constructed before the F6 fix can still read back the path they
+    /// passed in.
     #[must_use]
-    pub fn worktree_root(&self) -> &std::path::Path {
+    pub fn worktree_root(&self) -> &Path {
         &self.worktree_root
     }
+}
 
-    async fn read_file(&self, call: &ToolCall) -> ToolResultPayload {
-        let Some(args) = call.arguments.as_object() else {
-            return ToolResultPayload::Error {
-                message: "read_file: arguments must be an object".into(),
-            };
+/// Canonicalize `worktree_root` so the `starts_with` path-guard check works
+/// correctly on Windows (where `fs::canonicalize` adds the `\\?\` prefix).
+/// Falls back to the original path if canonicalization fails.
+fn canonical_root(worktree_root: &Path) -> PathBuf {
+    std::fs::canonicalize(worktree_root).unwrap_or_else(|_| worktree_root.to_path_buf())
+}
+
+async fn read_file(worktree_root: &Path, call: &ToolCall) -> ToolResultPayload {
+    let worktree_root = canonical_root(worktree_root);
+    let worktree_root = worktree_root.as_path();
+    let Some(args) = call.arguments.as_object() else {
+        return ToolResultPayload::Error {
+            message: "read_file: arguments must be an object".into(),
         };
-        let Some(rel_path) = args.get("path").and_then(|v| v.as_str()) else {
-            return ToolResultPayload::Error {
-                message: "read_file: missing 'path' arg".into(),
-            };
+    };
+    let Some(rel_path) = args.get("path").and_then(|v| v.as_str()) else {
+        return ToolResultPayload::Error {
+            message: "read_file: missing 'path' arg".into(),
         };
-        let binary = args
-            .get("binary")
-            .and_then(serde_json::Value::as_bool)
-            .unwrap_or(false);
-        let abs = self.worktree_root.join(rel_path);
-        let canonical = match std::fs::canonicalize(&abs) {
-            Ok(p) => p,
-            Err(e) => {
-                return ToolResultPayload::Error {
-                    message: format!("read_file: cannot canonicalize {}: {e}", abs.display()),
-                };
-            },
-        };
-        if !canonical.starts_with(&self.worktree_root) {
+    };
+    let binary = args
+        .get("binary")
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(false);
+    let abs = worktree_root.join(rel_path);
+    let canonical = match std::fs::canonicalize(&abs) {
+        Ok(p) => p,
+        Err(e) => {
             return ToolResultPayload::Error {
-                message: format!(
-                    "read_file: path {} escapes worktree {}",
-                    canonical.display(),
-                    self.worktree_root.display()
-                ),
+                message: format!("read_file: cannot canonicalize {}: {e}", abs.display()),
             };
-        }
-        if binary {
-            match tokio::fs::read(&canonical).await {
-                Ok(bytes) => {
-                    use base64::{Engine, engine::general_purpose::STANDARD};
-                    ToolResultPayload::Ok {
-                        content: serde_json::json!({
-                            "content_base64": STANDARD.encode(&bytes),
-                            "byte_len": bytes.len(),
-                        }),
-                    }
-                },
-                Err(e) => ToolResultPayload::Error {
-                    message: format!("read_file: {e}"),
-                },
-            }
-        } else {
-            match tokio::fs::read_to_string(&canonical).await {
-                Ok(s) => ToolResultPayload::Ok {
-                    content: serde_json::json!({
-                        "content_text": s,
-                    }),
-                },
-                Err(e) => ToolResultPayload::Error {
-                    message: format!("read_file: {e}"),
-                },
-            }
-        }
+        },
+    };
+    if !canonical.starts_with(worktree_root) {
+        return ToolResultPayload::Error {
+            message: format!(
+                "read_file: path {} escapes worktree {}",
+                canonical.display(),
+                worktree_root.display()
+            ),
+        };
     }
-
-    async fn write_file(&self, call: &ToolCall) -> ToolResultPayload {
-        let Some(args) = call.arguments.as_object() else {
-            return ToolResultPayload::Error {
-                message: "write_file: arguments must be an object".into(),
-            };
-        };
-        let Some(rel_path) = args.get("path").and_then(|v| v.as_str()) else {
-            return ToolResultPayload::Error {
-                message: "write_file: missing 'path' arg".into(),
-            };
-        };
-        let Some(content) = args.get("content").and_then(|v| v.as_str()) else {
-            return ToolResultPayload::Error {
-                message: "write_file: missing 'content' arg".into(),
-            };
-        };
-        let mode = args
-            .get("mode")
-            .and_then(|v| v.as_str())
-            .unwrap_or("overwrite");
-        let abs = self.worktree_root.join(rel_path);
-        // For write paths, the parent must canonicalize within worktree;
-        // the leaf may not yet exist.
-        let Some(parent) = abs.parent() else {
-            return ToolResultPayload::Error {
-                message: format!("write_file: invalid path {}", abs.display()),
-            };
-        };
-        let canonical_parent = match std::fs::canonicalize(parent) {
-            Ok(p) => p,
-            Err(e) => {
-                return ToolResultPayload::Error {
-                    message: format!(
-                        "write_file: cannot canonicalize parent {}: {e}",
-                        parent.display()
-                    ),
-                };
+    if binary {
+        match tokio::fs::read(&canonical).await {
+            Ok(bytes) => {
+                use base64::{Engine, engine::general_purpose::STANDARD};
+                ToolResultPayload::Ok {
+                    content: serde_json::json!({
+                        "content_base64": STANDARD.encode(&bytes),
+                        "byte_len": bytes.len(),
+                    }),
+                }
             },
-        };
-        if !canonical_parent.starts_with(&self.worktree_root) {
-            return ToolResultPayload::Error {
-                message: format!(
-                    "write_file: parent {} escapes worktree {}",
-                    canonical_parent.display(),
-                    self.worktree_root.display()
-                ),
-            };
+            Err(e) => ToolResultPayload::Error {
+                message: format!("read_file: {e}"),
+            },
         }
-        let leaf = abs.file_name().unwrap_or_default();
-        let final_path = canonical_parent.join(leaf);
-        let result = match mode {
-            "create" => {
-                if final_path.exists() {
-                    return ToolResultPayload::Error {
-                        message: format!(
-                            "write_file create: {} already exists",
-                            final_path.display()
-                        ),
-                    };
-                }
-                tokio::fs::write(&final_path, content).await
-            },
-            "overwrite" => tokio::fs::write(&final_path, content).await,
-            "append" => {
-                use tokio::io::AsyncWriteExt;
-                match tokio::fs::OpenOptions::new()
-                    .append(true)
-                    .create(true)
-                    .open(&final_path)
-                    .await
-                {
-                    Ok(mut f) => f.write_all(content.as_bytes()).await,
-                    Err(e) => Err(e),
-                }
-            },
-            other => {
-                return ToolResultPayload::Error {
-                    message: format!(
-                        "write_file: unknown mode '{other}', expected create/overwrite/append"
-                    ),
-                };
-            },
-        };
-        match result {
-            Ok(()) => ToolResultPayload::Ok {
+    } else {
+        match tokio::fs::read_to_string(&canonical).await {
+            Ok(s) => ToolResultPayload::Ok {
                 content: serde_json::json!({
-                    "bytes_written": content.len(),
+                    "content_text": s,
                 }),
             },
             Err(e) => ToolResultPayload::Error {
-                message: format!("write_file: {e}"),
+                message: format!("read_file: {e}"),
             },
         }
     }
+}
 
-    async fn shell_exec(&self, call: &ToolCall) -> ToolResultPayload {
-        let Some(args) = call.arguments.as_object() else {
-            return ToolResultPayload::Error {
-                message: "shell_exec: arguments must be an object".into(),
-            };
+async fn write_file(worktree_root: &Path, call: &ToolCall) -> ToolResultPayload {
+    let worktree_root = canonical_root(worktree_root);
+    let worktree_root = worktree_root.as_path();
+    let Some(args) = call.arguments.as_object() else {
+        return ToolResultPayload::Error {
+            message: "write_file: arguments must be an object".into(),
         };
-        let Some(command) = args.get("command").and_then(|v| v.as_str()) else {
-            return ToolResultPayload::Error {
-                message: "shell_exec: missing 'command' arg".into(),
-            };
+    };
+    let Some(rel_path) = args.get("path").and_then(|v| v.as_str()) else {
+        return ToolResultPayload::Error {
+            message: "write_file: missing 'path' arg".into(),
         };
-        let cwd = if let Some(rel) = args.get("cwd_relative").and_then(|v| v.as_str()) {
-            let joined = self.worktree_root.join(rel);
-            let canonical = match std::fs::canonicalize(&joined) {
-                Ok(p) => p,
-                Err(e) => {
-                    return ToolResultPayload::Error {
-                        message: format!(
-                            "shell_exec: cannot canonicalize cwd_relative {}: {e}",
-                            joined.display()
-                        ),
-                    };
-                },
+    };
+    let Some(content) = args.get("content").and_then(|v| v.as_str()) else {
+        return ToolResultPayload::Error {
+            message: "write_file: missing 'content' arg".into(),
+        };
+    };
+    let mode = args
+        .get("mode")
+        .and_then(|v| v.as_str())
+        .unwrap_or("overwrite");
+    let abs = worktree_root.join(rel_path);
+    // For write paths, the parent must canonicalize within worktree;
+    // the leaf may not yet exist.
+    let Some(parent) = abs.parent() else {
+        return ToolResultPayload::Error {
+            message: format!("write_file: invalid path {}", abs.display()),
+        };
+    };
+    let canonical_parent = match std::fs::canonicalize(parent) {
+        Ok(p) => p,
+        Err(e) => {
+            return ToolResultPayload::Error {
+                message: format!(
+                    "write_file: cannot canonicalize parent {}: {e}",
+                    parent.display()
+                ),
             };
-            if !canonical.starts_with(&self.worktree_root) {
+        },
+    };
+    if !canonical_parent.starts_with(worktree_root) {
+        return ToolResultPayload::Error {
+            message: format!(
+                "write_file: parent {} escapes worktree {}",
+                canonical_parent.display(),
+                worktree_root.display()
+            ),
+        };
+    }
+    let leaf = abs.file_name().unwrap_or_default();
+    let final_path = canonical_parent.join(leaf);
+    let result = match mode {
+        "create" => {
+            if final_path.exists() {
                 return ToolResultPayload::Error {
-                    message: format!(
-                        "shell_exec: cwd_relative {} escapes worktree {}",
-                        canonical.display(),
-                        self.worktree_root.display()
-                    ),
+                    message: format!("write_file create: {} already exists", final_path.display()),
                 };
             }
-            canonical
-        } else {
-            self.worktree_root.clone()
-        };
-        let timeout_secs = args
-            .get("timeout_seconds")
-            .and_then(serde_json::Value::as_u64)
-            .unwrap_or(300);
+            tokio::fs::write(&final_path, content).await
+        },
+        "overwrite" => tokio::fs::write(&final_path, content).await,
+        "append" => {
+            use tokio::io::AsyncWriteExt;
+            match tokio::fs::OpenOptions::new()
+                .append(true)
+                .create(true)
+                .open(&final_path)
+                .await
+            {
+                Ok(mut f) => f.write_all(content.as_bytes()).await,
+                Err(e) => Err(e),
+            }
+        },
+        other => {
+            return ToolResultPayload::Error {
+                message: format!(
+                    "write_file: unknown mode '{other}', expected create/overwrite/append"
+                ),
+            };
+        },
+    };
+    match result {
+        Ok(()) => ToolResultPayload::Ok {
+            content: serde_json::json!({
+                "bytes_written": content.len(),
+            }),
+        },
+        Err(e) => ToolResultPayload::Error {
+            message: format!("write_file: {e}"),
+        },
+    }
+}
 
-        let mut cmd = if cfg!(windows) {
-            let mut c = tokio::process::Command::new("cmd");
-            c.args(["/C", command]);
-            c
-        } else {
-            let mut c = tokio::process::Command::new("sh");
-            c.args(["-c", command]);
-            c
+async fn shell_exec(worktree_root: &Path, call: &ToolCall) -> ToolResultPayload {
+    let worktree_root = canonical_root(worktree_root);
+    let worktree_root = worktree_root.as_path();
+    let Some(args) = call.arguments.as_object() else {
+        return ToolResultPayload::Error {
+            message: "shell_exec: arguments must be an object".into(),
         };
-        cmd.current_dir(&cwd)
-            .stdout(std::process::Stdio::piped())
-            .stderr(std::process::Stdio::piped());
-
-        let child = match cmd.spawn() {
-            Ok(c) => c,
+    };
+    let Some(command) = args.get("command").and_then(|v| v.as_str()) else {
+        return ToolResultPayload::Error {
+            message: "shell_exec: missing 'command' arg".into(),
+        };
+    };
+    let cwd = if let Some(rel) = args.get("cwd_relative").and_then(|v| v.as_str()) {
+        let joined = worktree_root.join(rel);
+        let canonical = match std::fs::canonicalize(&joined) {
+            Ok(p) => p,
             Err(e) => {
                 return ToolResultPayload::Error {
-                    message: format!("shell_exec: spawn failed: {e}"),
+                    message: format!(
+                        "shell_exec: cannot canonicalize cwd_relative {}: {e}",
+                        joined.display()
+                    ),
                 };
             },
         };
-
-        let timeout = std::time::Duration::from_secs(timeout_secs);
-        let output_fut = child.wait_with_output();
-        let output = match tokio::time::timeout(timeout, output_fut).await {
-            Ok(Ok(o)) => o,
-            Ok(Err(e)) => {
-                return ToolResultPayload::Error {
-                    message: format!("shell_exec: wait failed: {e}"),
-                };
-            },
-            Err(_) => {
-                return ToolResultPayload::Error {
-                    message: format!("shell_exec: timeout after {timeout_secs}s"),
-                };
-            },
-        };
-
-        let stdout = truncate_with_marker(
-            String::from_utf8_lossy(&output.stdout).into_owned(),
-            TAIL_CAP,
-        );
-        let stderr = truncate_with_marker(
-            String::from_utf8_lossy(&output.stderr).into_owned(),
-            TAIL_CAP,
-        );
-        let exit_code = output.status.code().unwrap_or(-1);
-
-        ToolResultPayload::Ok {
-            content: serde_json::json!({
-                "stdout": stdout,
-                "stderr": stderr,
-                "exit_code": exit_code,
-            }),
+        if !canonical.starts_with(worktree_root) {
+            return ToolResultPayload::Error {
+                message: format!(
+                    "shell_exec: cwd_relative {} escapes worktree {}",
+                    canonical.display(),
+                    worktree_root.display()
+                ),
+            };
         }
+        canonical
+    } else {
+        worktree_root.to_path_buf()
+    };
+    let timeout_secs = args
+        .get("timeout_seconds")
+        .and_then(serde_json::Value::as_u64)
+        .unwrap_or(300);
+
+    let mut cmd = if cfg!(windows) {
+        let mut c = tokio::process::Command::new("cmd");
+        c.args(["/C", command]);
+        c
+    } else {
+        let mut c = tokio::process::Command::new("sh");
+        c.args(["-c", command]);
+        c
+    };
+    cmd.current_dir(&cwd)
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped());
+
+    let child = match cmd.spawn() {
+        Ok(c) => c,
+        Err(e) => {
+            return ToolResultPayload::Error {
+                message: format!("shell_exec: spawn failed: {e}"),
+            };
+        },
+    };
+
+    let timeout = std::time::Duration::from_secs(timeout_secs);
+    let output_fut = child.wait_with_output();
+    let output = match tokio::time::timeout(timeout, output_fut).await {
+        Ok(Ok(o)) => o,
+        Ok(Err(e)) => {
+            return ToolResultPayload::Error {
+                message: format!("shell_exec: wait failed: {e}"),
+            };
+        },
+        Err(_) => {
+            return ToolResultPayload::Error {
+                message: format!("shell_exec: timeout after {timeout_secs}s"),
+            };
+        },
+    };
+
+    let stdout = truncate_with_marker(
+        String::from_utf8_lossy(&output.stdout).into_owned(),
+        TAIL_CAP,
+    );
+    let stderr = truncate_with_marker(
+        String::from_utf8_lossy(&output.stderr).into_owned(),
+        TAIL_CAP,
+    );
+    let exit_code = output.status.code().unwrap_or(-1);
+
+    ToolResultPayload::Ok {
+        content: serde_json::json!({
+            "stdout": stdout,
+            "stderr": stderr,
+            "exit_code": exit_code,
+        }),
     }
 }
 
 #[async_trait]
 impl ToolDispatcher for WorktreeToolDispatcher {
-    async fn dispatch(&self, _ctx: &ToolDispatchContext<'_>, call: &ToolCall) -> ToolResultPayload {
+    async fn dispatch(&self, ctx: &ToolDispatchContext<'_>, call: &ToolCall) -> ToolResultPayload {
         match call.tool.as_str() {
-            "read_file" => self.read_file(call).await,
-            "write_file" => self.write_file(call).await,
-            "shell_exec" => self.shell_exec(call).await,
+            "read_file" => read_file(ctx.worktree_root, call).await,
+            "write_file" => write_file(ctx.worktree_root, call).await,
+            "shell_exec" => shell_exec(ctx.worktree_root, call).await,
             other => ToolResultPayload::Unsupported {
                 message: format!(
                     "WorktreeToolDispatcher: tool '{other}' not implemented (M5 supports read_file/write_file/shell_exec)"


### PR DESCRIPTION
## Summary

PR 3 of 6 for M7 milestone. Daemon end-to-end: server accept loop, signal handlers, real `surge-daemon` binary, `surge daemon` CLI subtree, and `--daemon` flag retrofit on `surge engine ...`. After this merges, the canonical M7 daemon UX works:

```bash
surge daemon start                     # starts the daemon
surge engine run flow.toml --daemon    # routes through daemon
surge daemon stop                      # graceful shutdown
```

**Predecessor:** [PR #21](https://github.com/vanyastaff/surge/pull/21) (PR 2 — pidfile, AdmissionController, BroadcastRegistry, IPC client) — merged.
**Successor:** PR 4 — surge-mcp rmcp wrapper + McpServerConnection.

## What lands

### `surge-daemon::server` (P6.1)
Accept-and-dispatch IPC loop. `run(cfg, facade, shutdown)` binds a local socket via `interprocess::local_socket::ListenerOptions`, accepts connections, spawns a per-connection task that reads `DaemonRequest` frames and dispatches to `LocalEngineFacade`. `Subscribe` requests spawn per-run forwarder tasks pumping `EngineRunEvent` → broadcast → wire as `DaemonEvent::PerRun`. `spawn_forward_task` notifies admission + publishes `RunFinished` global event on terminal. Wildcard arm on the request match returns `Error { code: BadRequest }` (was returning `None` initially — fixed inline).

### `surge-daemon::lifecycle` (P6.2)
Signal handlers: `install_signal_handlers(token)` cancels the token on SIGTERM/SIGINT (Unix) or Ctrl+C (Windows). `drain(token, grace)` helper for the daemon's main loop.

### `surge-daemon` binary (P6.3)
`main.rs` parses `--max-active`, `--shutdown-grace`, `--detached` via clap. Acquires PID lock pre-runtime; builds Storage + AcpBridge + WorktreeToolDispatcher + MultiplexingNotifier + Engine + LocalEngineFacade; spawns `run_server`; waits for shutdown then sleeps grace before aborting; releases lock + removes socket on exit.

### Cross-platform socket name resolution (P6.3 follow-up)
New shared helper `surge_orchestrator::engine::ipc::local_socket_name_from_path` translates filesystem paths to `interprocess::local_socket::Name` correctly on each platform: `GenericFilePath` on Unix, `GenericNamespaced` (basename → `\.\pipe\<name>`) on Windows. Fixes Windows daemon-bind that was failing with "not a named pipe path". Both server and client use the same helper.

### `surge daemon` CLI subtree (P6.4)
Four subcommands: `start --detached --max-active`, `stop --force`, `status`, `restart`. `start` auto-detaches via `nix::unistd::setsid()` (Unix) or `DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP` (Windows). Polls socket readiness up to 5s. `stop` sends SIGTERM/SIGKILL via `nix::sys::signal::kill` (Unix) or `taskkill /pid /F` (Windows). `status` pings live daemon via `DaemonEngineFacade::connect`.

### `--daemon` flag retrofit (P6.5)
Every `surge engine` subcommand except `logs` gains `--daemon`. With it, CLI auto-spawns the daemon (if not running) via `ensure_daemon_running()` and routes through `DaemonEngineFacade`. Without it, M6 in-process behaviour preserved verbatim. `resume` and `stop` now require `--daemon` (cross-process only); without the flag they return clear actionable errors. `ls --daemon` lists daemon-hosted runs; without it falls back to on-disk listing. `watch --daemon` falls back to disk-tail (full streaming subscribe is M7+ polish).

## Stats

- **8 commits** on top of PR 2 main:
  - `d742fac` P6.1 server
  - `070233e` P6.1 wildcard fix (review feedback)
  - `76bc91d` P6.2 lifecycle
  - `b13485c` P6.3 binary main.rs
  - `00cd6e9` P6.3 cross-platform socket name fix
  - `08c3376` P6.4 CLI subtree
  - `4ba5746` P6.5 --daemon retrofit
- **910 workspace lib tests pass** (no regressions; this PR adds no new unit tests — daemon end-to-end is covered by integration tests in PR 6)

## Acceptance criteria progress

§15 of spec — items 1, 2, 3, 4, 5, 6 (daemon start/stop on all 3 OSes, runs survive CLI exit, ls/stop cross-process, max_active concurrent runs, EngineFacade has 2 impls) are wired by this PR. Manual smoke tests on Linux/Windows recommended after merge — automated end-to-end coverage lands in PR 6.

## Test plan

- [x] `cargo build --workspace` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all --check` clean
- [x] `cargo test --workspace --lib` — 910 tests pass
- [x] Each task individually went through implementer → spec compliance review → code quality review (with 2 follow-up commits for review findings)
- [x] `surge daemon --help` enumerates 4 subcommands
- [x] `surge engine resume <id>` (no --daemon) returns clear error
- [x] `surge engine ls` (no --daemon) preserves M6 disk-listing

## Out of scope (later PRs)

- PR 4: surge-mcp rmcp wrapper + McpServerConnection
- PR 5: McpRegistry + RoutingToolDispatcher + sandbox-aware tool exposure
- PR 6: integration tests + READMEs + ROADMAP update
- PR 6 polish: AdmissionController drain task (queued runs auto-admit on completion), full Subscribe-based `watch --daemon` streaming

🤖 Generated with [Claude Code](https://claude.com/claude-code)