### PR TITLE
ui(phase1): connect runtime UI to surge-daemon as a client

### DIFF
--- a/crates/surge-ui/Cargo.toml
+++ b/crates/surge-ui/Cargo.toml
@@ -14,6 +14,8 @@ gpui-component-assets = "0.5"
 
 surge-core = { path = "../surge-core" }
 surge-acp = { path = "../surge-acp" }
+surge-orchestrator = { path = "../surge-orchestrator" }
+surge-daemon = { path = "../surge-daemon" }
 agent-client-protocol.workspace = true
 
 tokio.workspace = true

--- a/crates/surge-ui/src/app.rs
+++ b/crates/surge-ui/src/app.rs
@@ -373,6 +373,7 @@ impl SurgeApp {
                     _ => None,
                 }
             },
+            G::DaemonShuttingDown => Some(SurgeNotification::daemon_shutting_down()),
             _ => None,
         };
 
@@ -455,7 +456,19 @@ impl SurgeApp {
             let mut rx = match facade.subscribe_global().await {
                 Ok(rx) => rx,
                 Err(e) => {
+                    // The Connected state we set above implied an active
+                    // subscription; without it the UI would lie about
+                    // receiving events. Roll back to Failed so the
+                    // status pill is honest.
                     tracing::warn!("daemon subscribe_global failed: {e}");
+                    let reason = e.to_string();
+                    let _ = cx.update(|cx| {
+                        let _ = state_for_task.update(cx, |state, cx| {
+                            state.daemon_state =
+                                crate::daemon_link::ConnectionState::Failed(reason);
+                            cx.notify();
+                        });
+                    });
                     return;
                 },
             };

--- a/crates/surge-ui/src/app.rs
+++ b/crates/surge-ui/src/app.rs
@@ -93,7 +93,9 @@ impl SurgeApp {
         )
         .detach();
 
-        // Subscribe to SurgeEvents from AppState → queue notifications
+        // Subscribe to SurgeEvents from AppState → queue notifications.
+        // (Currently dormant — no in-process emitter; kept for the
+        // in-process orchestrator path that may surface later.)
         cx.subscribe(
             &state,
             |this, _state, event: &surge_core::SurgeEvent, cx| {
@@ -102,6 +104,14 @@ impl SurgeApp {
             },
         )
         .detach();
+
+        // Spawn the daemon connect + global-event subscription task.
+        // The runtime UI is a daemon client (per
+        // `docs/revision/rfcs/0008-ui-architecture.md`): it watches runs
+        // hosted by `surge-daemon` rather than running them in-process.
+        // This task: try_connect → list_runs → subscribe_global → loop
+        // pumping `GlobalDaemonEvent` into AppState + UI notifications.
+        Self::spawn_daemon_link(&state, cx);
 
         // Start in Welcome mode.
         let welcome = cx.new(WelcomeScreen::new);
@@ -333,6 +343,162 @@ impl SurgeApp {
         if let Some(notif) = notification {
             self.pending_notifications.push(notif);
         }
+    }
+
+    /// Queue a notification for a `GlobalDaemonEvent` (run lifecycle).
+    /// Mirrors `queue_notification_for_event` for the SurgeEvent path
+    /// but consumes daemon-side run lifecycle events instead.
+    fn queue_notification_for_global(
+        &mut self,
+        event: &surge_orchestrator::engine::ipc::GlobalDaemonEvent,
+    ) {
+        // Also send OS-level notification.
+        crate::notifications::os_notify_global(event);
+
+        use surge_orchestrator::engine::handle::RunOutcome;
+        use surge_orchestrator::engine::ipc::GlobalDaemonEvent as G;
+
+        let notification = match event {
+            G::RunAccepted { run_id } => Some(SurgeNotification::run_accepted(&run_id.short())),
+            G::RunFinished { run_id, outcome } => {
+                let short = run_id.short();
+                match outcome {
+                    RunOutcome::Completed { .. } => Some(SurgeNotification::run_completed(&short)),
+                    RunOutcome::Failed { error } => {
+                        Some(SurgeNotification::run_failed(&short, error))
+                    },
+                    RunOutcome::Aborted { reason } => {
+                        Some(SurgeNotification::run_aborted(&short, reason))
+                    },
+                    _ => None,
+                }
+            },
+            _ => None,
+        };
+
+        if let Some(notif) = notification {
+            self.pending_notifications.push(notif);
+        }
+    }
+
+    /// Spawn the daemon connection + global-event subscription task.
+    ///
+    /// Lifecycle on success:
+    ///   1. State flips to `Connecting`.
+    ///   2. `try_connect` opens the local socket; on failure flips
+    ///      to `Failed(reason)` and exits without retrying. (User-driven
+    ///      retry is a phase-2 affordance.)
+    ///   3. State flips to `Connected(facade)`. `list_runs` populates
+    ///      the run list once.
+    ///   4. `subscribe_global` opens the lifecycle event stream; the
+    ///      task loops on `recv` until the channel closes (daemon
+    ///      shutdown / connection drop).
+    ///   5. Each event lands in three places: `apply_global_event`
+    ///      mutates the run list, `queue_notification_for_global`
+    ///      queues an in-app banner, and `os_notify_global` fires an
+    ///      OS toast.
+    fn spawn_daemon_link(state: &Entity<AppState>, cx: &mut Context<Self>) {
+        let state_for_task = state.downgrade();
+        cx.spawn(async move |this: WeakEntity<Self>, cx: &mut AsyncApp| {
+            // Set Connecting.
+            let _ = cx.update(|cx| {
+                let _ = state_for_task.update(cx, |state, cx| {
+                    state.daemon_state = crate::daemon_link::ConnectionState::Connecting;
+                    cx.notify();
+                });
+            });
+
+            // Try to connect.
+            let facade = match crate::daemon_link::try_connect().await {
+                Ok(f) => f,
+                Err(e) => {
+                    tracing::info!("daemon not reachable on startup ({e}); UI continues offline");
+                    let _ = cx.update(|cx| {
+                        let _ = state_for_task.update(cx, |state, cx| {
+                            state.daemon_state =
+                                crate::daemon_link::ConnectionState::Failed(e.to_string());
+                            cx.notify();
+                        });
+                    });
+                    return;
+                },
+            };
+
+            // Connected — flip state, then list runs once.
+            let facade_for_state = facade.clone();
+            let _ = cx.update(|cx| {
+                let _ = state_for_task.update(cx, |state, cx| {
+                    state.daemon_state =
+                        crate::daemon_link::ConnectionState::Connected(facade_for_state);
+                    cx.notify();
+                });
+            });
+
+            {
+                use surge_orchestrator::engine::facade::EngineFacade as _;
+                match facade.list_runs().await {
+                    Ok(summaries) => {
+                        let _ = cx.update(|cx| {
+                            let _ = state_for_task.update(cx, |state, cx| {
+                                state.set_runs_from_summaries(&summaries);
+                                cx.notify();
+                            });
+                        });
+                    },
+                    Err(e) => {
+                        tracing::warn!("daemon list_runs failed: {e}");
+                    },
+                }
+            }
+
+            // Subscribe to the global lifecycle event stream.
+            let mut rx = match facade.subscribe_global().await {
+                Ok(rx) => rx,
+                Err(e) => {
+                    tracing::warn!("daemon subscribe_global failed: {e}");
+                    return;
+                },
+            };
+            tracing::info!("daemon link: subscribed to global events");
+
+            loop {
+                match rx.recv().await {
+                    Ok(event) => {
+                        let event_for_state = event.clone();
+                        let event_for_app = event.clone();
+                        let _ = cx.update(|cx| {
+                            let _ = state_for_task.update(cx, |state, cx| {
+                                state.apply_global_event(&event_for_state);
+                                cx.notify();
+                            });
+                            let _ = this.update(cx, |this, cx| {
+                                this.queue_notification_for_global(&event_for_app);
+                                cx.notify();
+                            });
+                        });
+                    },
+                    Err(tokio::sync::broadcast::error::RecvError::Closed) => {
+                        tracing::info!(
+                            "daemon link: global event channel closed; ending subscription"
+                        );
+                        break;
+                    },
+                    Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
+                        tracing::warn!(dropped = n, "daemon link: global event subscriber lagged");
+                    },
+                }
+            }
+
+            // Channel closed — flip back to Disconnected so the UI can
+            // surface a "reconnect" affordance later.
+            let _ = cx.update(|cx| {
+                let _ = state_for_task.update(cx, |state, cx| {
+                    state.daemon_state = crate::daemon_link::ConnectionState::Disconnected;
+                    cx.notify();
+                });
+            });
+        })
+        .detach();
     }
 
     /// Flush queued notifications (called from render where Window is available).

--- a/crates/surge-ui/src/app_state.rs
+++ b/crates/surge-ui/src/app_state.rs
@@ -170,22 +170,41 @@ impl AppState {
                 }
             },
             GlobalDaemonEvent::RunFinished { run_id, outcome } => {
+                // `RunOutcome` is `#[non_exhaustive]`. For known variants
+                // we map to the matching `RunStatus`. For an unknown
+                // future variant we deliberately do NOT collapse to
+                // `Aborted` — that would misrepresent e.g. a future
+                // `TimedOut` outcome as user-cancelled. Instead, leave
+                // the existing status untouched (typical case: it was
+                // `Active`, so it stays `Active`; the UI will surface
+                // the staleness when it next refreshes via `ListRuns`)
+                // and emit a tracing::debug so the gap is visible.
                 let new_status = match outcome {
-                    RunOutcome::Completed { .. } => RunStatus::Completed,
-                    RunOutcome::Failed { .. } => RunStatus::Failed,
-                    RunOutcome::Aborted { .. } => RunStatus::Aborted,
-                    // `RunOutcome` is `#[non_exhaustive]` — fall through to
-                    // a sane neutral status; refine when new variants land.
-                    _ => RunStatus::Aborted,
+                    RunOutcome::Completed { .. } => Some(RunStatus::Completed),
+                    RunOutcome::Failed { .. } => Some(RunStatus::Failed),
+                    RunOutcome::Aborted { .. } => Some(RunStatus::Aborted),
+                    _ => {
+                        tracing::debug!(
+                            run_id = %run_id,
+                            "RunFinished with unknown RunOutcome variant; keeping current status"
+                        );
+                        None
+                    },
                 };
                 if let Some(existing) = self.runs.iter_mut().find(|r| &r.run_id == run_id) {
-                    existing.status = new_status;
+                    if let Some(status) = new_status {
+                        existing.status = status;
+                    }
                 } else {
-                    // Unknown run id — synthesize a stub so the user sees
-                    // *something*. Real `started_at` is unrecoverable here.
+                    // Unknown run id AND unknown outcome — synthesize a
+                    // stub with our best guess (Aborted is least
+                    // misleading for "we don't know what happened, but
+                    // we know it ended"). Real `started_at` is
+                    // unrecoverable here.
+                    let stub_status = new_status.unwrap_or(RunStatus::Aborted);
                     self.runs.push(UiRun {
                         run_id: *run_id,
-                        status: new_status,
+                        status: stub_status,
                         started_at: chrono::Utc::now(),
                         last_event_seq: None,
                     });

--- a/crates/surge-ui/src/app_state.rs
+++ b/crates/surge-ui/src/app_state.rs
@@ -5,7 +5,12 @@ use gpui::EventEmitter;
 use surge_acp::{
     AgentHealth, AgentPool, DetectedAgent, HealthTracker, PermissionPolicy, Registry, RegistryEntry,
 };
+use surge_core::id::RunId;
 use surge_core::{Spec, SpecId, SurgeConfig, SurgeEvent, TaskId, TaskState};
+use surge_orchestrator::engine::handle::{RunStatus, RunSummary};
+use surge_orchestrator::engine::ipc::GlobalDaemonEvent;
+
+use crate::daemon_link::ConnectionState;
 
 /// Central application state shared across all UI screens.
 ///
@@ -39,6 +44,21 @@ pub struct AppState {
     /// Agent pool for ACP connections (created when project has agents configured).
     pub agent_pool: Option<Arc<AgentPool>>,
 
+    // ── Daemon (runtime UI client) ──
+    /// Connection state with `surge-daemon`. The runtime UI is a daemon
+    /// client: it lists / watches runs that the daemon hosts rather than
+    /// running them in-process. See `crate::daemon_link::try_connect`.
+    pub daemon_state: ConnectionState,
+    /// Run summaries last fetched / observed from the daemon. Updated by
+    /// the connect task on `ListRuns` and incrementally by the global-event
+    /// subscription as `RunAccepted` / `RunFinished` arrive.
+    ///
+    /// We store our own `UiRun` rather than `RunSummary` directly because
+    /// the latter is `#[non_exhaustive]` (engine can grow new fields) and
+    /// would prevent us from synthesising a stub when a `RunAccepted` for
+    /// an unknown id arrives ahead of a `ListRuns` refresh.
+    pub runs: Vec<UiRun>,
+
     // ── Events ──
     pub _event_tx: tokio::sync::broadcast::Sender<SurgeEvent>,
     pub recent_events: Vec<SurgeEvent>,
@@ -67,6 +87,29 @@ pub struct WorktreeEntry {
     pub exists: bool,
 }
 
+/// UI-side projection of a daemon-hosted run. Mirrors the orchestrator's
+/// `RunSummary` (which is `#[non_exhaustive]` and therefore not
+/// constructible from outside) but with only the fields the runtime UI
+/// reads today. Add fields here as the UI starts surfacing more state.
+#[derive(Debug, Clone)]
+pub struct UiRun {
+    pub run_id: RunId,
+    pub status: RunStatus,
+    pub started_at: chrono::DateTime<chrono::Utc>,
+    pub last_event_seq: Option<u64>,
+}
+
+impl From<&RunSummary> for UiRun {
+    fn from(s: &RunSummary) -> Self {
+        Self {
+            run_id: s.run_id,
+            status: s.status,
+            started_at: s.started_at,
+            last_event_seq: s.last_event_seq,
+        }
+    }
+}
+
 impl AppState {
     /// Create initial state with empty data and real registry.
     pub fn new() -> Self {
@@ -92,9 +135,73 @@ impl AppState {
             specs: Vec::new(),
             worktrees: Vec::new(),
             agent_pool: None,
+            daemon_state: ConnectionState::default(),
+            runs: Vec::new(),
             _event_tx: event_tx,
             recent_events: Vec::new(),
         }
+    }
+
+    /// Apply a `GlobalDaemonEvent` to the run list.
+    ///
+    /// `RunAccepted` inserts a fresh `RunSummary` if the id isn't
+    /// already known (or marks an existing one as `Active`).
+    /// `RunFinished` flips an existing run's status to a terminal
+    /// variant matching the outcome — keeps the entry around so the
+    /// UI can show "recently finished" runs without re-querying
+    /// `ListRuns`.
+    ///
+    /// Future variants are tolerated by ignoring (the wire enum is
+    /// `#[non_exhaustive]`).
+    pub fn apply_global_event(&mut self, event: &GlobalDaemonEvent) {
+        use surge_orchestrator::engine::handle::RunOutcome;
+
+        match event {
+            GlobalDaemonEvent::RunAccepted { run_id } => {
+                if let Some(existing) = self.runs.iter_mut().find(|r| &r.run_id == run_id) {
+                    existing.status = RunStatus::Active;
+                } else {
+                    self.runs.push(UiRun {
+                        run_id: *run_id,
+                        status: RunStatus::Active,
+                        started_at: chrono::Utc::now(),
+                        last_event_seq: None,
+                    });
+                }
+            },
+            GlobalDaemonEvent::RunFinished { run_id, outcome } => {
+                let new_status = match outcome {
+                    RunOutcome::Completed { .. } => RunStatus::Completed,
+                    RunOutcome::Failed { .. } => RunStatus::Failed,
+                    RunOutcome::Aborted { .. } => RunStatus::Aborted,
+                    // `RunOutcome` is `#[non_exhaustive]` — fall through to
+                    // a sane neutral status; refine when new variants land.
+                    _ => RunStatus::Aborted,
+                };
+                if let Some(existing) = self.runs.iter_mut().find(|r| &r.run_id == run_id) {
+                    existing.status = new_status;
+                } else {
+                    // Unknown run id — synthesize a stub so the user sees
+                    // *something*. Real `started_at` is unrecoverable here.
+                    self.runs.push(UiRun {
+                        run_id: *run_id,
+                        status: new_status,
+                        started_at: chrono::Utc::now(),
+                        last_event_seq: None,
+                    });
+                }
+            },
+            _ => {
+                // `GlobalDaemonEvent` is `#[non_exhaustive]`. Future
+                // variants are silently dropped here; add cases as
+                // they're introduced.
+            },
+        }
+    }
+
+    /// Replace the run list from a fresh `ListRuns` response.
+    pub fn set_runs_from_summaries(&mut self, summaries: &[RunSummary]) {
+        self.runs = summaries.iter().map(UiRun::from).collect();
     }
 
     /// Load project from a directory path.

--- a/crates/surge-ui/src/daemon_link.rs
+++ b/crates/surge-ui/src/daemon_link.rs
@@ -1,0 +1,77 @@
+//! Daemon connection lifecycle for the runtime UI.
+//!
+//! The runtime UI (this crate) is a daemon client per
+//! `docs/revision/rfcs/0008-ui-architecture.md` — it watches runs that
+//! the daemon hosts rather than running them in-process. This module
+//! owns the connection state machine and the `try_connect` helper used
+//! by `SurgeApp::new` on startup.
+//!
+//! Per-run event subscription lives in a follow-up phase and will live
+//! in its own module; this one stops at connect + global event
+//! subscription.
+
+use std::sync::Arc;
+
+use surge_orchestrator::engine::EngineError;
+use surge_orchestrator::engine::daemon_facade::DaemonEngineFacade;
+
+/// Where the runtime UI thinks the daemon is.
+///
+/// `Disconnected` is the initial / "user dismissed" state.
+/// `Connecting` is in-flight — the connect task hasn't finished yet.
+/// `Connected` carries the live facade for subsequent IPC.
+/// `Failed` carries a one-line reason; surfaced as a "click to retry"
+/// affordance in the UI.
+#[derive(Clone, Default)]
+pub enum ConnectionState {
+    #[default]
+    Disconnected,
+    Connecting,
+    Connected(Arc<DaemonEngineFacade>),
+    Failed(String),
+}
+
+impl std::fmt::Debug for ConnectionState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Disconnected => write!(f, "Disconnected"),
+            Self::Connecting => write!(f, "Connecting"),
+            Self::Connected(_) => write!(f, "Connected(<facade>)"),
+            Self::Failed(e) => write!(f, "Failed({e})"),
+        }
+    }
+}
+
+impl ConnectionState {
+    /// Convenience for the top-bar indicator.
+    #[must_use]
+    pub fn label(&self) -> &'static str {
+        match self {
+            Self::Disconnected => "Daemon: Disconnected",
+            Self::Connecting => "Daemon: Connecting…",
+            Self::Connected(_) => "Daemon: Connected",
+            Self::Failed(_) => "Daemon: Connection failed",
+        }
+    }
+
+    /// Hands the live facade to callers that need IPC. `None` for any
+    /// other state.
+    #[must_use]
+    pub fn facade(&self) -> Option<Arc<DaemonEngineFacade>> {
+        match self {
+            Self::Connected(f) => Some(f.clone()),
+            _ => None,
+        }
+    }
+}
+
+/// Resolve the daemon socket path and open a connection. Does NOT
+/// auto-start the daemon (yet) — that's a UX choice we'll surface as
+/// an explicit button rather than launching a background process
+/// silently on UI startup.
+pub async fn try_connect() -> Result<Arc<DaemonEngineFacade>, EngineError> {
+    let socket = surge_daemon::pidfile::socket_path()
+        .map_err(|e| EngineError::Internal(format!("daemon socket path: {e}")))?;
+    let facade = DaemonEngineFacade::connect(socket).await?;
+    Ok(Arc::new(facade))
+}

--- a/crates/surge-ui/src/main.rs
+++ b/crates/surge-ui/src/main.rs
@@ -10,6 +10,7 @@ mod actions;
 mod app;
 mod app_state;
 mod command_palette;
+mod daemon_link;
 mod markdown;
 mod notifications;
 mod project;

--- a/crates/surge-ui/src/notifications.rs
+++ b/crates/surge-ui/src/notifications.rs
@@ -68,6 +68,14 @@ impl SurgeNotification {
             .title("Run Aborted")
             .autohide(false)
     }
+
+    pub fn daemon_shutting_down() -> Notification {
+        Notification::warning(SharedString::from(
+            "Daemon is shutting down — active runs will be interrupted",
+        ))
+        .title("Daemon Shutting Down")
+        .autohide(false)
+    }
 }
 
 // ── OS-level native notifications ──────────────────────────────────
@@ -152,8 +160,12 @@ pub fn os_notify_global(event: &surge_orchestrator::engine::ipc::GlobalDaemonEve
                 _ => ("Run Finished".into(), format!("Run {short} finished")),
             }
         },
+        G::DaemonShuttingDown => (
+            "Daemon Shutting Down".into(),
+            "Active runs will be interrupted".into(),
+        ),
         // `GlobalDaemonEvent` is `#[non_exhaustive]`. Silently drop
-        // unknown variants here; add cases as new ones land.
+        // unknown future variants here; add cases as new ones land.
         _ => return,
     };
 

--- a/crates/surge-ui/src/notifications.rs
+++ b/crates/surge-ui/src/notifications.rs
@@ -44,6 +44,30 @@ impl SurgeNotification {
         .title("Rate Limit")
         .autohide(false)
     }
+
+    pub fn run_accepted(run_short: &str) -> Notification {
+        Notification::info(SharedString::from(format!("Run {run_short} accepted")))
+            .title("Run Started")
+    }
+
+    pub fn run_completed(run_short: &str) -> Notification {
+        Notification::success(SharedString::from(format!(
+            "Run {run_short} completed successfully"
+        )))
+        .title("Run Completed")
+    }
+
+    pub fn run_failed(run_short: &str, reason: &str) -> Notification {
+        Notification::error(SharedString::from(format!("{run_short}: {reason}")))
+            .title("Run Failed")
+            .autohide(false)
+    }
+
+    pub fn run_aborted(run_short: &str, reason: &str) -> Notification {
+        Notification::warning(SharedString::from(format!("{run_short}: {reason}")))
+            .title("Run Aborted")
+            .autohide(false)
+    }
 }
 
 // ── OS-level native notifications ──────────────────────────────────
@@ -97,6 +121,43 @@ pub fn send_os_notification(title: &str, body: &str) {
             "OS notification queue full; dropping notification"
         );
     }
+}
+
+/// Send OS notification for a `GlobalDaemonEvent` from the daemon
+/// runtime. Mirrors the `SurgeNotification::run_*` taxonomy used for
+/// in-app banners so the OS toast and the in-app card line up.
+pub fn os_notify_global(event: &surge_orchestrator::engine::ipc::GlobalDaemonEvent) {
+    use surge_orchestrator::engine::handle::RunOutcome;
+    use surge_orchestrator::engine::ipc::GlobalDaemonEvent as G;
+
+    let (title, body): (String, String) = match event {
+        G::RunAccepted { run_id } => (
+            "Run Started".into(),
+            format!("Run {} accepted", run_id.short()),
+        ),
+        G::RunFinished { run_id, outcome } => {
+            let short = run_id.short();
+            match outcome {
+                RunOutcome::Completed { .. } => (
+                    "Run Completed".into(),
+                    format!("Run {short} completed successfully"),
+                ),
+                RunOutcome::Failed { error } => ("Run Failed".into(), format!("{short}: {error}")),
+                RunOutcome::Aborted { reason } => {
+                    ("Run Aborted".into(), format!("{short}: {reason}"))
+                },
+                // `RunOutcome` is `#[non_exhaustive]`. Surface the new
+                // variant as a generic "finished" toast until the
+                // taxonomy here grows to match.
+                _ => ("Run Finished".into(), format!("Run {short} finished")),
+            }
+        },
+        // `GlobalDaemonEvent` is `#[non_exhaustive]`. Silently drop
+        // unknown variants here; add cases as new ones land.
+        _ => return,
+    };
+
+    send_os_notification(&title, &body);
 }
 
 /// Send OS notification for a SurgeEvent.


### PR DESCRIPTION
## Summary

Phase 1 of the runtime-UI alignment with [`docs/revision/rfcs/0008-ui-architecture.md`](docs/revision/rfcs/0008-ui-architecture.md).

The runtime UI is meant to be a **daemon client** — it watches runs hosted by `surge-daemon` rather than running them in-process. Pre-this-PR the crate had no link to the daemon at all, which left the in-app notification + OS-toast pipeline introduced in [#36](https://github.com/vanyastaff/surge/pull/36) effectively dead code (the `SurgeEvent` subscription in `SurgeApp::new` had no real source).

This PR lays the foundation. **No new visible UI yet** — phase 2 builds the live-mode runtime view on top of this.

## What lands

- **`Cargo.toml`** — depend on `surge-orchestrator` (for `DaemonEngineFacade`, `RunSummary`, `RunStatus`, `RunOutcome`, `GlobalDaemonEvent`) and `surge-daemon` (for socket-path discovery).
- **`daemon_link.rs` (new)** — `ConnectionState` enum (`Disconnected` / `Connecting` / `Connected(facade)` / `Failed(reason)`) + `try_connect()` async helper that resolves the socket via `surge_daemon::pidfile::socket_path()` and opens `DaemonEngineFacade::connect`.
- **`app_state.rs`** — `AppState` gains `daemon_state` and `runs: Vec<UiRun>`. `UiRun` is a UI-side projection of `RunSummary` because `RunSummary` is `#[non_exhaustive]` and can't be constructed from outside `surge-orchestrator` — we need to synthesise stubs when a `RunAccepted` for an unknown id arrives ahead of a `ListRuns` refresh. New methods: `apply_global_event` (in-place `RunAccepted` / `RunFinished` update with `#[non_exhaustive]`-tolerant fall-through arms) and `set_runs_from_summaries` (full replace from a fresh `ListRuns`).
- **`notifications.rs`** — `SurgeNotification` gains `run_accepted` / `run_completed` / `run_failed` / `run_aborted` helpers matching the existing `task_*` taxonomy. `os_notify_global` mirrors `os_notify_event` for daemon lifecycle events, routing through the same single-worker thread.
- **`app.rs`** — `SurgeApp::new` spawns `spawn_daemon_link`, a task that:
  1. flips `daemon_state` through `Connecting` → `Connected` (or `Failed`);
  2. runs `ListRuns` once on success to populate the run list;
  3. loops on `subscribe_global`, pumping each `GlobalDaemonEvent` into AppState (`apply_global_event`) + in-app banner queue (`queue_notification_for_global`) + OS toast (`os_notify_global`);
  4. on `RecvError::Closed` flips state back to `Disconnected` so phase 2 can surface a "click to reconnect" affordance.
  
  Daemon-not-running is a **non-error**: the task logs at `info`, sets state to `Failed`, and exits without retrying — UI continues offline.

The pre-existing `SurgeEvent` subscription on `AppState` is left in place but inert (no in-process orchestrator emitter today). Phase 2 will rebuild `live_execution.rs` against the new daemon link.

## What does NOT land (deferred)

- Live-mode three-pane runtime view (events / graph / detail) — phase 2.
- Per-run `subscribe_to_run` for the active-run event log — phase 2 (requires the new view to consume it).
- "Click to reconnect" UI affordance when state is `Failed` / `Disconnected` — phase 2 (right now you have to restart the app).
- Replay mode + scrubber + fork-from-here — phase 3.
- Pruning / migration of the 17 legacy screens (kanban, dashboard, insights, etc.) — phase 4.

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all --check`

UI is `gpui`; there's no automated test harness in the surge-ui crate. Manual verification will be straightforward in phase 2 once the live view is visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)