### PR TITLE
M7 polish: fix concurrent-merge regression of max_queue field

### DIFF
--- a/crates/surge-daemon/src/admission.rs
+++ b/crates/surge-daemon/src/admission.rs
@@ -295,7 +295,7 @@ mod tests {
 
     #[tokio::test]
     async fn cancel_queued_removes_from_fifo() {
-        let a = AdmissionController::new(1);
+        let a = AdmissionController::new(1, 4);
         let r1 = RunId::new();
         let r2 = RunId::new();
         let r3 = RunId::new();

--- a/crates/surge-daemon/tests/daemon_list_queued.rs
+++ b/crates/surge-daemon/tests/daemon_list_queued.rs
@@ -211,6 +211,7 @@ async fn list_runs_includes_queued_run_as_awaiting() {
     let socket = unique_socket_path(&temp, "ls_q");
     let cfg = ServerConfig {
         max_active: 1,
+        max_queue: 8,
         socket_path: socket.clone(),
     };
     let shutdown = CancellationToken::new();

--- a/crates/surge-daemon/tests/daemon_stop_queued.rs
+++ b/crates/surge-daemon/tests/daemon_stop_queued.rs
@@ -212,6 +212,7 @@ async fn stop_run_cancels_queued_run() {
     let socket = unique_socket_path(&temp, "stop_q");
     let cfg = ServerConfig {
         max_active: 1,
+        max_queue: 8,
         socket_path: socket.clone(),
     };
     let shutdown = CancellationToken::new();

--- a/crates/surge-daemon/tests/daemon_subscribe_global.rs
+++ b/crates/surge-daemon/tests/daemon_subscribe_global.rs
@@ -164,6 +164,7 @@ async fn subscribe_global_delivers_run_lifecycle_events() {
     let socket = unique_socket_path(&temp, "sub_glob");
     let cfg = ServerConfig {
         max_active: 4,
+        max_queue: 16,
         socket_path: socket.clone(),
     };
     let shutdown = CancellationToken::new();
@@ -282,6 +283,7 @@ async fn subscribe_global_is_idempotent_within_a_connection() {
     let socket = unique_socket_path(&temp, "sub_glob_idem");
     let cfg = ServerConfig {
         max_active: 4,
+        max_queue: 16,
         socket_path: socket.clone(),
     };
     let shutdown = CancellationToken::new();


### PR DESCRIPTION
## Summary

Quick fix for a regression that landed when M7 polish PRs [#30](https://github.com/vanyastaff/surge/pull/30), [#31](https://github.com/vanyastaff/surge/pull/31), [#32](https://github.com/vanyastaff/surge/pull/32), and [#33](https://github.com/vanyastaff/surge/pull/33) all merged into main.

Each PR was green on its own pre-merge CI. But [#33](https://github.com/vanyastaff/surge/pull/33) made `max_queue: usize` a mandatory field on `ServerConfig` and changed `AdmissionController::new` from `(max_active)` to `(max_active, max_queue)`. The other three PRs were branched from a pre-#33 main and added new test code referring to the older shape. Once all four were on main together, `cargo clippy --all-targets` and any `cargo test --all-targets` invocation that compiles the daemon test binaries fails with `missing field max_queue` and `this function takes 2 arguments but 1 argument was supplied`.

This is a textbook concurrent-PR-merge hazard: GitHub's diff-overlap detection wouldn't catch it because the broken test files and the new struct field are in different files.

## Fixes

- `crates/surge-daemon/src/admission.rs` — `cancel_queued_removes_from_fifo` test passes both args (`AdmissionController::new(1, 4)`).
- `crates/surge-daemon/tests/daemon_list_queued.rs` — `ServerConfig` gets `max_queue: 8`.
- `crates/surge-daemon/tests/daemon_stop_queued.rs` — `ServerConfig` gets `max_queue: 8`.
- `crates/surge-daemon/tests/daemon_subscribe_global.rs` — both `ServerConfig` literals get `max_queue: 16` (matches existing convention: `max_queue ≈ 4 × max_active`).

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p surge-daemon` (18 lib + 11 integration tests pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)