### PR TITLE
M7 polish: bound admission queue size

### DIFF
--- a/crates/surge-daemon/README.md
+++ b/crates/surge-daemon/README.md
@@ -53,6 +53,7 @@ CLI flags on `surge daemon start`:
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--max-active N` | 8 | Concurrent active runs cap. Excess starts queue (FIFO). |
+| `--max-queue N` | `max_active * 4` | FIFO admission queue cap. When both `max_active` and `max_queue` are hit, further `StartRun` requests are rejected with `QueueFull` so the daemon's pending-start map cannot grow without bound under load. |
 | `--shutdown-grace D` | 30s | Time to wait for in-flight runs to drain on stop. |
 | `--detached` | false | Detach from controlling terminal (Unix `setsid`, Windows `DETACHED_PROCESS`). |
 

--- a/crates/surge-daemon/src/admission.rs
+++ b/crates/surge-daemon/src/admission.rs
@@ -6,6 +6,7 @@ use surge_core::id::RunId;
 use tokio::sync::Mutex;
 
 /// Decision returned by `try_admit`.
+#[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum AdmissionDecision {
     /// Run admitted; daemon may proceed to call `engine.start_run`.
@@ -17,6 +18,17 @@ pub enum AdmissionDecision {
         /// Zero-based position in the queue at the moment of the call.
         position: usize,
     },
+    /// Both `active` and `queue` are at their respective caps; the run
+    /// was neither admitted nor queued. Daemon should reply with an
+    /// `Error { code: QueueFull }` so the client can back off and
+    /// retry instead of having an unbounded amount of work piled up
+    /// inside the daemon process.
+    QueueFull {
+        /// Current queue length at the moment of the rejection.
+        queue_len: usize,
+        /// Configured queue cap (the value `try_admit` was about to exceed).
+        max_queue: usize,
+    },
 }
 
 /// Concurrent admission policy.
@@ -24,6 +36,7 @@ pub struct AdmissionController {
     inner: Mutex<Inner>,
     notify: tokio::sync::Notify,
     max_active: usize,
+    max_queue: usize,
 }
 
 struct Inner {
@@ -32,9 +45,12 @@ struct Inner {
 }
 
 impl AdmissionController {
-    /// Construct with a hard cap on concurrent active runs.
+    /// Construct with a hard cap on concurrent active runs and on the
+    /// FIFO admission queue. When both are saturated, [`Self::try_admit`]
+    /// returns [`AdmissionDecision::QueueFull`] instead of growing the
+    /// queue without bound.
     #[must_use]
-    pub fn new(max_active: usize) -> Self {
+    pub fn new(max_active: usize, max_queue: usize) -> Self {
         Self {
             inner: Mutex::new(Inner {
                 active: HashSet::new(),
@@ -42,17 +58,24 @@ impl AdmissionController {
             }),
             notify: tokio::sync::Notify::new(),
             max_active,
+            max_queue,
         }
     }
 
     /// Attempt to admit a run. Returns [`AdmissionDecision::Admitted`]
-    /// if a slot was free or [`AdmissionDecision::Queued`] if the run
-    /// joined the FIFO queue.
+    /// if a slot was free, [`AdmissionDecision::Queued`] if the run
+    /// joined the FIFO queue, or [`AdmissionDecision::QueueFull`] if
+    /// both the active set and the queue are at their respective caps.
     pub async fn try_admit(&self, run_id: RunId) -> AdmissionDecision {
         let mut inner = self.inner.lock().await;
         if inner.active.len() < self.max_active {
             inner.active.insert(run_id);
             AdmissionDecision::Admitted
+        } else if inner.queue.len() >= self.max_queue {
+            AdmissionDecision::QueueFull {
+                queue_len: inner.queue.len(),
+                max_queue: self.max_queue,
+            }
         } else {
             inner.queue.push_back(run_id);
             AdmissionDecision::Queued {
@@ -103,6 +126,7 @@ impl AdmissionController {
             active: inner.active.len(),
             max_active: self.max_active,
             queued: inner.queue.len(),
+            max_queue: self.max_queue,
         }
     }
 
@@ -123,6 +147,8 @@ pub struct AdmissionSnapshot {
     pub max_active: usize,
     /// Runs currently waiting in the FIFO queue.
     pub queued: usize,
+    /// Configured cap on the FIFO queue length.
+    pub max_queue: usize,
 }
 
 #[cfg(test)]
@@ -131,7 +157,7 @@ mod tests {
 
     #[tokio::test]
     async fn under_cap_admits() {
-        let a = AdmissionController::new(2);
+        let a = AdmissionController::new(2, 4);
         let r1 = RunId::new();
         let r2 = RunId::new();
         assert_eq!(a.try_admit(r1).await, AdmissionDecision::Admitted);
@@ -140,7 +166,7 @@ mod tests {
 
     #[tokio::test]
     async fn over_cap_queues_in_fifo() {
-        let a = AdmissionController::new(1);
+        let a = AdmissionController::new(1, 4);
         let r1 = RunId::new();
         let r2 = RunId::new();
         let r3 = RunId::new();
@@ -157,7 +183,7 @@ mod tests {
 
     #[tokio::test]
     async fn complete_then_pop_admits_next() {
-        let a = AdmissionController::new(1);
+        let a = AdmissionController::new(1, 4);
         let r1 = RunId::new();
         let r2 = RunId::new();
         let _ = a.try_admit(r1).await;
@@ -170,7 +196,7 @@ mod tests {
 
     #[tokio::test]
     async fn try_admit_no_queue_rejects_at_cap() {
-        let a = AdmissionController::new(1);
+        let a = AdmissionController::new(1, 4);
         let r1 = RunId::new();
         let r2 = RunId::new();
         assert!(a.try_admit_no_queue(r1).await);
@@ -182,7 +208,7 @@ mod tests {
 
     #[tokio::test]
     async fn snapshot_counts() {
-        let a = AdmissionController::new(2);
+        let a = AdmissionController::new(2, 4);
         let r1 = RunId::new();
         let r2 = RunId::new();
         let r3 = RunId::new();
@@ -193,5 +219,57 @@ mod tests {
         assert_eq!(s.active, 2);
         assert_eq!(s.max_active, 2);
         assert_eq!(s.queued, 1);
+        assert_eq!(s.max_queue, 4);
+    }
+
+    #[tokio::test]
+    async fn rejects_with_queue_full_when_both_caps_hit() {
+        // max_active=1, max_queue=1: first admits, second queues, third
+        // is rejected as QueueFull. The rejected run is NOT enqueued,
+        // so the queue length stays at the cap, not above it.
+        let a = AdmissionController::new(1, 1);
+        let r1 = RunId::new();
+        let r2 = RunId::new();
+        let r3 = RunId::new();
+        assert_eq!(a.try_admit(r1).await, AdmissionDecision::Admitted);
+        assert_eq!(
+            a.try_admit(r2).await,
+            AdmissionDecision::Queued { position: 0 }
+        );
+        assert_eq!(
+            a.try_admit(r3).await,
+            AdmissionDecision::QueueFull {
+                queue_len: 1,
+                max_queue: 1,
+            }
+        );
+        let s = a.snapshot().await;
+        assert_eq!(s.active, 1);
+        assert_eq!(s.queued, 1, "queue must not grow past max_queue");
+    }
+
+    #[tokio::test]
+    async fn queue_full_does_not_block_admission_after_drain() {
+        // After the queued run is drained, the previously-rejected run
+        // can be re-admitted — the rejection is not sticky.
+        let a = AdmissionController::new(1, 1);
+        let r1 = RunId::new();
+        let r2 = RunId::new();
+        let r3 = RunId::new();
+        let _ = a.try_admit(r1).await;
+        let _ = a.try_admit(r2).await;
+        // r3 is rejected: queue is at cap.
+        assert!(matches!(
+            a.try_admit(r3).await,
+            AdmissionDecision::QueueFull { .. }
+        ));
+        // Free a slot, drain r2 from the queue, then retrying r3 should
+        // queue (queue back to empty, active back at cap from r2).
+        a.notify_completed(r1).await;
+        assert_eq!(a.pop_queued().await, Some(r2));
+        assert_eq!(
+            a.try_admit(r3).await,
+            AdmissionDecision::Queued { position: 0 }
+        );
     }
 }

--- a/crates/surge-daemon/src/error.rs
+++ b/crates/surge-daemon/src/error.rs
@@ -26,6 +26,17 @@ pub enum DaemonError {
         /// Number of runs waiting in the queue.
         queued: usize,
     },
+    /// FIFO admission queue is at its configured cap. The active set
+    /// may also be at cap, but the load-bearing condition is the queue
+    /// length: even if a slot freed instantly, accepting more work
+    /// would still grow the daemon's pending state without bound.
+    #[error("admission queue is full ({queue_len}/{max_queue})")]
+    QueueFull {
+        /// Current queue length.
+        queue_len: usize,
+        /// Configured queue cap.
+        max_queue: usize,
+    },
     /// Lookup of a run id the daemon does not currently host.
     #[error("run not active: {0}")]
     RunNotActive(surge_core::id::RunId),
@@ -52,6 +63,7 @@ impl DaemonError {
             Self::Framing(_) => ErrorCode::BadRequest,
             Self::Io(_) | Self::Pidfile(_) | Self::ClientGone => ErrorCode::Internal,
             Self::AdmissionFull { .. } => ErrorCode::AdmissionFull,
+            Self::QueueFull { .. } => ErrorCode::QueueFull,
             Self::RunNotActive(_) => ErrorCode::RunNotActive,
             Self::Storage(_) => ErrorCode::StorageError,
             Self::Engine(_) => ErrorCode::EngineError,
@@ -72,6 +84,16 @@ mod tests {
             queued: 3,
         };
         assert_eq!(e.code(), ErrorCode::AdmissionFull);
+    }
+
+    #[test]
+    fn queue_full_maps_to_queue_full() {
+        let e = DaemonError::QueueFull {
+            queue_len: 4,
+            max_queue: 4,
+        };
+        assert_eq!(e.code(), ErrorCode::QueueFull);
+        assert!(format!("{e}").contains("4/4"));
     }
 
     #[test]

--- a/crates/surge-daemon/src/main.rs
+++ b/crates/surge-daemon/src/main.rs
@@ -16,6 +16,13 @@ struct Args {
     /// Maximum concurrent active runs.
     #[arg(long, default_value_t = 8)]
     max_active: usize,
+    /// Maximum runs allowed to wait in the FIFO admission queue.
+    /// When omitted, defaults to `max_active * 4`. When both
+    /// `max_active` and this cap are saturated, further `StartRun`
+    /// requests are rejected with `QueueFull` so the daemon's
+    /// pending-start map cannot grow unboundedly under load.
+    #[arg(long)]
+    max_queue: Option<usize>,
     /// Graceful-shutdown grace window.
     #[arg(long, default_value = "30s", value_parser = parse_humantime)]
     shutdown_grace: Duration,
@@ -117,8 +124,10 @@ fn main() -> std::process::ExitCode {
             let _ = std::fs::write(path, env!("CARGO_PKG_VERSION"));
         }
 
+        let max_queue = args.max_queue.unwrap_or(args.max_active.saturating_mul(4));
         let server_cfg = ServerConfig {
             max_active: args.max_active,
+            max_queue,
             socket_path: socket_path.clone(),
         };
         let server_handle = tokio::spawn({

--- a/crates/surge-daemon/src/server.rs
+++ b/crates/surge-daemon/src/server.rs
@@ -50,6 +50,11 @@ type PendingStarts = Arc<Mutex<HashMap<RunId, PendingStartRun>>>;
 pub struct ServerConfig {
     /// Maximum concurrent active runs.
     pub max_active: usize,
+    /// Maximum runs allowed to wait in the FIFO admission queue. When
+    /// both `max_active` and this cap are hit, further `StartRun`
+    /// requests are rejected with [`ErrorCode::QueueFull`] instead of
+    /// growing the daemon's pending-start map without bound.
+    pub max_queue: usize,
     /// Path of the local socket to bind.
     pub socket_path: PathBuf,
 }
@@ -63,7 +68,7 @@ pub async fn run(
 ) -> Result<(), DaemonError> {
     use interprocess::local_socket::ListenerOptions;
 
-    let admission = Arc::new(AdmissionController::new(cfg.max_active));
+    let admission = Arc::new(AdmissionController::new(cfg.max_active, cfg.max_queue));
     let broadcast = Arc::new(BroadcastRegistry::new());
     let pending_starts: PendingStarts = Arc::new(Mutex::new(HashMap::new()));
 
@@ -346,6 +351,25 @@ async fn dispatch(
                         request_id,
                         run_id,
                         position,
+                    })
+                },
+                AdmissionDecision::QueueFull {
+                    queue_len,
+                    max_queue,
+                } => {
+                    // We optimistically inserted into `pending_starts`
+                    // before `try_admit` to close a TOCTOU window
+                    // against the drain task (see comment on the
+                    // insert above). Admission rejected — the run
+                    // will never be popped, so we MUST remove the
+                    // entry here or the daemon leaks the boxed Graph
+                    // and `EngineRunConfig` for every QueueFull
+                    // rejection.
+                    pending_starts.lock().await.remove(&run_id);
+                    Some(DaemonResponse::Error {
+                        request_id,
+                        code: ErrorCode::QueueFull,
+                        message: format!("queue is full ({queue_len}/{max_queue})"),
                     })
                 },
             }

--- a/crates/surge-daemon/tests/daemon_admission_queue.rs
+++ b/crates/surge-daemon/tests/daemon_admission_queue.rs
@@ -7,7 +7,8 @@ use surge_daemon::admission::{AdmissionController, AdmissionDecision};
 
 #[tokio::test]
 async fn fifo_queue_preserves_order() {
-    let a = AdmissionController::new(1);
+    // Roomy queue cap so we exercise the FIFO order, not the rejection.
+    let a = AdmissionController::new(1, 16);
     let r1 = RunId::new();
     let r2 = RunId::new();
     let r3 = RunId::new();
@@ -30,13 +31,20 @@ async fn fifo_queue_preserves_order() {
 
 #[tokio::test]
 async fn cap_8_admits_first_8_queues_rest() {
-    let a = AdmissionController::new(8);
+    let a = AdmissionController::new(8, 16);
     let mut admitted = 0;
     let mut queued = 0;
     for _ in 0..12 {
         match a.try_admit(RunId::new()).await {
             AdmissionDecision::Admitted => admitted += 1,
             AdmissionDecision::Queued { .. } => queued += 1,
+            AdmissionDecision::QueueFull { .. } => {
+                panic!("queue cap is 16; should not reject 4 queued runs")
+            },
+            // `AdmissionDecision` is `#[non_exhaustive]`; future variants
+            // should fail loudly here so the test starts caring about
+            // them rather than silently miscounting.
+            other => panic!("unexpected AdmissionDecision variant: {other:?}"),
         }
     }
     assert_eq!(admitted, 8);
@@ -44,4 +52,29 @@ async fn cap_8_admits_first_8_queues_rest() {
     let s = a.snapshot().await;
     assert_eq!(s.active, 8);
     assert_eq!(s.queued, 4);
+    assert_eq!(s.max_queue, 16);
+}
+
+#[tokio::test]
+async fn cap_8_with_tight_queue_rejects_overflow() {
+    // max_active=8, max_queue=2 — first 8 admit, next 2 queue, rest
+    // are rejected with QueueFull instead of growing the queue.
+    let a = AdmissionController::new(8, 2);
+    let mut admitted = 0;
+    let mut queued = 0;
+    let mut rejected = 0;
+    for _ in 0..12 {
+        match a.try_admit(RunId::new()).await {
+            AdmissionDecision::Admitted => admitted += 1,
+            AdmissionDecision::Queued { .. } => queued += 1,
+            AdmissionDecision::QueueFull { .. } => rejected += 1,
+            // See the FIFO test for why we keep this loud.
+            other => panic!("unexpected AdmissionDecision variant: {other:?}"),
+        }
+    }
+    assert_eq!(admitted, 8);
+    assert_eq!(queued, 2);
+    assert_eq!(rejected, 2);
+    let s = a.snapshot().await;
+    assert_eq!(s.queued, 2, "queue must not grow past max_queue");
 }

--- a/crates/surge-daemon/tests/daemon_e2e_smoke.rs
+++ b/crates/surge-daemon/tests/daemon_e2e_smoke.rs
@@ -85,6 +85,7 @@ async fn ping_round_trip() {
     let socket = unique_socket_path(&temp, "smoke");
     let cfg = ServerConfig {
         max_active: 4,
+        max_queue: 16,
         socket_path: socket.clone(),
     };
     let shutdown = CancellationToken::new();

--- a/crates/surge-daemon/tests/daemon_graceful_shutdown.rs
+++ b/crates/surge-daemon/tests/daemon_graceful_shutdown.rs
@@ -78,6 +78,7 @@ async fn shutdown_token_exits_within_500ms() {
     let socket = unique_socket_path(&temp, "shutdown");
     let cfg = ServerConfig {
         max_active: 4,
+        max_queue: 16,
         socket_path: socket,
     };
     let shutdown = CancellationToken::new();

--- a/crates/surge-daemon/tests/daemon_queue_full.rs
+++ b/crates/surge-daemon/tests/daemon_queue_full.rs
@@ -1,24 +1,25 @@
-//! Integration test for the queue-drain task.
+//! Bounded admission queue: when both `max_active` and `max_queue` are
+//! saturated, further `StartRun` requests are rejected with
+//! `Error { code: QueueFull }` instead of growing the daemon's
+//! pending-start map without bound.
 //!
-//! Setup: `run_server` with `max_active=1` and a stub facade whose
-//! `start_run` returns a quickly-terminating `RunHandle`.
+//! Setup: `run_server` with `max_active=1, max_queue=1` and a stub
+//! facade whose first `start_run` holds the events channel open
+//! until the test releases it. That keeps run 1 active and the queue
+//! occupied (after run 2 lands), so the third `StartRun` must hit
+//! `AdmissionDecision::QueueFull`.
 //!
 //! Procedure:
-//! 1. Send `StartRun` for run 1 over raw IPC → expect `StartRunOk`.
-//! 2. Send `StartRun` for run 2 over raw IPC → expect `StartRunQueued`.
-//! 3. The handle the stub returned for run 1 emits `Terminal` and its
-//!    completion future resolves immediately, so `spawn_forward_task`
-//!    calls `admission.notify_completed`.
-//! 4. The drain task wakes on `wait_changed`, pops run 2, and calls
-//!    `facade.start_run` again.
-//! 5. Assert `stub.start_count == 2` within a short timeout.
+//! 1. `StartRun` for run 1 over raw IPC → expect `StartRunOk`.
+//! 2. `StartRun` for run 2 → expect `StartRunQueued`.
+//! 3. `StartRun` for run 3 → expect `Error { code: QueueFull }`.
+//! 4. Release run 1 to let the drain task admit run 2 and the server
+//!    shut down cleanly.
 //!
-//! We use raw frame I/O (rather than `DaemonEngineFacade::start_run`)
-//! because the facade pipelines a `Subscribe` immediately after the
-//! StartRun reply, and that `Subscribe` fails for a queued run (the
-//! run is not yet registered with `BroadcastRegistry` until admission).
-//! That failure mode is documented as a known limitation of this PR;
-//! the drain-task production behaviour is what we want to exercise.
+//! Raw IPC (rather than `DaemonEngineFacade::start_run`) for the same
+//! reason as `daemon_queue_drain.rs`: the facade pipelines a
+//! `Subscribe` immediately after the StartRun reply, which fails for
+//! a queued / rejected run that has no per-run channel registered.
 
 use std::collections::BTreeMap;
 use std::path::PathBuf;
@@ -34,13 +35,16 @@ use surge_orchestrator::engine::EngineRunConfig;
 use surge_orchestrator::engine::facade::EngineFacade;
 use surge_orchestrator::engine::handle::{EngineRunEvent, RunHandle, RunOutcome};
 use surge_orchestrator::engine::ipc::{
-    DaemonRequest, DaemonResponse, local_socket_name_from_path, read_response_frame, write_frame,
+    DaemonRequest, DaemonResponse, ErrorCode, local_socket_name_from_path, read_response_frame,
+    write_frame,
 };
 use tempfile::TempDir;
 use tokio::io::{AsyncWriteExt, BufReader};
 use tokio::sync::broadcast;
 use tokio_util::sync::CancellationToken;
 
+/// macOS caps `sockaddr_un.sun_path` at 104 chars. The system temp dir
+/// on CI runners eats most of that, so we keep the prefix terse.
 fn unique_socket_path(temp: &TempDir, prefix: &str) -> PathBuf {
     let pid = std::process::id();
     let nanos = std::time::SystemTime::now()
@@ -54,7 +58,7 @@ fn make_minimal_graph() -> surge_core::graph::Graph {
     surge_core::graph::Graph {
         schema_version: surge_core::graph::SCHEMA_VERSION,
         metadata: surge_core::graph::GraphMetadata {
-            name: "queue-drain-test".into(),
+            name: "queue-full-test".into(),
             description: None,
             template_origin: None,
             created_at: chrono::Utc::now(),
@@ -67,11 +71,10 @@ fn make_minimal_graph() -> surge_core::graph::Graph {
     }
 }
 
-/// Stub `EngineFacade` whose `start_run` increments a counter and
-/// returns a `RunHandle`. The FIRST call's handle holds its events
-/// channel open until `release_first` fires — that lets the test
-/// queue a second `StartRun` while run 1 is still active. Subsequent
-/// calls return a handle that completes immediately.
+/// Stub facade: first `start_run` holds the events channel open until
+/// `release_first` fires; subsequent runs complete instantly. Used to
+/// pin run 1 in the active set while we test what happens when the
+/// queue fills.
 struct CountingStubFacade {
     start_count: AtomicUsize,
     release_first: Arc<tokio::sync::Notify>,
@@ -83,10 +86,6 @@ impl CountingStubFacade {
             start_count: AtomicUsize::new(0),
             release_first: Arc::new(tokio::sync::Notify::new()),
         }
-    }
-
-    fn start_count(&self) -> usize {
-        self.start_count.load(Ordering::SeqCst)
     }
 
     fn release_first(&self) {
@@ -110,10 +109,7 @@ impl EngineFacade for CountingStubFacade {
         let release = self.release_first.clone();
 
         if is_first {
-            // First run: hold events open until the test notifies
-            // `release_first`. Then emit Terminal and drop the sender,
-            // which lets `spawn_forward_task` finish and call
-            // `admission.notify_completed` — waking the drain task.
+            // First run: hold events open until released.
             tokio::spawn(async move {
                 release.notified().await;
                 let _ = tx.send(EngineRunEvent::Terminal(RunOutcome::Completed {
@@ -122,7 +118,6 @@ impl EngineFacade for CountingStubFacade {
                 drop(tx);
             });
         } else {
-            // Subsequent runs: complete instantly.
             let _ = tx.send(EngineRunEvent::Terminal(RunOutcome::Completed {
                 terminal: NodeKey::try_from("end").unwrap(),
             }));
@@ -179,14 +174,13 @@ impl EngineFacade for CountingStubFacade {
 }
 
 #[tokio::test]
-async fn queued_run_admitted_after_completion() {
+async fn third_start_run_at_saturation_returns_queue_full() {
     let temp = TempDir::new().unwrap();
-    let socket = unique_socket_path(&temp, "queue_drain");
+    // Keep the prefix short — see comment on unique_socket_path.
+    let socket = unique_socket_path(&temp, "q_full");
     let cfg = ServerConfig {
         max_active: 1,
-        // Plenty of queue capacity — this test exercises the drain
-        // path, not the rejection path.
-        max_queue: 8,
+        max_queue: 1,
         socket_path: socket.clone(),
     };
     let shutdown = CancellationToken::new();
@@ -208,7 +202,7 @@ async fn queued_run_admitted_after_completion() {
     let (read_half, mut write_half) = stream.split();
     let mut reader = BufReader::new(read_half);
 
-    // --- StartRun #1 ---
+    // --- StartRun #1 — admitted ---
     let run1 = RunId::new();
     let req1 = DaemonRequest::StartRun {
         request_id: 1,
@@ -233,7 +227,7 @@ async fn queued_run_admitted_after_completion() {
         other => panic!("expected StartRunOk for run1, got {other:?}"),
     }
 
-    // --- StartRun #2 — admission cap reached, should queue ---
+    // --- StartRun #2 — queued ---
     let run2 = RunId::new();
     let req2 = DaemonRequest::StartRun {
         request_id: 2,
@@ -263,24 +257,69 @@ async fn queued_run_admitted_after_completion() {
         other => panic!("expected StartRunQueued for run2, got {other:?}"),
     }
 
-    // Release run 1's terminal event. `spawn_forward_task` will call
-    // `admission.notify_completed`, the drain task wakes via
-    // `wait_changed`, and run 2 gets admitted via `facade.start_run`.
+    // --- StartRun #3 — both caps hit, expect QueueFull ---
+    let run3 = RunId::new();
+    let req3 = DaemonRequest::StartRun {
+        request_id: 3,
+        run_id: run3,
+        graph: Box::new(make_minimal_graph()),
+        worktree_path: temp.path().to_path_buf(),
+        run_config: EngineRunConfig::default(),
+    };
+    write_frame(&mut write_half, &req3)
+        .await
+        .expect("write StartRun #3");
+    write_half.flush().await.expect("flush #3");
+    let resp3 = read_response_frame(&mut reader)
+        .await
+        .expect("read #3")
+        .expect("frame #3");
+    match resp3 {
+        DaemonResponse::Error {
+            request_id,
+            code,
+            message,
+        } => {
+            assert_eq!(request_id, 3);
+            assert_eq!(code, ErrorCode::QueueFull);
+            assert!(
+                message.contains("queue is full"),
+                "expected diagnostic message; got {message:?}"
+            );
+            assert!(
+                message.contains("1/1"),
+                "message should include queue_len/max_queue numbers; got {message:?}"
+            );
+        },
+        other => panic!("expected Error{{QueueFull}} for run3, got {other:?}"),
+    }
+
+    // Now release run 1 so the drain task can admit run 2 and the
+    // server shuts down cleanly. Without this, the held-open events
+    // channel would keep the spawn_forward_task blocked past the
+    // 2s timeout below.
     stub.release_first();
 
-    // The stub's run-1 handle terminates immediately, so
-    // `spawn_forward_task` calls `admission.notify_completed` very
-    // quickly. The drain task should then pop run 2 and call
-    // `facade.start_run` for it. Poll the counter with a generous
-    // timeout to avoid CI flakes.
+    // After release, run 2 will be admitted (start_count == 2).
+    // The rejected run 3 must NOT result in another start_run call.
     let deadline = std::time::Instant::now() + Duration::from_secs(2);
-    while std::time::Instant::now() < deadline && stub.start_count() < 2 {
+    while std::time::Instant::now() < deadline && stub.start_count.load(Ordering::SeqCst) < 2 {
         tokio::time::sleep(Duration::from_millis(20)).await;
     }
     assert_eq!(
-        stub.start_count(),
+        stub.start_count.load(Ordering::SeqCst),
         2,
-        "drain task should have admitted the queued run within 2s"
+        "run 2 must be admitted exactly once via the drain task; run 3 must NOT \
+         have triggered a third start_run"
+    );
+
+    // Belt and braces: give the drain task a brief window to misbehave
+    // (re-admit a phantom run 3) before checking again.
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    assert_eq!(
+        stub.start_count.load(Ordering::SeqCst),
+        2,
+        "rejected run 3 must not appear in start_run history"
     );
 
     shutdown.cancel();

--- a/crates/surge-daemon/tests/daemon_subscribe_unknown.rs
+++ b/crates/surge-daemon/tests/daemon_subscribe_unknown.rs
@@ -98,6 +98,7 @@ async fn subscribe_unknown_run_returns_run_not_active() {
     let socket = unique_socket_path(&temp, "sub_unk");
     let cfg = ServerConfig {
         max_active: 4,
+        max_queue: 16,
         socket_path: socket.clone(),
     };
     let shutdown = CancellationToken::new();

--- a/crates/surge-orchestrator/src/engine/daemon_facade.rs
+++ b/crates/surge-orchestrator/src/engine/daemon_facade.rs
@@ -544,6 +544,7 @@ fn map_error(code: ErrorCode, message: &str) -> EngineError {
         ErrorCode::AdmissionFull => {
             EngineError::Internal(format!("daemon: admission full ({message})"))
         },
+        ErrorCode::QueueFull => EngineError::QueueFull(message.to_string()),
         ErrorCode::ShuttingDown => {
             EngineError::Internal(format!("daemon: shutting down ({message})"))
         },
@@ -559,5 +560,15 @@ mod tests {
     fn map_error_admission_full() {
         let e = map_error(ErrorCode::AdmissionFull, "8/8 active");
         assert!(format!("{e}").contains("admission full"));
+    }
+
+    #[test]
+    fn map_error_queue_full_returns_typed_variant() {
+        let e = map_error(ErrorCode::QueueFull, "queue is full (4/4)");
+        assert!(
+            matches!(e, EngineError::QueueFull(ref m) if m == "queue is full (4/4)"),
+            "QueueFull must surface as a typed variant carrying the daemon message; got {e:?}"
+        );
+        assert!(format!("{e}").contains("queue is full (4/4)"));
     }
 }

--- a/crates/surge-orchestrator/src/engine/error.rs
+++ b/crates/surge-orchestrator/src/engine/error.rs
@@ -50,6 +50,17 @@ pub enum EngineError {
     #[error("run not currently active in daemon: {0}")]
     RunNotActive(RunId),
 
+    /// The daemon's `AdmissionController` rejected a `StartRun`
+    /// because both the active set and the FIFO queue are at their
+    /// configured caps. Carries the operator-facing message produced
+    /// by the daemon (e.g. `"queue is full (8/8)"`) so callers can
+    /// surface it verbatim.
+    ///
+    /// Distinct from `Internal` so callers can back off and retry the
+    /// `start_run` call without parsing strings.
+    #[error("daemon queue full: {0}")]
+    QueueFull(String),
+
     /// An unexpected internal condition occurred.
     #[error("internal engine error: {0}")]
     Internal(String),

--- a/crates/surge-orchestrator/src/engine/ipc.rs
+++ b/crates/surge-orchestrator/src/engine/ipc.rs
@@ -30,6 +30,12 @@ pub enum ErrorCode {
     RunNotActive,
     /// `AdmissionController` queue overflow.
     AdmissionFull,
+    /// `AdmissionController` rejected a `StartRun` because the FIFO
+    /// queue is at its configured cap. Distinct from `AdmissionFull`,
+    /// which is used by `ResumeRun` to signal that the active set is
+    /// at cap (resumes are never queued). Clients should back off and
+    /// retry rather than treating this as a hard failure.
+    QueueFull,
     /// Underlying storage error (sqlite I/O, etc.).
     StorageError,
     /// Engine-level error (graph validation, run lifecycle, etc.).

--- a/crates/surge-orchestrator/src/engine/ipc.rs
+++ b/crates/surge-orchestrator/src/engine/ipc.rs
@@ -28,13 +28,19 @@ pub enum ErrorCode {
     RunNotFound,
     /// Lookup of a run id that the daemon knows but is not currently active.
     RunNotActive,
-    /// `AdmissionController` queue overflow.
+    /// `ResumeRun` was rejected because the active-runs cap (`max_active`)
+    /// is reached. Resumes are never queued — the user expects the run
+    /// to come back live — so the cap maps directly to a rejection.
+    /// Distinct from `QueueFull`, which signals the FIFO admission
+    /// queue (used only on the `StartRun` path) is at its own cap.
     AdmissionFull,
-    /// `AdmissionController` rejected a `StartRun` because the FIFO
-    /// queue is at its configured cap. Distinct from `AdmissionFull`,
-    /// which is used by `ResumeRun` to signal that the active set is
-    /// at cap (resumes are never queued). Clients should back off and
-    /// retry rather than treating this as a hard failure.
+    /// `StartRun` was rejected because the FIFO admission queue is at
+    /// its configured cap (`max_queue`); both `max_active` and the
+    /// queue are saturated, so the run was neither admitted nor
+    /// enqueued. Distinct from `AdmissionFull`, which is the
+    /// `ResumeRun`-side signal for active-cap rejection. Clients
+    /// should back off and retry rather than treating this as a
+    /// hard failure.
     QueueFull,
     /// Underlying storage error (sqlite I/O, etc.).
     StorageError,


### PR DESCRIPTION
## Summary

- Bound `AdmissionController.queue` with a configurable cap (default = `max_active * 4`); when both `max_active` and the queue cap are hit, `try_admit` returns `AdmissionDecision::QueueFull` instead of growing the queue without bound.
- Surface the rejection over IPC as `Error { code: QueueFull }`, with a typed `EngineError::QueueFull(String)` so daemon-facade callers can branch on the case without string-matching the error message — mirrors the `RunNotActive` typed variant added in [#29](https://github.com/vanyastaff/surge/pull/29).
- After [#28](https://github.com/vanyastaff/surge/pull/28), `dispatch::StartRun` inserts into `pending_starts` (which holds `Box<Graph>` + `EngineRunConfig`) **before** `try_admit` to close the TOCTOU window with the drain task. On `QueueFull` we now remove that entry so a rejected request does not leak its Graph payload.
- New `--max-queue` daemon CLI flag with auto-default `max_active * 4`. Documented in `crates/surge-daemon/README.md`.

## Why

`AdmissionController.queue` was a `VecDeque<RunId>` with no upper bound. Combined with the per-queued-run `PendingStartRun { graph: Box<Graph>, run_config, … }` map introduced in [#28](https://github.com/vanyastaff/surge/pull/28), a burst of `StartRun` requests at saturation grew daemon memory linearly with the burst size, with no signal to the client to back off. This PR closes that admission-feedback hole.

## Out of scope

- Dynamic / adaptive queue sizing.
- Priority queue (some runs cut to the front).
- Telemetry on queue depth (separate observability concern).

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all --check`
- [x] `cargo test --workspace --lib`
- [x] `cargo test -p surge-daemon` — all 8 test files pass, including the new `daemon_queue_full` (max_active=1, max_queue=1; 3rd raw-IPC StartRun comes back as `Error{QueueFull}` and does NOT result in a third `facade.start_run`).
- [x] `daemon_queue_full` re-run 5× consecutively: stable.
- [x] Existing `AdmissionController` unit tests + `daemon_admission_queue.rs` + `daemon_queue_drain.rs` still pass under the new `(max_active, max_queue)` constructor signature.

Refs [#28](https://github.com/vanyastaff/surge/pull/28). Do not merge — leaving for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)