### PR TITLE
examples: minimal flow.toml fixtures for hands-on M7 demo

### DIFF
--- a/examples/flow_minimal_agent.toml
+++ b/examples/flow_minimal_agent.toml
@@ -1,0 +1,70 @@
+# Two-node flow.toml — single Agent stage → Terminal.
+#
+# When run via `surge engine run examples/flow_minimal_agent.toml`,
+# the run starts, opens an ACP session against the configured agent
+# binary (Claude Code by default — needs `claude-code` in PATH), and
+# routes to Terminal::Success on the agent's `done` outcome.
+#
+# Without an agent installed, the agent stage will fail at session
+# open and you'll see a RunFailed event with an ACP error. That still
+# demonstrates the full pipeline: IPC (when --daemon), persistence,
+# event log, engine routing — only the ACP subprocess is missing.
+
+schema_version = 1
+start = "impl_1"
+
+[metadata]
+name = "flow_minimal_agent"
+created_at = "2026-05-05T00:00:00Z"
+
+[nodes.impl_1]
+id = "impl_1"
+
+[nodes.impl_1.position]
+x = 0.0
+y = 0.0
+
+[[nodes.impl_1.declared_outcomes]]
+id = "done"
+description = "Implementation complete"
+edge_kind_hint = "forward"
+is_terminal = false
+
+[nodes.impl_1.config]
+node_kind = "agent"
+profile = "implementer@1.0"
+bindings = []
+hooks = []
+
+[nodes.impl_1.config.limits]
+timeout_seconds = 900
+max_retries = 3
+max_tokens = 200000
+
+[nodes.impl_1.config.custom_fields]
+
+[nodes.end]
+id = "end"
+declared_outcomes = []
+
+[nodes.end.position]
+x = 200.0
+y = 0.0
+
+[nodes.end.config]
+node_kind = "terminal"
+
+[nodes.end.config.kind]
+type = "success"
+
+[[edges]]
+id = "e_impl_to_end"
+to = "end"
+kind = "forward"
+
+[edges.from]
+node = "impl_1"
+outcome = "done"
+
+[edges.policy]
+on_max_exceeded = "escalate"

--- a/examples/flow_terminal_only.toml
+++ b/examples/flow_terminal_only.toml
@@ -1,0 +1,29 @@
+# Smallest possible flow.toml — single Terminal node.
+#
+# When run via `surge engine run examples/flow_terminal_only.toml`,
+# the run starts, immediately hits the Terminal node, emits
+# RunCompleted, and exits cleanly — no agent / no MCP / no human
+# input required. The fastest possible demo of the pipeline +
+# persistence + IPC.
+
+schema_version = 1
+start = "end"
+edges = []
+
+[metadata]
+name = "flow_terminal_only"
+created_at = "2026-05-05T00:00:00Z"
+
+[nodes.end]
+id = "end"
+declared_outcomes = []
+
+[nodes.end.position]
+x = 0.0
+y = 0.0
+
+[nodes.end.config]
+node_kind = "terminal"
+
+[nodes.end.config.kind]
+type = "success"


### PR DESCRIPTION
## Summary

Two minimal flow.toml example fixtures so users can run the M7 daemon + engine pipeline hands-on without writing graph TOML from scratch.

- **`examples/flow_terminal_only.toml`** — single Terminal node. Runs end-to-end without any agent / MCP / human input. Fastest possible smoke. Verified locally:
  ```
  Terminal: Completed { terminal: NodeKey('end') }
  ```

- **`examples/flow_minimal_agent.toml`** — Agent → Terminal::Success. Exercises the full pipeline including ACP session-open. Without an agent in PATH, the agent stage fails with a clear ACP error (which still demonstrates IPC + persistence + engine routing work — only the ACP subprocess is missing).

## Test plan

- [x] `cargo build --workspace` clean
- [x] `cargo test --workspace --lib` no regressions (these are pure data files; no code changes)
- [x] `surge engine run examples/flow_terminal_only.toml` completes successfully (run persisted to `~/.surge/runs/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)