### PR TITLE
M5: fix nextest hang in 3 bridge integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,13 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: cargo test -p surge-orchestrator --tests -- --ignored
         timeout-minutes: 10
-        continue-on-error: true  # known M5 limitation: some tests hang on bridge worker reply routing (M5.1)
+        # `--ignored` includes long-running e2e flows and tests that need an
+        # external ACP agent; continue-on-error so a single one doesn't fail
+        # the build. (Earlier comment blamed an "M5.1 bridge reply-routing
+        # hang" — M5.1 has since landed and the AcpBridge::Drop deadlock that
+        # caused those hangs is fixed; the gate stays for the genuinely
+        # external-dep tests.)
+        continue-on-error: true
 
   clippy:
     name: Clippy

--- a/crates/surge-acp/src/bridge/acp_bridge.rs
+++ b/crates/surge-acp/src/bridge/acp_bridge.rs
@@ -239,11 +239,34 @@ impl AcpBridge {
 
 impl Drop for AcpBridge {
     fn drop(&mut self) {
-        // No await possible in Drop. Dropping the only owned cmd_tx
-        // (when `self` is dropped) closes the channel, causing the worker's
-        // `cmd_rx.recv()` to return `None` and the loop to exit. We then
-        // best-effort join the thread.
+        // CORRECTNESS — drop order matters.
+        //
+        // Rust runs custom `Drop::drop(&mut self)` BEFORE the struct's fields
+        // are dropped. If we just called `handle.join()` directly, `self.cmd_tx`
+        // would still be alive — the worker thread is parked inside
+        // `cmd_rx.recv().await` waiting for a command that will never come, and
+        // `join()` would block forever.
+        //
+        // This was masked under `cargo test` because tests follow the happy
+        // path (call `shutdown().await`, which takes the worker out and joins
+        // it itself, so this `Drop` runs with `worker == None`). It surfaced
+        // under `cargo nextest run` as the three "hung integration test"
+        // reports — those tests panic before reaching `shutdown().await` (e.g.
+        // on `bridge.open_session(...).await.unwrap()` if the agent binary is
+        // missing on a cold cache, or on an assertion mid-flow), and the
+        // resulting unwind reaches this `Drop` with the worker still parked.
+        // The process then sat in `join()` until nextest's wall-clock
+        // SLOW/TIMEOUT machinery killed it after 120s.
+        //
+        // Fix: explicitly drop the command sender first by swapping in a
+        // disconnected dummy. Once the real `cmd_tx` is gone the worker's
+        // `cmd_rx.recv()` returns `None`, `bridge_loop` returns, and the
+        // thread exits → `join()` returns promptly. The dummy's matching
+        // receiver is dropped immediately so any later (mistaken) send on the
+        // dummy fails fast rather than enqueuing into a phantom channel.
         if let Some(handle) = self.worker.take() {
+            let (dummy_tx, _dummy_rx) = mpsc::channel::<BridgeCommand>(1);
+            drop(std::mem::replace(&mut self.cmd_tx, dummy_tx));
             let _ = handle.join();
         }
     }
@@ -257,6 +280,35 @@ mod tests {
     async fn spawn_then_shutdown_clean() {
         let bridge = AcpBridge::with_defaults().unwrap();
         bridge.shutdown().await.unwrap();
+    }
+
+    /// Regression test for a `Drop` deadlock that surfaced under nextest as
+    /// "three integration tests hang for >120s" on PR #40.
+    ///
+    /// The bug: custom `Drop::drop(&mut self)` runs BEFORE the struct's fields
+    /// are dropped, so calling `worker.join()` directly inside `Drop` blocks
+    /// forever — the worker thread is parked on `cmd_rx.recv().await`, and
+    /// `cmd_tx` (a field of the same struct) is still alive at that point.
+    /// The hang only manifested when a test panicked before reaching
+    /// `shutdown().await`, which is exactly what happens when an integration
+    /// test fails an assertion or hits `AgentSpawnFailed`.
+    ///
+    /// This test exercises the panic-path drop directly: no `shutdown()`,
+    /// just create a bridge and drop it. Pre-fix this hangs forever; post-fix
+    /// it returns within milliseconds.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn drop_without_shutdown_does_not_deadlock() {
+        let start = std::time::Instant::now();
+        {
+            let _bridge = AcpBridge::with_defaults().unwrap();
+            // Intentionally NO `shutdown().await` — exercises the bare-Drop path.
+        }
+        let elapsed = start.elapsed();
+        assert!(
+            elapsed < std::time::Duration::from_secs(5),
+            "AcpBridge::Drop took {elapsed:?} (>5s) — drop deadlock regression. \
+             See `Drop for AcpBridge` for the cmd_tx-before-join ordering fix."
+        );
     }
 
     #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
## Summary

Three `surge-acp` integration tests appeared to hang for >120s under `cargo nextest run` while passing cleanly under `cargo test`. PR #40 (`ci/nextest-rust-cache`) surfaced this; commit 0f49f5f temporarily `#[ignore]`d them with a wrong "M5.1 bridge reply-routing" reason (commit 723c484 corrected the reason text, but the underlying bug remained).

**Root cause: `AcpBridge::Drop` is ordered wrong.**

Rust runs custom `Drop::drop(&mut self)` BEFORE the struct's fields are dropped, so calling `handle.join()` directly inside `Drop` blocks forever — the worker thread is parked on `cmd_rx.recv().await`, and `self.cmd_tx` (a field of the same struct) is still alive at that point. The hang only manifests when a test **panics** before reaching `shutdown().await` (which would otherwise take the worker out and join it cleanly with `cmd_tx` already closed). Under `cargo test` the three tests follow the happy path; under nextest they panic on the same paths (`AgentSpawnFailed` on a cold cache, asserts mid-flow, etc.) and the unwind reaches `Drop` with the worker still parked. The process then sits in `join()` until nextest's wall-clock `SLOW`/`TIMEOUT` machinery kills it — the `SLOW [>60s]/[>120s]/[>180s]` pattern reported on #40 is exactly the post-panic Drop deadlock, not a tokio runtime issue, not the M5.1 reply-routing limitation the `#[ignore]`s blamed.

**Fix:** in `Drop`, swap `cmd_tx` out for a disconnected dummy so the real sender drops BEFORE we call `handle.join()`. Worker's `cmd_rx` then returns `None`, `bridge_loop` returns, thread exits, `join()` returns promptly.

Also updates the misleading `# known M5 limitation: ... bridge worker reply routing (M5.1)` comment on the `--ignored` orchestrator step in `.github/workflows/ci.yml` — M5.1 landed in #12 (`a34a29e`) and the orchestrator hangs there shared the same `Drop` root cause this PR fixes.

The `#[ignore]`s on the three surge-acp integration tests live on the still-open #40 branch; once that branch rebases on this fix the ignores can be dropped (they were never on `main`).

## Test plan

- [x] **Reproducer (red→green):** new `drop_without_shutdown_does_not_deadlock` unit test in `acp_bridge.rs`. Reproduced the `SLOW [>60s] → [>120s] → [>180s] → [>240s]` pattern locally pre-fix; passes in ~10ms post-fix.
- [x] `cargo nextest run -p surge-acp` clean (235 passed, 1 leaky pre-existing).
- [x] `cargo nextest run --workspace --exclude surge-ui` clean (1299 passed, 1 leaky pre-existing).
- [x] `cargo test -p surge-acp` clean (no regression on the existing happy-path flow).
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean.
- [ ] CI ubuntu / windows / macos green on this PR (pending).

## Refs

- PR #40 (`ci/nextest-rust-cache`) where the hang first surfaced.
- Commit `0f49f5f` (added the wrong-reason `#[ignore]`s on the 3 tests) and commit `723c484` (corrected the reason text). Both can be reverted by #40's next rebase since the underlying bug is now fixed.
- Commit `00a9e44` (M3 force-kill on close timeout via `kill_tx`/`kill_rx`) — that fix is unrelated and remains correct; the kill_tx mechanism was a red herring for this hang.

🤖 Generated with [Claude Code](https://claude.com/claude-code)