### PR TITLE
M7 polish #4: SubscribeGlobal IPC + server-side fan-out

### DIFF
--- a/crates/surge-daemon/src/server.rs
+++ b/crates/surge-daemon/src/server.rs
@@ -145,6 +145,11 @@ struct ConnState {
     /// Per-run forwarder task handles. Populated by `Subscribe`;
     /// removed (and aborted) by `Unsubscribe` or connection teardown.
     forwarders: HashMap<RunId, tokio::task::JoinHandle<()>>,
+    /// Global-event forwarder task handle. Populated by `SubscribeGlobal`;
+    /// aborted by `UnsubscribeGlobal` or connection teardown. Only one
+    /// global subscription per connection — repeating `SubscribeGlobal`
+    /// replaces the existing forwarder.
+    global_forwarder: Option<tokio::task::JoinHandle<()>>,
 }
 
 async fn handle_connection(
@@ -161,6 +166,7 @@ async fn handle_connection(
     let state = Arc::new(Mutex::new(ConnState {
         subscriptions: HashSet::new(),
         forwarders: HashMap::new(),
+        global_forwarder: None,
     }));
 
     loop {
@@ -211,6 +217,9 @@ async fn handle_connection(
     // F5: Cleanup — abort any forwarder tasks the client left open.
     let mut s = state.lock().await;
     for (_, h) in s.forwarders.drain() {
+        h.abort();
+    }
+    if let Some(h) = s.global_forwarder.take() {
         h.abort();
     }
 
@@ -462,6 +471,28 @@ async fn dispatch(
             Some(DaemonResponse::UnsubscribeOk { request_id })
         },
 
+        DaemonRequest::SubscribeGlobal { request_id } => {
+            let rx = broadcast.subscribe_global();
+            let writer_for_task = writer.clone();
+            let handle = tokio::spawn(forward_global_to_client(rx, writer_for_task));
+            // Replace any pre-existing global forwarder on this connection
+            // (defensive — clients shouldn't double-subscribe, but if they
+            // do, we abort the old one rather than leak it).
+            let mut s = state.lock().await;
+            if let Some(old) = s.global_forwarder.replace(handle) {
+                old.abort();
+            }
+            Some(DaemonResponse::SubscribeGlobalOk { request_id })
+        },
+
+        DaemonRequest::UnsubscribeGlobal { request_id } => {
+            let mut s = state.lock().await;
+            if let Some(h) = s.global_forwarder.take() {
+                h.abort();
+            }
+            Some(DaemonResponse::UnsubscribeGlobalOk { request_id })
+        },
+
         DaemonRequest::Shutdown { request_id } => {
             // F4: actually cancel the shutdown token so the daemon exits.
             tracing::info!("Shutdown IPC received; cancelling shutdown token");
@@ -644,6 +675,35 @@ async fn forward_per_run_to_client(
                     dropped = n,
                     "per-run forwarder lagged"
                 );
+            },
+        }
+    }
+}
+
+/// Per-connection forwarder for daemon-level events: pumps the global
+/// broadcast → wire as [`DaemonEvent::Global`]. Exits when the
+/// broadcast closes (daemon shutdown) or the writer fails. Mirrors
+/// [`forward_per_run_to_client`] but for [`GlobalDaemonEvent`].
+async fn forward_global_to_client(
+    mut rx: tokio::sync::broadcast::Receiver<GlobalDaemonEvent>,
+    writer: Arc<Mutex<interprocess::local_socket::tokio::SendHalf>>,
+) {
+    loop {
+        match rx.recv().await {
+            Ok(event) => {
+                let frame = DaemonEvent::Global(event);
+                let mut w = writer.lock().await;
+                if let Err(e) = write_frame(&mut *w, &frame).await {
+                    tracing::debug!(
+                        err = %e,
+                        "global subscriber write failed; ending forwarder"
+                    );
+                    break;
+                }
+            },
+            Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
+            Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
+                tracing::warn!(dropped = n, "global forwarder lagged");
             },
         }
     }

--- a/crates/surge-daemon/src/server.rs
+++ b/crates/surge-daemon/src/server.rs
@@ -472,15 +472,32 @@ async fn dispatch(
         },
 
         DaemonRequest::SubscribeGlobal { request_id } => {
-            let rx = broadcast.subscribe_global();
-            let writer_for_task = writer.clone();
-            let handle = tokio::spawn(forward_global_to_client(rx, writer_for_task));
-            // Replace any pre-existing global forwarder on this connection
-            // (defensive — clients shouldn't double-subscribe, but if they
-            // do, we abort the old one rather than leak it).
+            // Idempotent. Spawning a second forwarder while the first
+            // is still alive would briefly race it: both receivers
+            // would observe the same `GlobalDaemonEvent` from
+            // `BroadcastRegistry.global` and each would call
+            // `write_frame` (the writer mutex serializes the wire
+            // writes, but the duplication is real and observable as
+            // two identical `DaemonEvent::Global` frames). Only
+            // (re)spawn when there is no live forwarder — i.e. either
+            // the slot is empty or the previous task has finished
+            // (e.g. writer error broke it out of its loop).
             let mut s = state.lock().await;
-            if let Some(old) = s.global_forwarder.replace(handle) {
-                old.abort();
+            let needs_new = match s.global_forwarder.as_ref() {
+                Some(h) => h.is_finished(),
+                None => true,
+            };
+            if needs_new {
+                // Drop the dead handle (if any) before spawning the
+                // replacement; abort is a no-op on an already-finished
+                // task but keeps the call symmetric with teardown.
+                if let Some(old) = s.global_forwarder.take() {
+                    old.abort();
+                }
+                let rx = broadcast.subscribe_global();
+                let writer_for_task = writer.clone();
+                let handle = tokio::spawn(forward_global_to_client(rx, writer_for_task));
+                s.global_forwarder = Some(handle);
             }
             Some(DaemonResponse::SubscribeGlobalOk { request_id })
         },

--- a/crates/surge-daemon/tests/daemon_subscribe_global.rs
+++ b/crates/surge-daemon/tests/daemon_subscribe_global.rs
@@ -263,3 +263,119 @@ async fn subscribe_global_delivers_run_lifecycle_events() {
     let server_result = join_result.expect("server task panicked");
     server_result.expect("server returned error");
 }
+
+/// Regression test for the Copilot review on PR #30: a second
+/// `SubscribeGlobal` on the same connection must not spawn a
+/// concurrent forwarder. If it did, each `GlobalDaemonEvent` would
+/// be forwarded twice on this connection's wire and every receiver
+/// produced by `EventDispatcher.global.subscribe()` would observe
+/// duplicate frames.
+///
+/// We can't directly inspect server-side task counts, so we assert
+/// the observable invariant: after two `subscribe_global()` calls
+/// followed by a `StartRun`, every receiver sees exactly ONE
+/// `RunAccepted{run_id}` and exactly ONE `RunFinished{run_id}` —
+/// never a third event for the same run.
+#[tokio::test]
+async fn subscribe_global_is_idempotent_within_a_connection() {
+    let temp = TempDir::new().unwrap();
+    let socket = unique_socket_path(&temp, "sub_glob_idem");
+    let cfg = ServerConfig {
+        max_active: 4,
+        socket_path: socket.clone(),
+    };
+    let shutdown = CancellationToken::new();
+    let stub: Arc<dyn EngineFacade> = Arc::new(InstantFinishStubFacade);
+
+    let server_handle = tokio::spawn({
+        let stub = stub.clone();
+        let shutdown = shutdown.clone();
+        async move { run_server(cfg, stub, shutdown).await }
+    });
+
+    let client = connect_with_retry(socket.clone(), Duration::from_secs(3))
+        .await
+        .expect("connect global subscriber");
+
+    // Two subscribes back-to-back. The second must be a no-op on the
+    // server side; the receiver returned by the second call is fed
+    // by the same local broadcast Sender.
+    let mut rx_first = client
+        .subscribe_global()
+        .await
+        .expect("first subscribe_global Ok");
+    let mut rx_second = client
+        .subscribe_global()
+        .await
+        .expect("second subscribe_global Ok");
+
+    // Drive a run on a separate raw-IPC connection so the StartRun
+    // response doesn't interleave on the subscriber connection.
+    let name = local_socket_name_from_path(&socket).expect("socket name");
+    let stream = LocalSocketStream::connect(name)
+        .await
+        .expect("connect issuer");
+    let (read_half, mut write_half) = stream.split();
+    let mut reader = BufReader::new(read_half);
+
+    let run_id = RunId::new();
+    let req = DaemonRequest::StartRun {
+        request_id: 1,
+        run_id,
+        graph: Box::new(make_minimal_graph()),
+        worktree_path: temp.path().to_path_buf(),
+        run_config: EngineRunConfig::default(),
+    };
+    write_frame(&mut write_half, &req)
+        .await
+        .expect("write StartRun");
+    write_half.flush().await.expect("flush StartRun");
+    let resp = read_response_frame(&mut reader)
+        .await
+        .expect("read StartRun resp")
+        .expect("frame StartRun resp");
+    assert!(matches!(resp, DaemonResponse::StartRunOk { .. }));
+
+    // Both receivers must observe exactly RunAccepted then RunFinished
+    // for this run — no third frame. Drain on each independently.
+    for (label, rx) in [("first", &mut rx_first), ("second", &mut rx_second)] {
+        let accepted = tokio::time::timeout(Duration::from_secs(2), rx.recv())
+            .await
+            .unwrap_or_else(|_| panic!("{label}: RunAccepted not received within 2s"))
+            .unwrap_or_else(|e| panic!("{label}: global channel closed early: {e:?}"));
+        match accepted {
+            GlobalDaemonEvent::RunAccepted { run_id: got } => assert_eq!(got, run_id),
+            other => panic!("{label}: expected RunAccepted, got {other:?}"),
+        }
+
+        let finished = tokio::time::timeout(Duration::from_secs(2), rx.recv())
+            .await
+            .unwrap_or_else(|_| panic!("{label}: RunFinished not received within 2s"))
+            .unwrap_or_else(|e| panic!("{label}: global channel closed early: {e:?}"));
+        match finished {
+            GlobalDaemonEvent::RunFinished {
+                run_id: got,
+                outcome: RunOutcome::Completed { .. },
+            } => assert_eq!(got, run_id),
+            other => panic!("{label}: expected RunFinished{{Completed}}, got {other:?}"),
+        }
+
+        // No further events should arrive for this run. A duplicate
+        // forwarder would have re-emitted RunAccepted/RunFinished a
+        // second time. 200ms is enough on tokio's current_thread.
+        match tokio::time::timeout(Duration::from_millis(200), rx.recv()).await {
+            Err(_) => {}, // timeout — good
+            Ok(Ok(unexpected)) => {
+                panic!("{label}: unexpected extra event after RunFinished: {unexpected:?}")
+            },
+            Ok(Err(e)) => panic!("{label}: unexpected channel error: {e:?}"),
+        }
+    }
+
+    shutdown.cancel();
+    let join_result = tokio::time::timeout(Duration::from_secs(2), server_handle)
+        .await
+        .expect("server did not shut down within 2s after cancellation");
+    let server_result = join_result.expect("server task panicked");
+    server_result.expect("server returned error");
+}

--- a/crates/surge-daemon/tests/daemon_subscribe_global.rs
+++ b/crates/surge-daemon/tests/daemon_subscribe_global.rs
@@ -1,0 +1,265 @@
+//! Integration test for `DaemonRequest::SubscribeGlobal` and the
+//! corresponding server-side fan-out of [`GlobalDaemonEvent`] frames.
+//!
+//! Setup: `run_server` with `max_active=4` and a stub facade whose
+//! `start_run` returns a quickly-terminating `RunHandle` (mirrors the
+//! `CountingStubFacade` pattern from `daemon_queue_drain.rs`).
+//!
+//! Procedure:
+//! 1. Connect via `DaemonEngineFacade::connect`, call
+//!    `subscribe_global()` to enable the wire-level forwarder for
+//!    daemon-level events on this connection.
+//! 2. Open a SECOND raw-IPC connection and send `StartRun` over it.
+//!    We use a separate connection so the StartRun reply doesn't get
+//!    multiplexed onto the global subscriber's stream — the
+//!    `subscribe_global()` connection only needs to observe broadcast
+//!    events, not request responses.
+//! 3. Receive on the global receiver: assert `RunAccepted{run_id}`
+//!    arrives, then later `RunFinished{run_id, outcome: Completed}`.
+//! 4. Shut down cleanly.
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+
+use interprocess::local_socket::tokio::prelude::*;
+use surge_core::id::RunId;
+use surge_core::keys::NodeKey;
+use surge_daemon::{ServerConfig, run_server};
+use surge_orchestrator::engine::EngineRunConfig;
+use surge_orchestrator::engine::daemon_facade::DaemonEngineFacade;
+use surge_orchestrator::engine::facade::EngineFacade;
+use surge_orchestrator::engine::handle::{EngineRunEvent, RunHandle, RunOutcome};
+use surge_orchestrator::engine::ipc::{
+    DaemonRequest, DaemonResponse, GlobalDaemonEvent, local_socket_name_from_path,
+    read_response_frame, write_frame,
+};
+use tempfile::TempDir;
+use tokio::io::{AsyncWriteExt, BufReader};
+use tokio::sync::broadcast;
+use tokio_util::sync::CancellationToken;
+
+fn unique_socket_path(temp: &TempDir, prefix: &str) -> PathBuf {
+    let pid = std::process::id();
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    temp.path().join(format!("{prefix}_{pid}_{nanos}.sock"))
+}
+
+fn make_minimal_graph() -> surge_core::graph::Graph {
+    surge_core::graph::Graph {
+        schema_version: surge_core::graph::SCHEMA_VERSION,
+        metadata: surge_core::graph::GraphMetadata {
+            name: "subscribe-global-test".into(),
+            description: None,
+            template_origin: None,
+            created_at: chrono::Utc::now(),
+            author: None,
+        },
+        start: NodeKey::try_from("placeholder").unwrap(),
+        nodes: BTreeMap::new(),
+        edges: Vec::new(),
+        subgraphs: BTreeMap::new(),
+    }
+}
+
+/// Repeatedly attempt to connect to the daemon socket until the
+/// listener accepts a connection (or the deadline elapses). macOS CI
+/// runners have shown >200ms tails between spawn and `bind` returning.
+async fn connect_with_retry(
+    socket: PathBuf,
+    timeout: Duration,
+) -> Result<DaemonEngineFacade, surge_orchestrator::engine::EngineError> {
+    let deadline = std::time::Instant::now() + timeout;
+    loop {
+        match DaemonEngineFacade::connect(socket.clone()).await {
+            Ok(c) => return Ok(c),
+            Err(e) if std::time::Instant::now() >= deadline => return Err(e),
+            Err(_) => {
+                tokio::time::sleep(Duration::from_millis(50)).await;
+            },
+        }
+    }
+}
+
+/// Stub `EngineFacade` whose `start_run` returns a `RunHandle` that
+/// emits `Terminal` and the completion future resolves immediately.
+/// This drives `spawn_forward_task` to publish `RunFinished` into the
+/// broadcast registry — exactly what the global subscription should
+/// observe.
+struct InstantFinishStubFacade;
+
+#[async_trait::async_trait]
+impl EngineFacade for InstantFinishStubFacade {
+    async fn start_run(
+        &self,
+        run_id: RunId,
+        _graph: surge_core::graph::Graph,
+        _worktree_path: PathBuf,
+        _run_config: EngineRunConfig,
+    ) -> Result<RunHandle, surge_orchestrator::engine::EngineError> {
+        let (tx, rx) = broadcast::channel(8);
+        // Emit Terminal then drop the sender so spawn_forward_task's
+        // recv loop sees Closed and proceeds to publish RunFinished.
+        let _ = tx.send(EngineRunEvent::Terminal(RunOutcome::Completed {
+            terminal: NodeKey::try_from("end").unwrap(),
+        }));
+        drop(tx);
+        let completion = tokio::spawn(async move {
+            RunOutcome::Completed {
+                terminal: NodeKey::try_from("end").unwrap(),
+            }
+        });
+        Ok(RunHandle {
+            run_id,
+            events: rx,
+            completion,
+        })
+    }
+
+    async fn resume_run(
+        &self,
+        _run_id: RunId,
+        _worktree_path: PathBuf,
+    ) -> Result<RunHandle, surge_orchestrator::engine::EngineError> {
+        Err(surge_orchestrator::engine::EngineError::Internal(
+            "stub: resume_run not used in this test".into(),
+        ))
+    }
+
+    async fn stop_run(
+        &self,
+        _run_id: RunId,
+        _reason: String,
+    ) -> Result<(), surge_orchestrator::engine::EngineError> {
+        Ok(())
+    }
+
+    async fn resolve_human_input(
+        &self,
+        _run_id: RunId,
+        _call_id: Option<String>,
+        _response: serde_json::Value,
+    ) -> Result<(), surge_orchestrator::engine::EngineError> {
+        Ok(())
+    }
+
+    async fn list_runs(
+        &self,
+    ) -> Result<
+        Vec<surge_orchestrator::engine::handle::RunSummary>,
+        surge_orchestrator::engine::EngineError,
+    > {
+        Ok(vec![])
+    }
+}
+
+#[tokio::test]
+async fn subscribe_global_delivers_run_lifecycle_events() {
+    let temp = TempDir::new().unwrap();
+    // Keep the prefix short — macOS caps sockaddr_un.sun_path at 104 chars.
+    let socket = unique_socket_path(&temp, "sub_glob");
+    let cfg = ServerConfig {
+        max_active: 4,
+        socket_path: socket.clone(),
+    };
+    let shutdown = CancellationToken::new();
+    let stub: Arc<dyn EngineFacade> = Arc::new(InstantFinishStubFacade);
+
+    let server_handle = tokio::spawn({
+        let stub = stub.clone();
+        let shutdown = shutdown.clone();
+        async move { run_server(cfg, stub, shutdown).await }
+    });
+
+    // --- Subscriber connection (high-level facade) ---
+    let client = connect_with_retry(socket.clone(), Duration::from_secs(3))
+        .await
+        .expect("connect global subscriber");
+    let mut global_rx = client
+        .subscribe_global()
+        .await
+        .expect("subscribe_global Ok");
+
+    // --- Issuer connection (raw IPC) ---
+    // Use a separate connection so the StartRun response goes back on
+    // the issuer connection's wire and doesn't interleave with the
+    // global subscriber's events.
+    let name = local_socket_name_from_path(&socket).expect("socket name");
+    let stream = LocalSocketStream::connect(name)
+        .await
+        .expect("connect issuer");
+    let (read_half, mut write_half) = stream.split();
+    let mut reader = BufReader::new(read_half);
+
+    let run_id = RunId::new();
+    let req = DaemonRequest::StartRun {
+        request_id: 1,
+        run_id,
+        graph: Box::new(make_minimal_graph()),
+        worktree_path: temp.path().to_path_buf(),
+        run_config: EngineRunConfig::default(),
+    };
+    write_frame(&mut write_half, &req)
+        .await
+        .expect("write StartRun");
+    write_half.flush().await.expect("flush StartRun");
+
+    let resp = read_response_frame(&mut reader)
+        .await
+        .expect("read StartRun resp")
+        .expect("frame StartRun resp");
+    match resp {
+        DaemonResponse::StartRunOk {
+            request_id,
+            run_id: got,
+        } => {
+            assert_eq!(request_id, 1);
+            assert_eq!(got, run_id);
+        },
+        other => panic!("expected StartRunOk, got {other:?}"),
+    }
+
+    // --- Assert global events arrive ---
+    // RunAccepted is published synchronously inside dispatch::StartRun
+    // BEFORE facade.start_run is called; RunFinished is published by
+    // spawn_forward_task once the handle's events stream closes and
+    // the completion future resolves. Both should arrive within a
+    // couple of seconds.
+    let accepted = tokio::time::timeout(Duration::from_secs(2), global_rx.recv())
+        .await
+        .expect("RunAccepted not received within 2s")
+        .expect("global channel unexpectedly closed before RunAccepted");
+    match accepted {
+        GlobalDaemonEvent::RunAccepted { run_id: got } => assert_eq!(got, run_id),
+        other => panic!("expected RunAccepted, got {other:?}"),
+    }
+
+    let finished = tokio::time::timeout(Duration::from_secs(2), global_rx.recv())
+        .await
+        .expect("RunFinished not received within 2s")
+        .expect("global channel unexpectedly closed before RunFinished");
+    match finished {
+        GlobalDaemonEvent::RunFinished {
+            run_id: got,
+            outcome,
+        } => {
+            assert_eq!(got, run_id);
+            match outcome {
+                RunOutcome::Completed { .. } => {},
+                other => panic!("expected Completed outcome, got {other:?}"),
+            }
+        },
+        other => panic!("expected RunFinished, got {other:?}"),
+    }
+
+    shutdown.cancel();
+    let join_result = tokio::time::timeout(Duration::from_secs(2), server_handle)
+        .await
+        .expect("server did not shut down within 2s after cancellation");
+    let server_result = join_result.expect("server task panicked");
+    server_result.expect("server returned error");
+}

--- a/crates/surge-orchestrator/src/engine/daemon_facade.rs
+++ b/crates/surge-orchestrator/src/engine/daemon_facade.rs
@@ -488,6 +488,61 @@ impl DaemonEngineFacade {
         }
     }
 
+    /// Subscribe to daemon-level [`GlobalDaemonEvent`] notifications.
+    /// Returns a `broadcast::Receiver<GlobalDaemonEvent>` that yields
+    /// events the daemon publishes (e.g. `RunAccepted`, `RunFinished`,
+    /// `DaemonShuttingDown`) for the lifetime of this connection.
+    ///
+    /// Past events are NOT replayed — only events fired AFTER the
+    /// daemon registers the subscription arrive. The local broadcast
+    /// channel was created up-front in `DaemonClient::connect`; this
+    /// method simply hands out a fresh receiver and tells the daemon
+    /// to start fanning out global events to this connection's wire.
+    ///
+    /// Errors with `EngineError::Internal` if the IPC fails or an
+    /// unexpected response variant arrives.
+    pub async fn subscribe_global(
+        &self,
+    ) -> Result<broadcast::Receiver<GlobalDaemonEvent>, EngineError> {
+        // Subscribe to the local channel BEFORE sending the IPC so any
+        // global events arriving immediately after the daemon registers
+        // the subscription are delivered to the caller.
+        let rx = self.inner.event_dispatcher.global.subscribe();
+
+        let resp = self
+            .inner
+            .rpc(|request_id| DaemonRequest::SubscribeGlobal { request_id })
+            .await?;
+        match resp {
+            DaemonResponse::SubscribeGlobalOk { .. } => Ok(rx),
+            DaemonResponse::Error { code, message, .. } => Err(map_error(code, &message)),
+            other => Err(EngineError::Internal(format!(
+                "unexpected response to SubscribeGlobal: {other:?}"
+            ))),
+        }
+    }
+
+    /// Unsubscribe from daemon-level events. Sends `UnsubscribeGlobal`
+    /// IPC; the local `broadcast::Receiver` returned by
+    /// [`Self::subscribe_global`] naturally drops on the caller's
+    /// side and will see `Closed` on subsequent `recv` calls once the
+    /// last sender clone goes away (the local sender lives until the
+    /// connection drops, so existing receivers keep yielding past
+    /// events the daemon already pushed).
+    pub async fn unsubscribe_global(&self) -> Result<(), EngineError> {
+        let resp = self
+            .inner
+            .rpc(|request_id| DaemonRequest::UnsubscribeGlobal { request_id })
+            .await?;
+        match resp {
+            DaemonResponse::UnsubscribeGlobalOk { .. } => Ok(()),
+            DaemonResponse::Error { code, message, .. } => Err(map_error(code, &message)),
+            other => Err(EngineError::Internal(format!(
+                "unexpected response to UnsubscribeGlobal: {other:?}"
+            ))),
+        }
+    }
+
     /// Unsubscribe from a run's events. Drops the per-run broadcast
     /// channel locally (subscribers see Closed); sends Unsubscribe
     /// IPC to the daemon so it stops pumping events to this connection.

--- a/crates/surge-orchestrator/src/engine/ipc.rs
+++ b/crates/surge-orchestrator/src/engine/ipc.rs
@@ -114,6 +114,21 @@ pub enum DaemonRequest {
         /// Identifier of the run to unsubscribe from.
         run_id: RunId,
     },
+    /// Subscribe to daemon-level [`GlobalDaemonEvent`] notifications. The
+    /// daemon will start sending [`DaemonEvent::Global`] frames for every
+    /// `GlobalDaemonEvent` published while this subscription is active,
+    /// until [`DaemonRequest::UnsubscribeGlobal`] arrives or the connection
+    /// closes. Past events are NOT replayed — the receiver only sees
+    /// events fired AFTER the daemon registers the subscription.
+    SubscribeGlobal {
+        /// Client-assigned identifier echoed in the response.
+        request_id: RequestId,
+    },
+    /// Cancel a previous global subscription.
+    UnsubscribeGlobal {
+        /// Client-assigned identifier echoed in the response.
+        request_id: RequestId,
+    },
     /// Begin a graceful daemon shutdown.
     Shutdown {
         /// Client-assigned identifier echoed in the response.
@@ -134,6 +149,8 @@ impl DaemonRequest {
             | Self::ListRuns { request_id }
             | Self::Subscribe { request_id, .. }
             | Self::Unsubscribe { request_id, .. }
+            | Self::SubscribeGlobal { request_id }
+            | Self::UnsubscribeGlobal { request_id }
             | Self::Shutdown { request_id } => *request_id,
         }
     }
@@ -200,6 +217,16 @@ pub enum DaemonResponse {
         /// Echoed `request_id` from the originating [`DaemonRequest::Unsubscribe`].
         request_id: RequestId,
     },
+    /// [`DaemonRequest::SubscribeGlobal`] accepted; global daemon events will follow.
+    SubscribeGlobalOk {
+        /// Echoed `request_id` from the originating [`DaemonRequest::SubscribeGlobal`].
+        request_id: RequestId,
+    },
+    /// [`DaemonRequest::UnsubscribeGlobal`] accepted.
+    UnsubscribeGlobalOk {
+        /// Echoed `request_id` from the originating [`DaemonRequest::UnsubscribeGlobal`].
+        request_id: RequestId,
+    },
     /// [`DaemonRequest::Shutdown`] accepted; daemon is draining.
     ShutdownOk {
         /// Echoed `request_id` from the originating [`DaemonRequest::Shutdown`].
@@ -231,6 +258,8 @@ impl DaemonResponse {
             | Self::ListRunsOk { request_id, .. }
             | Self::SubscribeOk { request_id }
             | Self::UnsubscribeOk { request_id }
+            | Self::SubscribeGlobalOk { request_id }
+            | Self::UnsubscribeGlobalOk { request_id }
             | Self::ShutdownOk { request_id }
             | Self::Error { request_id, .. } => *request_id,
         }


### PR DESCRIPTION
## Summary

Closes the wire-side gap noted in [#29](https://github.com/vanyastaff/surge/pull/29)'s `dispatch::StartRun` Queued-arm comment: the daemon publishes `GlobalDaemonEvent` (e.g. `RunAccepted`, `RunFinished`) into `BroadcastRegistry.global`, and the client-side read loop in `DaemonEngineFacade` already routes `DaemonEvent::Global` frames into `EventDispatcher.global` — but **no server-side code subscribed the broadcast and forwarded it onto the wire**. Net effect: clients couldn't observe global events at all, and the "subscribe-global → see RunAccepted → re-Subscribe per-run" workaround for queued runs was unreachable.

This PR adds the missing IPC surface and server-side forwarder.

- New IPC: `DaemonRequest::SubscribeGlobal` / `UnsubscribeGlobal` + matching `SubscribeGlobalOk` / `UnsubscribeGlobalOk` responses (`#[non_exhaustive]` preserved).
- Server: `ConnState` gains `global_forwarder: Option<JoinHandle<()>>`; `dispatch` spawns `forward_global_to_client` (mirrors `forward_per_run_to_client`) on `SubscribeGlobal`, aborts it on `UnsubscribeGlobal` and on connection teardown. Re-`SubscribeGlobal` replaces the existing forwarder defensively.
- Client: `DaemonEngineFacade::subscribe_global()` / `unsubscribe_global()`. The local `broadcast::Sender` already lived inside `DaemonClient::connect`'s read loop, so the helper just hands out a fresh receiver before piping the IPC.
- Past events are NOT replayed — `tokio::sync::broadcast` semantics mean only events fired AFTER the daemon registers the subscription arrive.

## Out of scope

- Persistence-replay of past `GlobalDaemonEvent` for late subscribers.
- A "watch a queued run" CLI command building on this surface.
- Backpressure beyond `DEFAULT_GLOBAL_CAPACITY = 64` already in `BroadcastRegistry`.

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all --check`
- [x] `cargo test -p surge-daemon` — 6 integration files, all green (new `daemon_subscribe_global.rs` brings count from 5 → 6)
- [x] `cargo test -p surge-orchestrator --lib` — 209 tests pass
- [x] TDD red-green verified on the new test by temporarily stubbing the server-side forwarder; test failed with `RunAccepted not received within 2s`, then passed once the forwarder was restored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)