### PR TITLE
M7 polish #2: AdmissionController queue drain

### DIFF
--- a/crates/surge-daemon/Cargo.toml
+++ b/crates/surge-daemon/Cargo.toml
@@ -41,3 +41,4 @@ nix.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true
+chrono.workspace = true

--- a/crates/surge-daemon/src/server.rs
+++ b/crates/surge-daemon/src/server.rs
@@ -242,15 +242,44 @@ async fn dispatch(
             worktree_path,
             run_config,
         } => {
+            // Insert into `pending_starts` BEFORE `try_admit`. If we did
+            // it after, an unrelated active run could complete in the
+            // gap, wake the drain task, which would `pop_queued` our
+            // run_id and find no `PendingStartRun` entry — silently
+            // dropping the request. By stashing first, the drain task
+            // sees a consistent view: any run_id it pops is guaranteed
+            // to have its parameters already recorded here. The
+            // `Admitted` arm below removes the entry it just inserted
+            // (the run is in `active`, not `queue`, so the drain task
+            // can never observe it).
+            pending_starts.lock().await.insert(
+                run_id,
+                PendingStartRun {
+                    graph,
+                    worktree_path,
+                    run_config,
+                    request_id,
+                },
+            );
             let decision = admission.try_admit(run_id).await;
             match decision {
                 AdmissionDecision::Admitted => {
+                    let pending = pending_starts
+                        .lock()
+                        .await
+                        .remove(&run_id)
+                        .expect("just inserted; only the drain task removes other entries");
                     broadcast.publish_global(GlobalDaemonEvent::RunAccepted { run_id });
                     let publisher = broadcast.register(run_id).await;
                     let admission_for_completion = admission.clone();
                     let broadcast_for_completion = broadcast.clone();
                     match facade
-                        .start_run(run_id, *graph, worktree_path, run_config)
+                        .start_run(
+                            run_id,
+                            *pending.graph,
+                            pending.worktree_path,
+                            pending.run_config,
+                        )
                         .await
                     {
                         Ok(handle) => {
@@ -275,26 +304,21 @@ async fn dispatch(
                     }
                 },
                 AdmissionDecision::Queued { position } => {
-                    // Stash the StartRun parameters; the drain-queue task in
-                    // `run` will pick them up via `pop_queued` once a slot
-                    // frees and replay the same Admitted-arm logic
-                    // (broadcast.register, facade.start_run, spawn_forward_task).
+                    // `pending_starts` is already populated above; the
+                    // drain task in `run` will pick it up via
+                    // `pop_queued` once a slot frees, then replay the
+                    // same admitted-arm logic (broadcast.register,
+                    // facade.start_run, spawn_forward_task).
                     //
-                    // Known limitation: the original IPC connection that
-                    // received StartRunQueued is NOT auto-resubscribed to the
-                    // eventually-admitted run's events. Clients that want to
-                    // observe the admitted run should re-issue `Subscribe`
-                    // (or run `surge engine watch <run_id> --daemon`) once
-                    // they see `GlobalDaemonEvent::RunAccepted` for the id.
-                    pending_starts.lock().await.insert(
-                        run_id,
-                        PendingStartRun {
-                            graph,
-                            worktree_path,
-                            run_config,
-                            request_id,
-                        },
-                    );
+                    // Known limitation: the original IPC connection
+                    // that received `StartRunQueued` is NOT
+                    // auto-resubscribed to the eventually-admitted
+                    // run's events. Even re-issuing `Subscribe` after
+                    // observing `GlobalDaemonEvent::RunAccepted` is
+                    // racy today because the existing dispatch
+                    // publishes `RunAccepted` before
+                    // `BroadcastRegistry::register`; that ordering
+                    // race is out-of-scope for this PR.
                     Some(DaemonResponse::StartRunQueued {
                         request_id,
                         run_id,

--- a/crates/surge-daemon/src/server.rs
+++ b/crates/surge-daemon/src/server.rs
@@ -13,15 +13,38 @@ use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::sync::Arc;
 use surge_core::id::RunId;
+use surge_orchestrator::engine::EngineRunConfig;
 use surge_orchestrator::engine::facade::EngineFacade;
 use surge_orchestrator::engine::handle::EngineRunEvent;
 use surge_orchestrator::engine::ipc::{
-    DaemonEvent, DaemonRequest, DaemonResponse, ErrorCode, GlobalDaemonEvent, read_request_frame,
-    write_frame,
+    DaemonEvent, DaemonRequest, DaemonResponse, ErrorCode, GlobalDaemonEvent, RequestId,
+    read_request_frame, write_frame,
 };
 use tokio::io::{AsyncWriteExt, BufReader};
 use tokio::sync::Mutex;
 use tokio_util::sync::CancellationToken;
+
+/// Stashed `StartRun` parameters held by the daemon while admission has
+/// queued the run. The original IPC connection's writer is intentionally
+/// NOT kept — by the time the drain task admits this run the connection
+/// may already be gone, and clients that care about events for the
+/// eventually-admitted run should re-subscribe via `surge engine watch
+/// <run_id> --daemon`.
+struct PendingStartRun {
+    graph: Box<surge_core::graph::Graph>,
+    worktree_path: PathBuf,
+    run_config: EngineRunConfig,
+    /// Original `request_id` from the queued `StartRun`. Diagnostics only;
+    /// the `StartRunQueued` reply has already been written and no further
+    /// response is sent on that request.
+    #[allow(dead_code)]
+    request_id: RequestId,
+}
+
+/// Map from queued `RunId` → its stashed `StartRun` params. Populated by
+/// `dispatch::StartRun` when admission queues; drained by the
+/// drain-queue task in [`run`].
+type PendingStarts = Arc<Mutex<HashMap<RunId, PendingStartRun>>>;
 
 /// Top-level daemon-server config.
 pub struct ServerConfig {
@@ -42,6 +65,7 @@ pub async fn run(
 
     let admission = Arc::new(AdmissionController::new(cfg.max_active));
     let broadcast = Arc::new(BroadcastRegistry::new());
+    let pending_starts: PendingStarts = Arc::new(Mutex::new(HashMap::new()));
 
     // F2: Unlink any stale socket file from a previous unclean exit.
     // On Windows, the named pipe doesn't live on the filesystem so this is a no-op.
@@ -61,6 +85,19 @@ pub async fn run(
 
     tracing::info!(socket = %cfg.socket_path.display(), "daemon listening");
 
+    // Drain task: when an active run completes (or any other admission
+    // state change happens) and there is a queued run, pop it from the
+    // FIFO and trigger the same Admitted-arm logic that
+    // `dispatch::StartRun` runs (broadcast.register, facade.start_run,
+    // spawn_forward_task, RunAccepted publication).
+    spawn_drain_task(
+        admission.clone(),
+        broadcast.clone(),
+        facade.clone(),
+        pending_starts.clone(),
+        shutdown.clone(),
+    );
+
     loop {
         tokio::select! {
             () = shutdown.cancelled() => {
@@ -73,6 +110,7 @@ pub async fn run(
                         let facade = facade.clone();
                         let admission = admission.clone();
                         let broadcast = broadcast.clone();
+                        let pending_starts = pending_starts.clone();
                         let shutdown_for_conn = shutdown.clone();
                         tokio::spawn(async move {
                             if let Err(e) = handle_connection(
@@ -80,6 +118,7 @@ pub async fn run(
                                 facade,
                                 admission,
                                 broadcast,
+                                pending_starts,
                                 shutdown_for_conn,
                             )
                             .await
@@ -113,6 +152,7 @@ async fn handle_connection(
     facade: Arc<dyn EngineFacade>,
     admission: Arc<AdmissionController>,
     broadcast: Arc<BroadcastRegistry>,
+    pending_starts: PendingStarts,
     shutdown: CancellationToken,
 ) -> Result<(), DaemonError> {
     let (read_half, write_half) = stream.split();
@@ -144,6 +184,7 @@ async fn handle_connection(
                             &*facade,
                             &admission,
                             &broadcast,
+                            &pending_starts,
                             &state,
                             &writer,
                             &shutdown,
@@ -177,11 +218,13 @@ async fn handle_connection(
 }
 
 #[allow(clippy::too_many_lines)]
+#[allow(clippy::too_many_arguments)]
 async fn dispatch(
     req: DaemonRequest,
     facade: &dyn EngineFacade,
     admission: &Arc<AdmissionController>,
     broadcast: &Arc<BroadcastRegistry>,
+    pending_starts: &PendingStarts,
     state: &Arc<Mutex<ConnState>>,
     writer: &Arc<Mutex<interprocess::local_socket::tokio::SendHalf>>,
     shutdown: &CancellationToken,
@@ -232,13 +275,26 @@ async fn dispatch(
                     }
                 },
                 AdmissionDecision::Queued { position } => {
-                    // TODO M7: drain-queue task lands with Phase 9 or 10 polish.
-                    // Until that task exists, a queued run sits in the FIFO queue
-                    // and will only be admitted when an active run finishes AND
-                    // pop_queued() is called externally (e.g., a Phase 9 drain loop).
-                    // The client receives StartRunQueued and must poll or rely on
-                    // GlobalDaemonEvent::RunAccepted to know when its run eventually
-                    // starts.
+                    // Stash the StartRun parameters; the drain-queue task in
+                    // `run` will pick them up via `pop_queued` once a slot
+                    // frees and replay the same Admitted-arm logic
+                    // (broadcast.register, facade.start_run, spawn_forward_task).
+                    //
+                    // Known limitation: the original IPC connection that
+                    // received StartRunQueued is NOT auto-resubscribed to the
+                    // eventually-admitted run's events. Clients that want to
+                    // observe the admitted run should re-issue `Subscribe`
+                    // (or run `surge engine watch <run_id> --daemon`) once
+                    // they see `GlobalDaemonEvent::RunAccepted` for the id.
+                    pending_starts.lock().await.insert(
+                        run_id,
+                        PendingStartRun {
+                            graph,
+                            worktree_path,
+                            run_config,
+                            request_id,
+                        },
+                    );
                     Some(DaemonResponse::StartRunQueued {
                         request_id,
                         run_id,
@@ -377,6 +433,101 @@ async fn dispatch(
                 message: "unsupported request method".into(),
             })
         },
+    }
+}
+
+/// Spawn the drain-queue task. Wakes on every admission state change
+/// (run completion, etc.) and pops queued runs while a slot is free,
+/// triggering the same admitted-arm logic that a fresh `StartRun`
+/// would. Exits cleanly on `shutdown.cancelled()`.
+fn spawn_drain_task(
+    admission: Arc<AdmissionController>,
+    broadcast: Arc<BroadcastRegistry>,
+    facade: Arc<dyn EngineFacade>,
+    pending_starts: PendingStarts,
+    shutdown: CancellationToken,
+) {
+    tokio::spawn(async move {
+        loop {
+            tokio::select! {
+                () = shutdown.cancelled() => {
+                    tracing::debug!("drain-queue task exiting (shutdown)");
+                    break;
+                }
+                () = admission.wait_changed() => {
+                    drain_one_pass(
+                        &admission,
+                        &broadcast,
+                        facade.as_ref(),
+                        &pending_starts,
+                    )
+                    .await;
+                }
+            }
+        }
+    });
+}
+
+/// Pop every queued run we currently have a slot for and admit it.
+/// Pulled into a helper for readability. Each iteration mirrors the
+/// `AdmissionDecision::Admitted` arm in `dispatch`.
+async fn drain_one_pass(
+    admission: &Arc<AdmissionController>,
+    broadcast: &Arc<BroadcastRegistry>,
+    facade: &dyn EngineFacade,
+    pending_starts: &PendingStarts,
+) {
+    while let Some(run_id) = admission.pop_queued().await {
+        let Some(pending) = pending_starts.lock().await.remove(&run_id) else {
+            // pop_queued returned an id we have no PendingStartRun for.
+            // Shouldn't happen unless queue/map fell out of sync, but be
+            // defensive: free the slot we just claimed via pop_queued
+            // (otherwise the active set leaks) and continue draining.
+            tracing::warn!(
+                run_id = %run_id,
+                "drain-queue: pop_queued returned id with no PendingStartRun; releasing slot"
+            );
+            admission.notify_completed(run_id).await;
+            continue;
+        };
+        broadcast.publish_global(GlobalDaemonEvent::RunAccepted { run_id });
+        let publisher = broadcast.register(run_id).await;
+        let admission_for_completion = admission.clone();
+        let broadcast_for_completion = broadcast.clone();
+        match facade
+            .start_run(
+                run_id,
+                *pending.graph,
+                pending.worktree_path,
+                pending.run_config,
+            )
+            .await
+        {
+            Ok(handle) => {
+                spawn_forward_task(
+                    run_id,
+                    handle,
+                    publisher,
+                    admission_for_completion,
+                    broadcast_for_completion,
+                );
+            },
+            Err(e) => {
+                tracing::error!(
+                    run_id = %run_id,
+                    err = %e,
+                    "drain-queue: queued run failed to start; deregistering"
+                );
+                broadcast.deregister(run_id).await;
+                admission.notify_completed(run_id).await;
+                broadcast.publish_global(GlobalDaemonEvent::RunFinished {
+                    run_id,
+                    outcome: surge_orchestrator::engine::handle::RunOutcome::Aborted {
+                        reason: format!("queued start failed: {e}"),
+                    },
+                });
+            },
+        }
     }
 }
 

--- a/crates/surge-daemon/tests/daemon_queue_drain.rs
+++ b/crates/surge-daemon/tests/daemon_queue_drain.rs
@@ -1,0 +1,285 @@
+//! Integration test for the queue-drain task.
+//!
+//! Setup: `run_server` with `max_active=1` and a stub facade whose
+//! `start_run` returns a quickly-terminating `RunHandle`.
+//!
+//! Procedure:
+//! 1. Send `StartRun` for run 1 over raw IPC → expect `StartRunOk`.
+//! 2. Send `StartRun` for run 2 over raw IPC → expect `StartRunQueued`.
+//! 3. The handle the stub returned for run 1 emits `Terminal` and its
+//!    completion future resolves immediately, so `spawn_forward_task`
+//!    calls `admission.notify_completed`.
+//! 4. The drain task wakes on `wait_changed`, pops run 2, and calls
+//!    `facade.start_run` again.
+//! 5. Assert `stub.start_count == 2` within a short timeout.
+//!
+//! We use raw frame I/O (rather than `DaemonEngineFacade::start_run`)
+//! because the facade pipelines a `Subscribe` immediately after the
+//! StartRun reply, and that `Subscribe` fails for a queued run (the
+//! run is not yet registered with `BroadcastRegistry` until admission).
+//! That failure mode is documented as a known limitation of this PR;
+//! the drain-task production behaviour is what we want to exercise.
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
+
+use interprocess::local_socket::tokio::prelude::*;
+use surge_core::id::RunId;
+use surge_core::keys::NodeKey;
+use surge_daemon::{ServerConfig, run_server};
+use surge_orchestrator::engine::EngineRunConfig;
+use surge_orchestrator::engine::facade::EngineFacade;
+use surge_orchestrator::engine::handle::{EngineRunEvent, RunHandle, RunOutcome};
+use surge_orchestrator::engine::ipc::{
+    DaemonRequest, DaemonResponse, local_socket_name_from_path, read_response_frame, write_frame,
+};
+use tempfile::TempDir;
+use tokio::io::{AsyncWriteExt, BufReader};
+use tokio::sync::broadcast;
+use tokio_util::sync::CancellationToken;
+
+fn unique_socket_path(temp: &TempDir, prefix: &str) -> PathBuf {
+    let pid = std::process::id();
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    temp.path().join(format!("{prefix}_{pid}_{nanos}.sock"))
+}
+
+fn make_minimal_graph() -> surge_core::graph::Graph {
+    surge_core::graph::Graph {
+        schema_version: surge_core::graph::SCHEMA_VERSION,
+        metadata: surge_core::graph::GraphMetadata {
+            name: "queue-drain-test".into(),
+            description: None,
+            template_origin: None,
+            created_at: chrono::Utc::now(),
+            author: None,
+        },
+        start: NodeKey::try_from("placeholder").unwrap(),
+        nodes: BTreeMap::new(),
+        edges: Vec::new(),
+        subgraphs: BTreeMap::new(),
+    }
+}
+
+/// Stub `EngineFacade` whose `start_run` increments a counter and
+/// returns a `RunHandle`. The FIRST call's handle holds its events
+/// channel open until `release_first` fires — that lets the test
+/// queue a second `StartRun` while run 1 is still active. Subsequent
+/// calls return a handle that completes immediately.
+struct CountingStubFacade {
+    start_count: AtomicUsize,
+    release_first: Arc<tokio::sync::Notify>,
+}
+
+impl CountingStubFacade {
+    fn new() -> Self {
+        Self {
+            start_count: AtomicUsize::new(0),
+            release_first: Arc::new(tokio::sync::Notify::new()),
+        }
+    }
+
+    fn start_count(&self) -> usize {
+        self.start_count.load(Ordering::SeqCst)
+    }
+
+    fn release_first(&self) {
+        self.release_first.notify_one();
+    }
+}
+
+#[async_trait::async_trait]
+impl EngineFacade for CountingStubFacade {
+    async fn start_run(
+        &self,
+        run_id: RunId,
+        _graph: surge_core::graph::Graph,
+        _worktree_path: PathBuf,
+        _run_config: EngineRunConfig,
+    ) -> Result<RunHandle, surge_orchestrator::engine::EngineError> {
+        let prev = self.start_count.fetch_add(1, Ordering::SeqCst);
+        let is_first = prev == 0;
+
+        let (tx, rx) = broadcast::channel(8);
+        let release = self.release_first.clone();
+
+        if is_first {
+            // First run: hold events open until the test notifies
+            // `release_first`. Then emit Terminal and drop the sender,
+            // which lets `spawn_forward_task` finish and call
+            // `admission.notify_completed` — waking the drain task.
+            tokio::spawn(async move {
+                release.notified().await;
+                let _ = tx.send(EngineRunEvent::Terminal(RunOutcome::Completed {
+                    terminal: NodeKey::try_from("end").unwrap(),
+                }));
+                drop(tx);
+            });
+        } else {
+            // Subsequent runs: complete instantly.
+            let _ = tx.send(EngineRunEvent::Terminal(RunOutcome::Completed {
+                terminal: NodeKey::try_from("end").unwrap(),
+            }));
+            drop(tx);
+        }
+
+        let completion = tokio::spawn(async move {
+            RunOutcome::Completed {
+                terminal: NodeKey::try_from("end").unwrap(),
+            }
+        });
+        Ok(RunHandle {
+            run_id,
+            events: rx,
+            completion,
+        })
+    }
+
+    async fn resume_run(
+        &self,
+        _run_id: RunId,
+        _worktree_path: PathBuf,
+    ) -> Result<RunHandle, surge_orchestrator::engine::EngineError> {
+        Err(surge_orchestrator::engine::EngineError::Internal(
+            "stub: resume_run not used in this test".into(),
+        ))
+    }
+
+    async fn stop_run(
+        &self,
+        _run_id: RunId,
+        _reason: String,
+    ) -> Result<(), surge_orchestrator::engine::EngineError> {
+        Ok(())
+    }
+
+    async fn resolve_human_input(
+        &self,
+        _run_id: RunId,
+        _call_id: Option<String>,
+        _response: serde_json::Value,
+    ) -> Result<(), surge_orchestrator::engine::EngineError> {
+        Ok(())
+    }
+
+    async fn list_runs(
+        &self,
+    ) -> Result<
+        Vec<surge_orchestrator::engine::handle::RunSummary>,
+        surge_orchestrator::engine::EngineError,
+    > {
+        Ok(vec![])
+    }
+}
+
+#[tokio::test]
+async fn queued_run_admitted_after_completion() {
+    let temp = TempDir::new().unwrap();
+    let socket = unique_socket_path(&temp, "queue_drain");
+    let cfg = ServerConfig {
+        max_active: 1,
+        socket_path: socket.clone(),
+    };
+    let shutdown = CancellationToken::new();
+    let stub = Arc::new(CountingStubFacade::new());
+    let stub_for_facade: Arc<dyn EngineFacade> = stub.clone();
+
+    let server_handle = tokio::spawn({
+        let shutdown = shutdown.clone();
+        async move { run_server(cfg, stub_for_facade, shutdown).await }
+    });
+
+    // Wait for the listener to come up before connecting.
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    let name = local_socket_name_from_path(&socket).expect("socket name");
+    let stream = LocalSocketStream::connect(name)
+        .await
+        .expect("connect to daemon");
+    let (read_half, mut write_half) = stream.split();
+    let mut reader = BufReader::new(read_half);
+
+    // --- StartRun #1 ---
+    let run1 = RunId::new();
+    let req1 = DaemonRequest::StartRun {
+        request_id: 1,
+        run_id: run1,
+        graph: Box::new(make_minimal_graph()),
+        worktree_path: temp.path().to_path_buf(),
+        run_config: EngineRunConfig::default(),
+    };
+    write_frame(&mut write_half, &req1)
+        .await
+        .expect("write StartRun #1");
+    write_half.flush().await.expect("flush #1");
+    let resp1 = read_response_frame(&mut reader)
+        .await
+        .expect("read #1")
+        .expect("frame #1");
+    match resp1 {
+        DaemonResponse::StartRunOk { request_id, run_id } => {
+            assert_eq!(request_id, 1);
+            assert_eq!(run_id, run1);
+        },
+        other => panic!("expected StartRunOk for run1, got {other:?}"),
+    }
+
+    // --- StartRun #2 — admission cap reached, should queue ---
+    let run2 = RunId::new();
+    let req2 = DaemonRequest::StartRun {
+        request_id: 2,
+        run_id: run2,
+        graph: Box::new(make_minimal_graph()),
+        worktree_path: temp.path().to_path_buf(),
+        run_config: EngineRunConfig::default(),
+    };
+    write_frame(&mut write_half, &req2)
+        .await
+        .expect("write StartRun #2");
+    write_half.flush().await.expect("flush #2");
+    let resp2 = read_response_frame(&mut reader)
+        .await
+        .expect("read #2")
+        .expect("frame #2");
+    match resp2 {
+        DaemonResponse::StartRunQueued {
+            request_id,
+            run_id,
+            position,
+        } => {
+            assert_eq!(request_id, 2);
+            assert_eq!(run_id, run2);
+            assert_eq!(position, 0);
+        },
+        other => panic!("expected StartRunQueued for run2, got {other:?}"),
+    }
+
+    // Release run 1's terminal event. `spawn_forward_task` will call
+    // `admission.notify_completed`, the drain task wakes via
+    // `wait_changed`, and run 2 gets admitted via `facade.start_run`.
+    stub.release_first();
+
+    // The stub's run-1 handle terminates immediately, so
+    // `spawn_forward_task` calls `admission.notify_completed` very
+    // quickly. The drain task should then pop run 2 and call
+    // `facade.start_run` for it. Poll the counter with a generous
+    // timeout to avoid CI flakes.
+    let deadline = std::time::Instant::now() + Duration::from_secs(2);
+    while std::time::Instant::now() < deadline && stub.start_count() < 2 {
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    assert_eq!(
+        stub.start_count(),
+        2,
+        "drain task should have admitted the queued run within 2s"
+    );
+
+    shutdown.cancel();
+    let _ = tokio::time::timeout(Duration::from_secs(2), server_handle).await;
+}

--- a/crates/surge-daemon/tests/daemon_queue_drain.rs
+++ b/crates/surge-daemon/tests/daemon_queue_drain.rs
@@ -281,5 +281,9 @@ async fn queued_run_admitted_after_completion() {
     );
 
     shutdown.cancel();
-    let _ = tokio::time::timeout(Duration::from_secs(2), server_handle).await;
+    let join_result = tokio::time::timeout(Duration::from_secs(2), server_handle)
+        .await
+        .expect("server did not shut down within 2s after cancellation");
+    let server_result = join_result.expect("server task panicked");
+    server_result.expect("server returned error");
 }


### PR DESCRIPTION
## Summary

- Spawn a drain-queue task in `server::run` that, on `admission.wait_changed`, pops queued runs and replays the same `AdmissionDecision::Admitted` arm logic (`broadcast.register`, `facade.start_run`, `spawn_forward_task`, `RunAccepted` publication).
- Stash queued `StartRun` parameters (`graph` + `worktree_path` + `run_config`) in a server-scoped `pending_starts: Arc<Mutex<HashMap<RunId, PendingStartRun>>>` so the drain task can replay them later. `AdmissionController` API stays unchanged — parametrising it over a payload would have been more invasive without buying us anything the new map doesn't already cover.
- Replace the `// TODO M7: drain-queue task lands with Phase 9 or 10 polish` placeholder in `dispatch::StartRun`'s `Queued` arm with the actual stash + comment documenting the known limitation.
- Add `tests/daemon_queue_drain.rs`: with `max_active=1`, two raw-IPC `StartRun` requests yield `StartRunOk` then `StartRunQueued`; once the test releases the first run's terminal, the drain task admits the second by calling `facade.start_run` again. Stub facade exposes a release-handle so we can keep run 1 active during request 2.

## Why

Before this PR, `max_active > 1` was a soft cap: any over-cap `StartRun` returned `StartRunQueued` to the client and then sat in `admission.queue` forever — `pop_queued()` had no caller. This made the daemon's admission control non-functional whenever it actually engaged.

## Known limitation (out-of-scope)

The original IPC connection that received `StartRunQueued` does **not** receive event notifications for the eventually-admitted run. The connection's writer is intentionally not stashed (it may be gone by the time the drain admits), and `DaemonEngineFacade::start_run` immediately pipelines `Subscribe` after the queued response — that `Subscribe` fails with `RunNotActive` because admission hasn't registered the run with `BroadcastRegistry` yet.

Workaround for clients that care: re-issue `Subscribe` (or run `surge engine watch <run_id> --daemon`) after observing `GlobalDaemonEvent::RunAccepted` for the queued id. The Subscribe-vs-fast-run race is a separate polish PR (#29 in the planned series).

## Predecessor in the polish series

Follows [#27](https://github.com/vanyastaff/surge/pull/27) — M7 polish #1 (`surge engine watch --daemon` real streaming + Copilot review fixes).

## Test plan

- [x] `cargo build --workspace` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all --check` clean
- [x] `cargo test --workspace --lib` no regressions
- [x] `cargo test -p surge-daemon` — new `daemon_queue_drain::queued_run_admitted_after_completion` passes alongside existing daemon tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)