### PR TITLE
feat(orchestrator): Triage Author LLM dispatch via ACP — RFC-0010 Plan-C-polish #6

### DIFF
--- a/crates/surge-daemon/Cargo.toml
+++ b/crates/surge-daemon/Cargo.toml
@@ -46,3 +46,5 @@ nix.workspace = true
 [dev-dependencies]
 tempfile.workspace = true
 chrono.workspace = true
+surge-orchestrator.workspace = true
+surge-acp.workspace = true

--- a/crates/surge-daemon/src/main.rs
+++ b/crates/surge-daemon/src/main.rs
@@ -371,13 +371,15 @@ async fn deliver_desktop(
     }
 }
 
-/// Handle one `RouterOutput::Triage` event end-to-end.
+/// Handle a single `RouterOutput::Triage` event end-to-end.
 ///
-/// Returns `true` if the caller loop should `continue` (i.e. if we already
-/// fell back and the outer iteration should not do further processing). Returns
-/// `false` only in the `Enqueued` path when `run_id` / `node_key` parsing
-/// fails — in that case the caller skips delivery but doesn't need a `continue`.
-/// In practice the loop always calls `continue` after this returns.
+/// Pipeline: source lookup → `fetch_task` → candidate assembly →
+/// active-runs snapshot → `dispatch_triage` → decision routing.
+///
+/// Always delivers some signal to the user — either an InboxCard
+/// (Enqueued or fallback), a tracker comment (Duplicate / OOS),
+/// or an Unclear notification. Errors at any step are logged and
+/// fall back to a Medium-priority placeholder InboxCard.
 async fn handle_triage_event(
     event: surge_intake::types::TaskEvent,
     source_map: &std::collections::HashMap<String, Arc<dyn TaskSource>>,

--- a/crates/surge-daemon/src/main.rs
+++ b/crates/surge-daemon/src/main.rs
@@ -351,20 +351,15 @@ async fn deliver_fallback_inbox(
 /// Deliver a rendered notification through the Desktop channel.
 ///
 /// Shared by the Enqueued and Unclear paths to avoid repeating the
-/// `run_id` / `node_key` boilerplate inline.
+/// `node_key` / channel-construction boilerplate inline. Callers
+/// supply the `run_id` so it stays consistent with whatever id is
+/// embedded in the rendered card (e.g., `InboxCardPayload.run_id`).
 async fn deliver_desktop(
     notifier: &Arc<dyn surge_notify::NotifyDeliverer>,
     task_id: &surge_intake::types::TaskId,
+    run_id: surge_core::id::RunId,
     rendered: surge_notify::RenderedNotification,
 ) {
-    let run_id_str = ulid::Ulid::new().to_string();
-    let run_id = match run_id_str.parse::<surge_core::id::RunId>() {
-        Ok(id) => id,
-        Err(e) => {
-            tracing::warn!(error = %e, "skipping desktop delivery: bad run_id");
-            return;
-        },
-    };
     let node_key = match surge_core::keys::NodeKey::try_new("intake") {
         Ok(k) => k,
         Err(e) => {
@@ -507,6 +502,16 @@ async fn dispatch_triage_decision(
                 .unwrap_or("unknown")
                 .to_string();
             let run_id_str = ulid::Ulid::new().to_string();
+            // Parse before constructing the payload so we can fail-early and
+            // share the same RunId between payload.run_id and the delivery
+            // context (avoids drift the inline path used to have).
+            let run_id = match run_id_str.parse::<surge_core::id::RunId>() {
+                Ok(id) => id,
+                Err(e) => {
+                    tracing::warn!(error = %e, "skipping enqueued delivery: bad run_id");
+                    return;
+                },
+            };
             let payload = surge_notify::messages::InboxCardPayload {
                 task_id: event.task_id.clone(),
                 source_id: event.source_id.clone(),
@@ -529,7 +534,7 @@ async fn dispatch_triage_decision(
                 priority = ?payload.priority,
                 "delivering LLM-derived InboxCard"
             );
-            deliver_desktop(notifier, &event.task_id, rendered).await;
+            deliver_desktop(notifier, &event.task_id, run_id, rendered).await;
         },
         TriageDecision::Duplicate { of, reasoning } => {
             let body = format!(
@@ -562,13 +567,23 @@ async fn dispatch_triage_decision(
             }
         },
         TriageDecision::Unclear { question } => {
+            // Unclear has no associated InboxCardPayload (no payload run_id
+            // to mirror), so we mint a fresh ulid for the delivery context.
+            let run_id_str = ulid::Ulid::new().to_string();
+            let run_id = match run_id_str.parse::<surge_core::id::RunId>() {
+                Ok(id) => id,
+                Err(e) => {
+                    tracing::warn!(error = %e, "skipping unclear delivery: bad run_id");
+                    return;
+                },
+            };
             let rendered = surge_notify::RenderedNotification {
                 severity: surge_core::notify_config::NotifySeverity::Warn,
                 title: format!("Triage unclear · {}", event.task_id.as_str()),
                 body: question,
                 artifact_paths: vec![],
             };
-            deliver_desktop(notifier, &event.task_id, rendered).await;
+            deliver_desktop(notifier, &event.task_id, run_id, rendered).await;
         },
     }
 }

--- a/crates/surge-daemon/src/main.rs
+++ b/crates/surge-daemon/src/main.rs
@@ -117,7 +117,7 @@ fn main() -> std::process::ExitCode {
         );
 
         let engine = Arc::new(Engine::new_with_mcp(
-            bridge,
+            Arc::clone(&bridge),
             Arc::clone(&storage),
             tool_dispatcher,
             Arc::clone(&notifier),
@@ -208,7 +208,14 @@ fn main() -> std::process::ExitCode {
         }
 
         if !sources.is_empty() {
-            spawn_task_router(sources, source_map, Arc::clone(&notifier), Arc::clone(&storage)).await;
+            spawn_task_router(
+                sources,
+                source_map,
+                Arc::clone(&notifier),
+                Arc::clone(&storage),
+                Arc::clone(&bridge),
+            )
+            .await;
         } else {
             info!("no task sources configured; skipping TaskRouter spawn");
         }
@@ -257,7 +264,6 @@ fn surge_runs_dir() -> std::path::PathBuf {
 /// know `event.source_id`, (b) `source.fetch_task` fails, or (c)
 /// `dispatch_triage` returns `TriageError`. Preserves Plan-C-MVP
 /// behaviour for unrecoverable provider errors.
-#[allow(dead_code)] // wired in T11
 async fn deliver_fallback_inbox(
     notifier: &Arc<dyn surge_notify::NotifyDeliverer>,
     event: &surge_intake::types::TaskEvent,
@@ -327,12 +333,236 @@ async fn deliver_fallback_inbox(
     }
 }
 
-/// Spawn the TaskRouter and its output consumer (placeholder for T9.3).
+/// Deliver a rendered notification through the Desktop channel.
+///
+/// Shared by the Enqueued and Unclear paths to avoid repeating the
+/// `run_id` / `node_key` boilerplate inline.
+async fn deliver_desktop(
+    notifier: &Arc<dyn surge_notify::NotifyDeliverer>,
+    task_id: &surge_intake::types::TaskId,
+    rendered: surge_notify::RenderedNotification,
+) {
+    let run_id_str = ulid::Ulid::new().to_string();
+    let run_id = match run_id_str.parse::<surge_core::id::RunId>() {
+        Ok(id) => id,
+        Err(e) => {
+            tracing::warn!(error = %e, "skipping desktop delivery: bad run_id");
+            return;
+        },
+    };
+    let node_key = match surge_core::keys::NodeKey::try_new("intake") {
+        Ok(k) => k,
+        Err(e) => {
+            tracing::warn!(error = %e, "skipping desktop delivery: bad NodeKey");
+            return;
+        },
+    };
+    let channel = surge_core::notify_config::NotifyChannel::Desktop;
+    let ctx = surge_notify::NotifyDeliveryContext {
+        run_id,
+        node: &node_key,
+    };
+    match notifier.deliver(&ctx, &channel, &rendered).await {
+        Ok(()) => tracing::info!(task_id = %task_id, "desktop notification delivered"),
+        Err(surge_notify::NotifyError::ChannelNotConfigured) => {
+            tracing::debug!(task_id = %task_id, "Desktop channel not configured")
+        },
+        Err(e) => tracing::warn!(error = %e, task_id = %task_id, "desktop delivery failed"),
+    }
+}
+
+/// Handle one `RouterOutput::Triage` event end-to-end.
+///
+/// Returns `true` if the caller loop should `continue` (i.e. if we already
+/// fell back and the outer iteration should not do further processing). Returns
+/// `false` only in the `Enqueued` path when `run_id` / `node_key` parsing
+/// fails — in that case the caller skips delivery but doesn't need a `continue`.
+/// In practice the loop always calls `continue` after this returns.
+async fn handle_triage_event(
+    event: surge_intake::types::TaskEvent,
+    source_map: &std::collections::HashMap<String, Arc<dyn TaskSource>>,
+    notifier: &Arc<dyn surge_notify::NotifyDeliverer>,
+    storage: &Arc<Storage>,
+    bridge: &Arc<dyn surge_acp::bridge::facade::BridgeFacade>,
+) {
+    // Step 1: look up source.
+    let source = match source_map.get(&event.source_id).cloned() {
+        Some(s) => s,
+        None => {
+            tracing::warn!(
+                source_id = %event.source_id,
+                "no source registered for triage event; falling back"
+            );
+            deliver_fallback_inbox(notifier, &event).await;
+            return;
+        },
+    };
+
+    // Step 2: fetch full task details.
+    let task_details = match source.fetch_task(&event.task_id).await {
+        Ok(td) => td,
+        Err(e) => {
+            tracing::warn!(error = %e, task_id = %event.task_id, "fetch_task failed; falling back");
+            deliver_fallback_inbox(notifier, &event).await;
+            return;
+        },
+    };
+
+    // Step 3: candidates (soft failure → empty).
+    let candidates = surge_intake::candidates::build_for_task(&*source, &task_details, 15)
+        .await
+        .unwrap_or_else(|e| {
+            tracing::warn!(
+                error = %e,
+                task_id = %event.task_id,
+                "build_for_task failed; using empty candidates"
+            );
+            Vec::new()
+        });
+
+    // Step 4: active runs (soft failure → empty).
+    let active_run_rows = storage.snapshot_active_runs(32).await.unwrap_or_else(|e| {
+        tracing::warn!(error = %e, "snapshot_active_runs failed; using empty list");
+        Vec::new()
+    });
+
+    // Step 5: map rows → orchestrator type.
+    let active_runs: Vec<surge_orchestrator::triage::ActiveRunSummary> = active_run_rows
+        .into_iter()
+        .map(|r| surge_orchestrator::triage::ActiveRunSummary {
+            run_id: r.run_id,
+            task_id: r.task_id,
+            status: r.status,
+            started_at: chrono::DateTime::<chrono::Utc>::from_timestamp_millis(r.started_at_ms)
+                .map(|dt| dt.to_rfc3339())
+                .unwrap_or_default(),
+        })
+        .collect();
+
+    // Step 6: build input + options.
+    let input = surge_orchestrator::triage::TriageInput {
+        task: task_details.clone(),
+        candidates,
+        active_runs,
+    };
+    let scratch_root = surge_runs_dir().join("intake").join("triage");
+    let opts = surge_orchestrator::triage::TriageOptions::with_scratch_root(
+        scratch_root,
+        surge_orchestrator::triage::find_claude_binary(),
+    );
+
+    // Step 7: dispatch and route the four-way decision.
+    let decision =
+        match surge_orchestrator::triage::dispatch_triage(Arc::clone(bridge), input, opts).await {
+            Ok(d) => d,
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    task_id = %event.task_id,
+                    "triage invariant failure; falling back"
+                );
+                deliver_fallback_inbox(notifier, &event).await;
+                return;
+            },
+        };
+
+    dispatch_triage_decision(decision, &event, &task_details, &source, notifier).await;
+}
+
+/// Route a `TriageDecision` to the appropriate output channel.
+async fn dispatch_triage_decision(
+    decision: surge_intake::types::TriageDecision,
+    event: &surge_intake::types::TaskEvent,
+    task_details: &surge_intake::types::TaskDetails,
+    source: &Arc<dyn TaskSource>,
+    notifier: &Arc<dyn surge_notify::NotifyDeliverer>,
+) {
+    use surge_intake::types::TriageDecision;
+    match decision {
+        TriageDecision::Enqueued {
+            priority, summary, ..
+        } => {
+            let provider = event
+                .task_id
+                .as_str()
+                .split(':')
+                .next()
+                .unwrap_or("unknown")
+                .to_string();
+            let run_id_str = ulid::Ulid::new().to_string();
+            let payload = surge_notify::messages::InboxCardPayload {
+                task_id: event.task_id.clone(),
+                source_id: event.source_id.clone(),
+                provider,
+                title: task_details.title.clone(),
+                summary,
+                priority,
+                task_url: task_details.url.clone(),
+                run_id: run_id_str,
+            };
+            let rendered_desktop = surge_notify::desktop::format_inbox_card_desktop(&payload);
+            let rendered = surge_notify::RenderedNotification {
+                severity: surge_core::notify_config::NotifySeverity::Info,
+                title: rendered_desktop.title,
+                body: rendered_desktop.body,
+                artifact_paths: vec![],
+            };
+            tracing::info!(
+                task_id = %event.task_id,
+                priority = ?payload.priority,
+                "delivering LLM-derived InboxCard"
+            );
+            deliver_desktop(notifier, &event.task_id, rendered).await;
+        },
+        TriageDecision::Duplicate { of, reasoning } => {
+            let body = format!(
+                "Surge: detected duplicate of {}. {}",
+                of.as_str(),
+                reasoning
+            );
+            match source.post_comment(&event.task_id, &body).await {
+                Ok(()) => {
+                    tracing::info!(task_id = %event.task_id, duplicate_of = %of, "duplicate comment posted")
+                },
+                Err(e) => tracing::warn!(
+                    error = %e,
+                    task_id = %event.task_id,
+                    "duplicate comment post failed"
+                ),
+            }
+        },
+        TriageDecision::OutOfScope { reasoning } => {
+            let body = format!("Surge: out of scope. {}", reasoning);
+            match source.post_comment(&event.task_id, &body).await {
+                Ok(()) => {
+                    tracing::info!(task_id = %event.task_id, "out_of_scope comment posted")
+                },
+                Err(e) => tracing::warn!(
+                    error = %e,
+                    task_id = %event.task_id,
+                    "out_of_scope comment post failed"
+                ),
+            }
+        },
+        TriageDecision::Unclear { question } => {
+            let rendered = surge_notify::RenderedNotification {
+                severity: surge_core::notify_config::NotifySeverity::Warn,
+                title: format!("Triage unclear · {}", event.task_id.as_str()),
+                body: question,
+                artifact_paths: vec![],
+            };
+            deliver_desktop(notifier, &event.task_id, rendered).await;
+        },
+    }
+}
+
+/// Spawn the TaskRouter and its output consumer.
 async fn spawn_task_router(
     sources: Vec<Arc<dyn TaskSource>>,
     source_map: HashMap<String, Arc<dyn TaskSource>>,
     notifier: Arc<dyn surge_notify::NotifyDeliverer>,
     storage: Arc<Storage>,
+    bridge: Arc<dyn surge_acp::bridge::facade::BridgeFacade>,
 ) {
     use rusqlite::Connection;
 
@@ -379,94 +609,23 @@ async fn spawn_task_router(
         }
     });
 
-    // Consume router output and build InboxCard payloads (T9.3).
+    // Consume router output and build InboxCard payloads.
     let source_map_for_consumer = Arc::new(source_map);
+    let bridge_for_consumer = Arc::clone(&bridge);
+    let storage_for_consumer = Arc::clone(&storage);
+    let notifier_for_consumer = Arc::clone(&notifier);
     tokio::spawn(async move {
         while let Some(out) = rx.recv().await {
             match out {
                 surge_intake::router::RouterOutput::Triage { event } => {
-                    // MVP placeholder: build an InboxCardPayload and log it.
-                    // Triage Author LLM dispatch + actual delivery are Plan-C-polish.
-                    let title = event
-                        .raw_payload
-                        .get("title")
-                        .and_then(|v| v.as_str())
-                        .unwrap_or("New ticket")
-                        .to_string();
-                    let task_url = event
-                        .raw_payload
-                        .get("url")
-                        .and_then(|v| v.as_str())
-                        .unwrap_or("")
-                        .to_string();
-                    let provider = event
-                        .task_id
-                        .as_str()
-                        .split(':')
-                        .next()
-                        .unwrap_or("unknown")
-                        .to_string();
-                    let run_id_str = ulid::Ulid::new().to_string();
-                    let payload = surge_notify::messages::InboxCardPayload {
-                        task_id: event.task_id.clone(),
-                        source_id: event.source_id.clone(),
-                        provider: provider.clone(),
-                        title: title.clone(),
-                        summary: String::new(),
-                        priority: surge_intake::types::Priority::Medium,
-                        task_url,
-                        run_id: run_id_str.clone(),
-                    };
-                    let msg = surge_notify::messages::NotifyMessage::InboxCard(payload.clone());
-                    tracing::info!(
-                        task_id = %event.task_id,
-                        "router output: triage → InboxCard built"
-                    );
-
-                    // Render to RenderedNotification using the desktop formatter
-                    let rendered_desktop =
-                        surge_notify::desktop::format_inbox_card_desktop(&payload);
-                    let rendered = surge_notify::RenderedNotification {
-                        severity: surge_core::notify_config::NotifySeverity::Info,
-                        title: rendered_desktop.title.clone(),
-                        body: rendered_desktop.body.clone(),
-                        artifact_paths: vec![],
-                    };
-
-                    // Parse run_id and construct NodeKey for delivery context
-                    let run_id = match run_id_str.parse::<surge_core::id::RunId>() {
-                        Ok(id) => id,
-                        Err(e) => {
-                            tracing::warn!(error = %e, "failed to parse run_id as RunId; skipping delivery");
-                            continue;
-                        },
-                    };
-                    let node_key = match surge_core::keys::NodeKey::try_new("intake") {
-                        Ok(key) => key,
-                        Err(e) => {
-                            tracing::warn!(error = %e, "failed to construct intake NodeKey; skipping delivery");
-                            continue;
-                        },
-                    };
-
-                    // Attempt delivery through Desktop channel
-                    let channel = surge_core::notify_config::NotifyChannel::Desktop;
-                    let ctx = surge_notify::NotifyDeliveryContext {
-                        run_id,
-                        node: &node_key,
-                    };
-                    match notifier.deliver(&ctx, &channel, &rendered).await {
-                        Ok(()) => {
-                            tracing::info!(task_id = %event.task_id, "InboxCard delivered to Desktop")
-                        },
-                        Err(surge_notify::NotifyError::ChannelNotConfigured) => {
-                            tracing::debug!(task_id = %event.task_id, "Desktop channel not configured; skipping");
-                        },
-                        Err(e) => {
-                            tracing::warn!(error = %e, task_id = %event.task_id, "InboxCard delivery to Desktop failed")
-                        },
-                    }
-                    let _ = msg; // keep msg in scope for now
+                    handle_triage_event(
+                        event,
+                        &source_map_for_consumer,
+                        &notifier_for_consumer,
+                        &storage_for_consumer,
+                        &bridge_for_consumer,
+                    )
+                    .await;
                 },
                 surge_intake::router::RouterOutput::EarlyDuplicate { event, run_id } => {
                     let source_id = event.source_id.clone();

--- a/crates/surge-daemon/src/main.rs
+++ b/crates/surge-daemon/src/main.rs
@@ -251,6 +251,82 @@ fn surge_runs_dir() -> std::path::PathBuf {
         .unwrap_or_else(|| std::path::PathBuf::from(".surge"))
 }
 
+/// Deliver a Medium-priority placeholder InboxCard for `event`.
+///
+/// Used as the fallback path when (a) the source registry doesn't
+/// know `event.source_id`, (b) `source.fetch_task` fails, or (c)
+/// `dispatch_triage` returns `TriageError`. Preserves Plan-C-MVP
+/// behaviour for unrecoverable provider errors.
+#[allow(dead_code)] // wired in T11
+async fn deliver_fallback_inbox(
+    notifier: &Arc<dyn surge_notify::NotifyDeliverer>,
+    event: &surge_intake::types::TaskEvent,
+) {
+    let title = event
+        .raw_payload
+        .get("title")
+        .and_then(|v| v.as_str())
+        .unwrap_or("New ticket")
+        .to_string();
+    let task_url = event
+        .raw_payload
+        .get("url")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+    let provider = event
+        .task_id
+        .as_str()
+        .split(':')
+        .next()
+        .unwrap_or("unknown")
+        .to_string();
+    let run_id_str = ulid::Ulid::new().to_string();
+    let payload = surge_notify::messages::InboxCardPayload {
+        task_id: event.task_id.clone(),
+        source_id: event.source_id.clone(),
+        provider,
+        title,
+        summary: String::new(),
+        priority: surge_intake::types::Priority::Medium,
+        task_url,
+        run_id: run_id_str.clone(),
+    };
+    let rendered_desktop = surge_notify::desktop::format_inbox_card_desktop(&payload);
+    let rendered = surge_notify::RenderedNotification {
+        severity: surge_core::notify_config::NotifySeverity::Info,
+        title: rendered_desktop.title.clone(),
+        body: rendered_desktop.body.clone(),
+        artifact_paths: vec![],
+    };
+    let run_id = match run_id_str.parse::<surge_core::id::RunId>() {
+        Ok(id) => id,
+        Err(e) => {
+            tracing::warn!(error = %e, "failed to parse run_id; skipping fallback delivery");
+            return;
+        },
+    };
+    let node_key = match surge_core::keys::NodeKey::try_new("intake") {
+        Ok(key) => key,
+        Err(e) => {
+            tracing::warn!(error = %e, "failed to construct intake NodeKey");
+            return;
+        },
+    };
+    let channel = surge_core::notify_config::NotifyChannel::Desktop;
+    let ctx = surge_notify::NotifyDeliveryContext {
+        run_id,
+        node: &node_key,
+    };
+    match notifier.deliver(&ctx, &channel, &rendered).await {
+        Ok(()) => tracing::info!(task_id = %event.task_id, "fallback InboxCard delivered"),
+        Err(surge_notify::NotifyError::ChannelNotConfigured) => {
+            tracing::debug!(task_id = %event.task_id, "Desktop channel not configured")
+        },
+        Err(e) => tracing::warn!(error = %e, task_id = %event.task_id, "fallback delivery failed"),
+    }
+}
+
 /// Spawn the TaskRouter and its output consumer (placeholder for T9.3).
 async fn spawn_task_router(
     sources: Vec<Arc<dyn TaskSource>>,

--- a/crates/surge-daemon/tests/triage_wiring.rs
+++ b/crates/surge-daemon/tests/triage_wiring.rs
@@ -157,13 +157,13 @@ async fn triage_enqueued_yields_real_priority() {
         bridge_drive.pump_scripted_events().await;
     });
 
-    let opts = surge_orchestrator::triage::TriageOptions {
-        claude_binary: Some(std::path::PathBuf::from("/dev/null")),
-        attempt_timeout: Duration::from_secs(2),
-        max_attempts: 1,
-        scratch_root: tmp.path().to_path_buf(),
-        keep_scratch_on_failure: false,
-    };
+    let mut opts = surge_orchestrator::triage::TriageOptions::with_scratch_root(
+        tmp.path().to_path_buf(),
+        Some(std::path::PathBuf::from("/dev/null")),
+    );
+    opts.attempt_timeout = Duration::from_secs(2);
+    opts.max_attempts = 1;
+    opts.keep_scratch_on_failure = false;
     let input = surge_orchestrator::triage::TriageInput {
         task: task.clone(),
         candidates: vec![],

--- a/crates/surge-daemon/tests/triage_wiring.rs
+++ b/crates/surge-daemon/tests/triage_wiring.rs
@@ -1,0 +1,194 @@
+//! Daemon smoke test: end-to-end wiring of dispatch_triage. Uses
+//! MockBridge + MockTaskSource to validate the TriageDecision
+//! constructed for an Enqueued decision carries a non-Medium
+//! (LLM-derived) priority.
+//!
+//! This test does NOT exercise the consumer task in `main.rs`
+//! directly (it's tightly coupled to daemon lifecycle); instead we
+//! reproduce the dispatch_triage call against a mock bridge with the
+//! same TriageInput shape the daemon would build. The point is
+//! signature-drift detection between dispatch_triage and the
+//! daemon's expected inputs.
+
+use async_trait::async_trait;
+use chrono::Utc;
+use std::collections::VecDeque;
+use std::str::FromStr;
+use std::sync::Arc;
+use std::time::Duration;
+use surge_acp::bridge::error::{
+    BridgeError, CloseSessionError, OpenSessionError, ReplyToToolError, SendMessageError,
+};
+use surge_acp::bridge::event::{BridgeEvent, ToolResultPayload};
+use surge_acp::bridge::facade::BridgeFacade;
+use surge_acp::bridge::session::{MessageContent, SessionConfig, SessionState};
+use surge_core::{OutcomeKey, SessionId};
+use surge_intake::testing::MockTaskSource;
+use surge_intake::types::{Priority, TaskDetails, TaskId, TriageDecision};
+use tempfile::TempDir;
+use tokio::sync::{Mutex, broadcast};
+
+/// Minimal MockBridge fixture for testing dispatch_triage.
+/// (Simplified variant of surge-orchestrator::tests::fixtures::mock_bridge::MockBridge.)
+struct MockBridge {
+    scripted_events: Mutex<VecDeque<BridgeEvent>>,
+    tx: broadcast::Sender<BridgeEvent>,
+    pinned_session_ids: Mutex<VecDeque<SessionId>>,
+}
+
+impl MockBridge {
+    fn new() -> Self {
+        let (tx, _rx) = broadcast::channel(256);
+        Self {
+            scripted_events: Mutex::new(VecDeque::new()),
+            tx,
+            pinned_session_ids: Mutex::new(VecDeque::new()),
+        }
+    }
+
+    async fn pin_next_session_id(&self, id: SessionId) {
+        self.pinned_session_ids.lock().await.push_back(id);
+    }
+
+    async fn enqueue_event(&self, event: BridgeEvent) {
+        self.scripted_events.lock().await.push_back(event);
+    }
+
+    async fn pump_scripted_events(&self) {
+        let mut q = self.scripted_events.lock().await;
+        while let Some(ev) = q.pop_front() {
+            let _ = self.tx.send(ev);
+        }
+    }
+}
+
+#[async_trait]
+impl BridgeFacade for MockBridge {
+    async fn open_session(&self, _config: SessionConfig) -> Result<SessionId, OpenSessionError> {
+        let id = self
+            .pinned_session_ids
+            .lock()
+            .await
+            .pop_front()
+            .unwrap_or_else(SessionId::new);
+        Ok(id)
+    }
+
+    async fn send_message(
+        &self,
+        _session: SessionId,
+        _content: MessageContent,
+    ) -> Result<(), SendMessageError> {
+        Ok(())
+    }
+
+    async fn reply_to_tool(
+        &self,
+        _session: SessionId,
+        _call_id: String,
+        _payload: ToolResultPayload,
+    ) -> Result<(), ReplyToToolError> {
+        Ok(())
+    }
+
+    async fn session_state(&self, _session: SessionId) -> Result<SessionState, BridgeError> {
+        Err(BridgeError::WorkerDead)
+    }
+
+    async fn close_session(&self, _session: SessionId) -> Result<(), CloseSessionError> {
+        Ok(())
+    }
+
+    fn subscribe(&self) -> broadcast::Receiver<BridgeEvent> {
+        self.tx.subscribe()
+    }
+}
+
+#[tokio::test]
+async fn triage_enqueued_yields_real_priority() {
+    // Arrange: mock task source with one task (unused in this test, but kept for symmetry).
+    let _src = Arc::new(MockTaskSource::new("mock:t", "mock"));
+    let task = TaskDetails {
+        task_id: TaskId::try_new("mock:t#1").unwrap(),
+        source_id: "mock:t".into(),
+        title: "Fix parser panic".into(),
+        description: "Stack overflow on invalid UTF-8".into(),
+        status: "open".into(),
+        labels: vec!["surge:enabled".into()],
+        url: "https://example.com/issues/1".into(),
+        created_at: Utc::now(),
+        updated_at: Utc::now(),
+        assignee: None,
+        raw_payload: serde_json::json!({}),
+    };
+
+    // Mock bridge scripted to return Enqueued{priority: Urgent}.
+    let bridge = Arc::new(MockBridge::new());
+    let session = surge_core::SessionId::new();
+    bridge.pin_next_session_id(session).await;
+
+    let tmp = TempDir::new().unwrap();
+    let scratch_root = tmp.path().to_path_buf();
+    let bridge_drive = Arc::clone(&bridge);
+    let drive = tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_millis(80)).await;
+        // Find the scratch subdirectory created by dispatch_triage.
+        let scratch = std::fs::read_dir(&scratch_root)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .find(|e| e.file_type().map(|t| t.is_dir()).unwrap_or(false))
+            .expect("dispatcher created scratch subdir")
+            .path();
+        // Write the triage decision JSON with Urgent priority.
+        std::fs::write(
+            scratch.join("triage_decision.json"),
+            r#"{"decision":"enqueued","priority":"urgent","priority_reasoning":"prod crash","summary":"hot fix"}"#,
+        )
+        .unwrap();
+        // Emit the OutcomeReported event to signal completion.
+        bridge_drive
+            .enqueue_event(BridgeEvent::OutcomeReported {
+                session,
+                outcome: OutcomeKey::from_str("enqueued").unwrap(),
+                summary: "agent completed triage".into(),
+                artifacts_produced: vec!["triage_decision.json".into()],
+            })
+            .await;
+        bridge_drive.pump_scripted_events().await;
+    });
+
+    let opts = surge_orchestrator::triage::TriageOptions {
+        claude_binary: Some(std::path::PathBuf::from("/dev/null")),
+        attempt_timeout: Duration::from_secs(2),
+        max_attempts: 1,
+        scratch_root: tmp.path().to_path_buf(),
+        keep_scratch_on_failure: false,
+    };
+    let input = surge_orchestrator::triage::TriageInput {
+        task: task.clone(),
+        candidates: vec![],
+        active_runs: vec![],
+    };
+
+    let result = surge_orchestrator::triage::dispatch_triage(
+        Arc::clone(&bridge) as Arc<dyn BridgeFacade>,
+        input,
+        opts,
+    )
+    .await
+    .unwrap();
+    drive.await.unwrap();
+
+    // Assert: not Medium, and priority round-trips into the decision.
+    match result {
+        TriageDecision::Enqueued { priority, .. } => {
+            assert_eq!(priority, Priority::Urgent);
+            assert_ne!(
+                priority,
+                Priority::Medium,
+                "must NOT regress to Medium placeholder"
+            );
+        },
+        other => panic!("expected Enqueued, got {other:?}"),
+    }
+}

--- a/crates/surge-intake/src/candidates.rs
+++ b/crates/surge-intake/src/candidates.rs
@@ -95,6 +95,29 @@ impl CandidateInput {
     }
 }
 
+/// Build a top-`limit` candidate set for a given task by calling the
+/// source's `list_open_tasks` and filtering via Jaccard similarity.
+///
+/// The source's full open-task list is bounded by the source impl
+/// (typically ≤200 entries); this helper reduces to the top `limit`.
+pub async fn build_for_task(
+    source: &std::sync::Arc<dyn crate::TaskSource>,
+    target: &crate::types::TaskDetails,
+    limit: usize,
+) -> crate::Result<Vec<crate::types::TaskSummary>> {
+    let open = source.list_open_tasks().await?;
+    let inputs: Vec<CandidateInput> = open.iter().map(CandidateInput::from_summary).collect();
+    let scored = top_by_keyword_overlap(target, &inputs, limit);
+    Ok(scored
+        .into_iter()
+        .filter_map(|s| {
+            open.iter()
+                .find(|t| t.task_id.as_str() == s.task_id)
+                .cloned()
+        })
+        .collect())
+}
+
 /// One ranked candidate with its similarity score.
 #[derive(Debug, Clone, PartialEq)]
 pub struct ScoredCandidate {
@@ -177,5 +200,82 @@ mod tests {
             .collect();
         let top = top_by_keyword_overlap(&target, &cs, 5);
         assert_eq!(top.len(), 5);
+    }
+}
+
+#[cfg(test)]
+mod build_for_task_tests {
+    use super::*;
+    use crate::testing::MockTaskSource;
+    use crate::types::TaskId;
+    use chrono::Utc;
+    use std::sync::Arc;
+
+    fn td(id: &str, title: &str, body: &str) -> TaskDetails {
+        TaskDetails {
+            task_id: TaskId::try_new(id).unwrap(),
+            source_id: "mock:t".into(),
+            title: title.into(),
+            description: body.into(),
+            status: "open".into(),
+            labels: vec![],
+            url: format!("https://x/{id}"),
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+            assignee: None,
+            raw_payload: serde_json::json!({}),
+        }
+    }
+
+    #[tokio::test]
+    async fn returns_top_n_by_jaccard_similarity() {
+        let src = Arc::new(MockTaskSource::new("mock:t", "mock"));
+        // Two candidates exist: one closely related, one unrelated.
+        src.put_task(td(
+            "mock:t#10",
+            "fix parser panic on nested objects",
+            "stack overflow",
+        ))
+        .await;
+        src.put_task(td("mock:t#20", "update readme typo", "docs only"))
+            .await;
+
+        let target = td(
+            "mock:t#100",
+            "parser crashes with deeply nested json",
+            "stack overflow when JSON has more than 16 nested levels",
+        );
+
+        let arc: Arc<dyn crate::TaskSource> = src.clone();
+        let result = build_for_task(&arc, &target, 5).await.unwrap();
+
+        // The semantically-close candidate should appear; readme typo should not
+        // (Jaccard score = 0 against parser/json/nested tokens).
+        let ids: Vec<&str> = result.iter().map(|s| s.task_id.as_str()).collect();
+        assert!(ids.contains(&"mock:t#10"));
+        assert!(!ids.contains(&"mock:t#20"));
+    }
+
+    #[tokio::test]
+    async fn excludes_target_itself() {
+        let src = Arc::new(MockTaskSource::new("mock:t", "mock"));
+        // Insert the target as if it's also "open" — common in real trackers.
+        src.put_task(td("mock:t#100", "parser crash", "nested json"))
+            .await;
+
+        let target = td("mock:t#100", "parser crash", "nested json");
+
+        let arc: Arc<dyn crate::TaskSource> = src.clone();
+        let result = build_for_task(&arc, &target, 5).await.unwrap();
+        assert!(result.iter().all(|s| s.task_id.as_str() != "mock:t#100"));
+    }
+
+    #[tokio::test]
+    async fn empty_open_set_returns_empty() {
+        let src = Arc::new(MockTaskSource::new("mock:t", "mock"));
+        let target = td("mock:t#1", "anything", "");
+        let arc: Arc<dyn crate::TaskSource> = src.clone();
+        let result = build_for_task(&arc, &target, 5).await.unwrap();
+        assert!(result.is_empty());
     }
 }

--- a/crates/surge-intake/src/candidates.rs
+++ b/crates/surge-intake/src/candidates.rs
@@ -101,7 +101,7 @@ impl CandidateInput {
 /// The source's full open-task list is bounded by the source impl
 /// (typically ≤200 entries); this helper reduces to the top `limit`.
 pub async fn build_for_task(
-    source: &std::sync::Arc<dyn crate::TaskSource>,
+    source: &dyn crate::TaskSource,
     target: &crate::types::TaskDetails,
     limit: usize,
 ) -> crate::Result<Vec<crate::types::TaskSummary>> {
@@ -110,6 +110,10 @@ pub async fn build_for_task(
     let scored = top_by_keyword_overlap(target, &inputs, limit);
     Ok(scored
         .into_iter()
+        // Linear lookup back into `open` to recover the full TaskSummary
+        // for each scored result. Acceptable: scored.len() <= limit (≤15)
+        // and open.len() is bounded by the source impl (≤200), so this
+        // is at most ~3000 comparisons per triage call.
         .filter_map(|s| {
             open.iter()
                 .find(|t| t.task_id.as_str() == s.task_id)
@@ -247,7 +251,7 @@ mod build_for_task_tests {
         );
 
         let arc: Arc<dyn crate::TaskSource> = src.clone();
-        let result = build_for_task(&arc, &target, 5).await.unwrap();
+        let result = build_for_task(&*arc, &target, 5).await.unwrap();
 
         // The semantically-close candidate should appear; readme typo should not
         // (Jaccard score = 0 against parser/json/nested tokens).
@@ -266,7 +270,7 @@ mod build_for_task_tests {
         let target = td("mock:t#100", "parser crash", "nested json");
 
         let arc: Arc<dyn crate::TaskSource> = src.clone();
-        let result = build_for_task(&arc, &target, 5).await.unwrap();
+        let result = build_for_task(&*arc, &target, 5).await.unwrap();
         assert!(result.iter().all(|s| s.task_id.as_str() != "mock:t#100"));
     }
 
@@ -275,7 +279,7 @@ mod build_for_task_tests {
         let src = Arc::new(MockTaskSource::new("mock:t", "mock"));
         let target = td("mock:t#1", "anything", "");
         let arc: Arc<dyn crate::TaskSource> = src.clone();
-        let result = build_for_task(&arc, &target, 5).await.unwrap();
+        let result = build_for_task(&*arc, &target, 5).await.unwrap();
         assert!(result.is_empty());
     }
 }

--- a/crates/surge-intake/src/types.rs
+++ b/crates/surge-intake/src/types.rs
@@ -246,6 +246,7 @@ pub struct TaskDetails {
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
     pub assignee: Option<String>,
+    #[serde(default)]
     pub raw_payload: serde_json::Value,
 }
 

--- a/crates/surge-orchestrator/Cargo.toml
+++ b/crates/surge-orchestrator/Cargo.toml
@@ -28,6 +28,7 @@ tokio-util = { version = "0.7", features = ["rt"] }
 futures = "0.3"
 base64 = "0.22"
 interprocess.workspace = true
+ulid = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/surge-orchestrator/Cargo.toml
+++ b/crates/surge-orchestrator/Cargo.toml
@@ -40,3 +40,6 @@ insta = { workspace = true }
 
 [[example]]
 name = "engine_in_daemon"
+
+[features]
+_bootstrap_llm_test = []

--- a/crates/surge-orchestrator/Cargo.toml
+++ b/crates/surge-orchestrator/Cargo.toml
@@ -36,6 +36,7 @@ chrono = { workspace = true }
 anyhow = { workspace = true }
 tiny_http = { workspace = true }
 surge-notify = { workspace = true }
+insta = { workspace = true }
 
 [[example]]
 name = "engine_in_daemon"

--- a/crates/surge-orchestrator/src/snapshots/surge_orchestrator__triage__tests__triage_initial_prompt.snap
+++ b/crates/surge-orchestrator/src/snapshots/surge_orchestrator__triage__tests__triage_initial_prompt.snap
@@ -1,0 +1,84 @@
+---
+source: crates/surge-orchestrator/src/triage.rs
+expression: rendered
+---
+You triage incoming tickets from external task sources.
+
+You receive:
+- The new ticket (title, body, labels, status, URL)
+- List of currently active Surge runs and their associated ticket_ids
+- Top 15-25 candidate tickets (similar open tickets + recent specs)
+- Project context (cwd, language, top-level files)
+
+Your job:
+1. Decide whether this ticket is a duplicate, out-of-scope, unclear, or should be enqueued.
+2. Assess priority (urgent/high/medium/low) from the ticket text and labels.
+3. Output a structured decision.
+
+Anti-patterns to avoid:
+- Do not invent details that aren't in the ticket.
+- Do not mark "duplicate" unless similarity is strong (>0.80 confidence).
+- Always provide priority — never skip.
+- Do not propose implementation; that's downstream.
+
+
+# Inputs
+
+The triage input is encoded as JSON. The shape is:
+- task: TaskDetails
+- candidates: TaskSummary[]
+- active_runs: ActiveRunSummary[]
+
+The literal JSON follows:
+
+{
+  "task": {
+    "task_id": "github_issues:test/repo#42",
+    "source_id": "github_issues:test/repo",
+    "title": "Add tracing to auth middleware",
+    "description": "We have no observability into the auth flow.",
+    "status": "open",
+    "labels": [
+      "surge:enabled",
+      "area/auth"
+    ],
+    "url": "https://github.com/test/repo/issues/42",
+    "created_at": "2026-05-01T10:00:00Z",
+    "updated_at": "2026-05-05T12:00:00Z",
+    "assignee": null,
+    "raw_payload": {}
+  },
+  "candidates": [
+    {
+      "task_id": "github_issues:test/repo#10",
+      "title": "Update README",
+      "status": "open",
+      "url": "https://github.com/test/repo/issues/10",
+      "updated_at": "2026-04-28T09:00:00Z"
+    }
+  ],
+  "active_runs": [
+    {
+      "run_id": "01HXX0000000000000000RUN1",
+      "task_id": "github_issues:test/repo#9",
+      "status": "Running",
+      "started_at": "2026-05-06T10:00:00Z"
+    }
+  ]
+}
+
+# Task
+
+Decide whether this ticket is a duplicate, out-of-scope, unclear, or should be enqueued. Then, in your working directory:
+
+1. Write your structured decision to `triage_decision.json` (schema below).
+2. Write a 3-5 line markdown blurb to `inbox_summary.md` (used as the body of the inbox card on `enqueued`; safe to omit otherwise).
+3. Call `report_stage_outcome` with the matching `outcome` and `artifacts_produced = ["triage_decision.json", "inbox_summary.md"]`.
+
+triage_decision.json schema:
+- decision: "enqueued" | "duplicate" | "out_of_scope" | "unclear"
+- duplicate_of: string (task id) or null
+- priority: "urgent" | "high" | "medium" | "low"
+- priority_reasoning: one sentence
+- summary: one sentence
+- question: string (only when decision = "unclear")

--- a/crates/surge-orchestrator/src/triage.rs
+++ b/crates/surge-orchestrator/src/triage.rs
@@ -161,6 +161,43 @@ pub enum TriageError {
 /// already has its own native sandbox enforcement. The profile's
 /// `[sandbox] mode = ...` field is a semantic marker the agent reads,
 /// not a directive the bridge enforces.
+/// Best-effort discovery of the Claude binary path.
+///
+/// Probe order:
+/// 1. `SURGE_CLAUDE_BINARY` env var (must point to an existing file).
+/// 2. `CLAUDE_PATH` env var (existing convention from `surge-acp::discovery`).
+/// 3. Standard install locations for the current platform: e.g.
+///    `/usr/local/bin/claude`, `/opt/homebrew/bin/claude`, `~/.local/bin/claude`,
+///    `%USERPROFILE%\AppData\Local\Programs\claude\claude.exe`.
+///
+/// Returns `None` if no candidate exists. The dispatcher then surfaces
+/// a configuration-hint Unclear notification.
+#[must_use]
+pub fn find_claude_binary() -> Option<PathBuf> {
+    for var in ["SURGE_CLAUDE_BINARY", "CLAUDE_PATH"] {
+        if let Ok(v) = std::env::var(var) {
+            let p = PathBuf::from(v);
+            if p.is_file() {
+                return Some(p);
+            }
+        }
+    }
+
+    use surge_acp::discovery::Platform;
+    let bin_name = if cfg!(windows) {
+        "claude.exe"
+    } else {
+        "claude"
+    };
+    for base in Platform::current().standard_paths() {
+        let candidate = base.join(bin_name);
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+    }
+    None
+}
+
 fn delegated_sandbox() -> Box<dyn surge_acp::bridge::sandbox::Sandbox> {
     Box::new(surge_acp::bridge::sandbox::AlwaysAllowSandbox)
 }
@@ -584,5 +621,61 @@ mod tests {
         let rendered = super::render_prompt(&input, Some("previous attempt malformed JSON"));
         assert!(rendered.contains("# Feedback from previous attempt"));
         assert!(rendered.contains("previous attempt malformed JSON"));
+    }
+
+    #[test]
+    fn find_claude_binary_returns_env_when_set() {
+        let tmp = tempfile::tempdir().unwrap();
+        let fake = tmp.path().join("claude-fake");
+        std::fs::write(&fake, b"#!/bin/sh\necho fake\n").unwrap();
+        // SAFETY: setting an env var in a single-threaded test is fine, though
+        // Rust 2024 marks std::env::set_var as unsafe due to potential data races
+        // when other threads are running. We are inside a #[test] which Cargo
+        // executes single-threaded for unit tests by default, but if the harness
+        // ever runs tests in parallel (which it does), this is best-effort. Other
+        // tests should not depend on this var. Restore at end.
+        let _prev = std::env::var("SURGE_CLAUDE_BINARY").ok();
+        unsafe {
+            std::env::set_var("SURGE_CLAUDE_BINARY", &fake);
+        }
+        let result = super::find_claude_binary();
+        unsafe {
+            std::env::remove_var("SURGE_CLAUDE_BINARY");
+        }
+        if let Some(prev) = _prev {
+            unsafe {
+                std::env::set_var("SURGE_CLAUDE_BINARY", prev);
+            }
+        }
+        assert_eq!(result, Some(fake));
+    }
+
+    #[test]
+    fn find_claude_binary_returns_none_when_not_found() {
+        // Clear both env vars to ensure we test the standard-paths fallback.
+        let prev_surge = std::env::var("SURGE_CLAUDE_BINARY").ok();
+        let prev_claude = std::env::var("CLAUDE_PATH").ok();
+        unsafe {
+            std::env::remove_var("SURGE_CLAUDE_BINARY");
+            std::env::remove_var("CLAUDE_PATH");
+        }
+
+        // Relaxed assertion: we can't 100% guarantee `claude` isn't on PATH on
+        // this machine; if Some is returned, it must exist on disk. None is
+        // also a valid outcome.
+        if let Some(p) = super::find_claude_binary() {
+            assert!(p.exists(), "discovery returned a non-existent path: {p:?}");
+        }
+
+        if let Some(p) = prev_surge {
+            unsafe {
+                std::env::set_var("SURGE_CLAUDE_BINARY", p);
+            }
+        }
+        if let Some(p) = prev_claude {
+            unsafe {
+                std::env::set_var("CLAUDE_PATH", p);
+            }
+        }
     }
 }

--- a/crates/surge-orchestrator/src/triage.rs
+++ b/crates/surge-orchestrator/src/triage.rs
@@ -522,4 +522,67 @@ mod tests {
             "system prompt should contain the actual instruction text; got: {extracted}"
         );
     }
+
+    #[test]
+    fn render_prompt_snapshot() {
+        use chrono::TimeZone;
+        let task = TaskDetails {
+            task_id: TaskId::try_new("github_issues:test/repo#42").unwrap(),
+            source_id: "github_issues:test/repo".into(),
+            title: "Add tracing to auth middleware".into(),
+            description: "We have no observability into the auth flow.".into(),
+            status: "open".into(),
+            labels: vec!["surge:enabled".into(), "area/auth".into()],
+            url: "https://github.com/test/repo/issues/42".into(),
+            created_at: chrono::Utc.with_ymd_and_hms(2026, 5, 1, 10, 0, 0).unwrap(),
+            updated_at: chrono::Utc.with_ymd_and_hms(2026, 5, 5, 12, 0, 0).unwrap(),
+            assignee: None,
+            raw_payload: serde_json::json!({}),
+        };
+        let candidates = vec![TaskSummary {
+            task_id: TaskId::try_new("github_issues:test/repo#10").unwrap(),
+            title: "Update README".into(),
+            status: "open".into(),
+            url: "https://github.com/test/repo/issues/10".into(),
+            updated_at: chrono::Utc.with_ymd_and_hms(2026, 4, 28, 9, 0, 0).unwrap(),
+        }];
+        let active_runs = vec![ActiveRunSummary {
+            run_id: "01HXX0000000000000000RUN1".into(),
+            task_id: Some("github_issues:test/repo#9".into()),
+            status: "Running".into(),
+            started_at: "2026-05-06T10:00:00Z".into(),
+        }];
+        let input = TriageInput {
+            task,
+            candidates,
+            active_runs,
+        };
+        let rendered = super::render_prompt(&input, None);
+        insta::assert_snapshot!("triage_initial_prompt", rendered);
+    }
+
+    #[test]
+    fn render_prompt_with_feedback_includes_feedback_block() {
+        let task = TaskDetails {
+            task_id: TaskId::try_new("github_issues:t/r#1").unwrap(),
+            source_id: "github_issues:t/r".into(),
+            title: "x".into(),
+            description: "y".into(),
+            status: "open".into(),
+            labels: vec![],
+            url: "https://x".into(),
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+            assignee: None,
+            raw_payload: serde_json::json!({}),
+        };
+        let input = TriageInput {
+            task,
+            candidates: vec![],
+            active_runs: vec![],
+        };
+        let rendered = super::render_prompt(&input, Some("previous attempt malformed JSON"));
+        assert!(rendered.contains("# Feedback from previous attempt"));
+        assert!(rendered.contains("previous attempt malformed JSON"));
+    }
 }

--- a/crates/surge-orchestrator/src/triage.rs
+++ b/crates/surge-orchestrator/src/triage.rs
@@ -7,7 +7,11 @@
 
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
+use std::sync::Arc;
 use std::time::Duration;
+use surge_acp::bridge::event::{BridgeEvent, SessionEndReason};
+use surge_acp::bridge::facade::BridgeFacade;
+use surge_core::{OutcomeKey, SessionId};
 use surge_intake::types::{Priority, TaskDetails, TaskId, TaskSummary, TriageDecision};
 
 /// Full input bundle handed to Triage Author at the start of its session.
@@ -147,6 +151,265 @@ pub enum TriageError {
     /// (open_session / send_message / close_session).
     #[error("acp bridge: {0}")]
     Bridge(String),
+}
+
+/// Bridge-level sandbox for sessions where Surge delegates isolation
+/// to the agent itself (per Vision-2026 §"Sandbox-delegated").
+///
+/// Returns `AlwaysAllowSandbox` — the bridge applies no tool filtering,
+/// because each ACP-conformant agent (Claude Code, Codex CLI, etc.)
+/// already has its own native sandbox enforcement. The profile's
+/// `[sandbox] mode = ...` field is a semantic marker the agent reads,
+/// not a directive the bridge enforces.
+fn delegated_sandbox() -> Box<dyn surge_acp::bridge::sandbox::Sandbox> {
+    Box::new(surge_acp::bridge::sandbox::AlwaysAllowSandbox)
+}
+
+fn event_session_id(event: &BridgeEvent) -> Option<SessionId> {
+    match event {
+        BridgeEvent::SessionEstablished { session, .. }
+        | BridgeEvent::AgentMessage { session, .. }
+        | BridgeEvent::TokenUsage { session, .. }
+        | BridgeEvent::ToolCall { session, .. }
+        | BridgeEvent::ToolResult { session, .. }
+        | BridgeEvent::OutcomeReported { session, .. }
+        | BridgeEvent::HumanInputRequested { session, .. }
+        | BridgeEvent::SessionEnded { session, .. } => Some(*session),
+        BridgeEvent::Error { session, .. } => *session,
+    }
+}
+
+/// Per-attempt error type — distinguishes retryable from fatal.
+enum AttemptError {
+    /// Bridge facade itself failed (open/send/close); fatal.
+    Bridge(String),
+    /// Retryable: timeout, agent crash, malformed artifact.
+    Retryable(String),
+}
+
+fn render_prompt(input: &TriageInput, feedback: Option<&str>) -> String {
+    let json = serde_json::to_string_pretty(input).unwrap_or_else(|_| "{}".into());
+    let mut out = String::new();
+    out.push_str(crate::BOOTSTRAP_TRIAGE_AUTHOR_TOML);
+    out.push_str("\n\n# Inputs\n\nThe triage input is encoded as JSON. The shape is:\n");
+    out.push_str("- task: TaskDetails\n- candidates: TaskSummary[]\n- active_runs: ActiveRunSummary[]\n\n");
+    out.push_str("The literal JSON follows:\n\n");
+    out.push_str(&json);
+    out.push_str("\n\n# Task\n\nDecide whether this ticket is a duplicate, out-of-scope, unclear, \
+                  or should be enqueued. Then, in your working directory:\n\n\
+                  1. Write your structured decision to `triage_decision.json` (schema below).\n\
+                  2. Write a 3-5 line markdown blurb to `inbox_summary.md` (used as the body of \
+                     the inbox card on `enqueued`; safe to omit otherwise).\n\
+                  3. Call `report_stage_outcome` with the matching `outcome` and \
+                     `artifacts_produced = [\"triage_decision.json\", \"inbox_summary.md\"]`.\n\n");
+    out.push_str("triage_decision.json schema:\n\
+                  - decision: \"enqueued\" | \"duplicate\" | \"out_of_scope\" | \"unclear\"\n\
+                  - duplicate_of: string (task id) or null\n\
+                  - priority: \"urgent\" | \"high\" | \"medium\" | \"low\"\n\
+                  - priority_reasoning: one sentence\n\
+                  - summary: one sentence\n\
+                  - question: string (only when decision = \"unclear\")\n");
+    if let Some(fb) = feedback {
+        out.push_str("\n# Feedback from previous attempt\n\n");
+        out.push_str(fb);
+        out.push('\n');
+    }
+    out
+}
+
+async fn try_one_attempt(
+    bridge: Arc<dyn BridgeFacade>,
+    input: &TriageInput,
+    claude_binary: &std::path::Path,
+    scratch_dir: &std::path::Path,
+    attempt_timeout: Duration,
+    attempt: u32,
+    feedback: Option<&str>,
+) -> Result<TriageDecision, AttemptError> {
+    use std::collections::BTreeMap;
+    use surge_acp::bridge::session::{AgentKind, MessageContent, SessionConfig};
+    use surge_acp::client::PermissionPolicy;
+
+    let prompt_text = render_prompt(input, feedback);
+
+    let declared_outcomes = vec![
+        OutcomeKey::try_from("enqueued").map_err(|e| AttemptError::Bridge(e.to_string()))?,
+        OutcomeKey::try_from("duplicate").map_err(|e| AttemptError::Bridge(e.to_string()))?,
+        OutcomeKey::try_from("out_of_scope").map_err(|e| AttemptError::Bridge(e.to_string()))?,
+        OutcomeKey::try_from("unclear").map_err(|e| AttemptError::Bridge(e.to_string()))?,
+    ];
+
+    let mut bindings = BTreeMap::new();
+    bindings.insert("intake.task_id".into(), input.task.task_id.as_str().to_string());
+    bindings.insert("intake.attempt".into(), attempt.to_string());
+
+    let cfg = SessionConfig {
+        agent_kind: AgentKind::ClaudeCode {
+            binary: claude_binary.to_path_buf(),
+            extra_args: vec![],
+        },
+        working_dir: scratch_dir.to_path_buf(),
+        system_prompt: prompt_text.clone(),
+        declared_outcomes,
+        allows_escalation: false,
+        tools: vec![],
+        sandbox: delegated_sandbox(),
+        permission_policy: PermissionPolicy::default(),
+        bindings,
+    };
+
+    let mut events = bridge.subscribe();
+
+    let session_id = bridge
+        .open_session(cfg)
+        .await
+        .map_err(|e| AttemptError::Bridge(format!("open_session: {e}")))?;
+
+    bridge
+        .send_message(session_id, MessageContent::Text(prompt_text))
+        .await
+        .map_err(|e| AttemptError::Bridge(format!("send_message: {e}")))?;
+
+    // Drive the event loop with a single timeout.
+    let outcome_result = tokio::time::timeout(attempt_timeout, async {
+        loop {
+            match events.recv().await {
+                Ok(ev) => {
+                    if event_session_id(&ev) != Some(session_id) {
+                        continue;
+                    }
+                    match ev {
+                        BridgeEvent::OutcomeReported { outcome, .. } => return Ok(outcome),
+                        BridgeEvent::SessionEnded { reason, .. } => match reason {
+                            SessionEndReason::AgentCrashed { .. } => {
+                                return Err(format!("agent crashed: {reason:?}"))
+                            }
+                            SessionEndReason::Timeout { .. } => {
+                                return Err("session timeout".into())
+                            }
+                            _ => continue,
+                        },
+                        _ => continue,
+                    }
+                }
+                Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => continue,
+                Err(tokio::sync::broadcast::error::RecvError::Closed) => {
+                    return Err("event stream closed".into())
+                }
+            }
+        }
+    })
+    .await;
+
+    let _ = bridge.close_session(session_id).await;
+
+    let outcome = match outcome_result {
+        Err(_elapsed) => return Err(AttemptError::Retryable("timeout".into())),
+        Ok(Err(msg)) => return Err(AttemptError::Retryable(msg)),
+        Ok(Ok(outcome)) => outcome,
+    };
+
+    // Read the artifact and parse.
+    let json_path = scratch_dir.join("triage_decision.json");
+    let raw = std::fs::read(&json_path)
+        .map_err(|e| AttemptError::Retryable(format!("triage_decision.json missing: {e}")))?;
+    let parsed: TriageJson = serde_json::from_slice(&raw)
+        .map_err(|e| AttemptError::Retryable(format!("triage_decision.json malformed: {e}")))?;
+    let mut decision = parsed
+        .into_decision()
+        .map_err(|e| AttemptError::Retryable(format!("decision rejected: {e}")))?;
+
+    // For Enqueued, splice in the inbox_summary.md if present.
+    if let TriageDecision::Enqueued { summary, .. } = &mut decision {
+        if summary.is_empty() {
+            if let Ok(md) = std::fs::read_to_string(scratch_dir.join("inbox_summary.md")) {
+                *summary = md;
+            }
+        }
+    }
+
+    // Sanity-check the agent's reported outcome string against the parsed decision.
+    let outcome_str = outcome.as_str();
+    let decision_kind = match &decision {
+        TriageDecision::Enqueued { .. } => "enqueued",
+        TriageDecision::Duplicate { .. } => "duplicate",
+        TriageDecision::OutOfScope { .. } => "out_of_scope",
+        TriageDecision::Unclear { .. } => "unclear",
+    };
+    if outcome_str != decision_kind {
+        return Err(AttemptError::Retryable(format!(
+            "outcome ({outcome_str}) mismatch with decision ({decision_kind})"
+        )));
+    }
+
+    Ok(decision)
+}
+
+/// Dispatch a Triage Author session against the supplied bridge.
+///
+/// Returns `Ok(TriageDecision)` even on retry exhaustion (materialises
+/// as `Unclear` with a diagnostic question). `Err(TriageError)` is
+/// reserved for invariant violations that prevent any forward progress.
+///
+/// # Errors
+/// - [`TriageError::Scratch`] if the per-call scratch directory
+///   cannot be created.
+/// - [`TriageError::Bridge`] for facade-level dead-bridge or
+///   handshake failures.
+pub async fn dispatch_triage(
+    bridge: Arc<dyn BridgeFacade>,
+    input: TriageInput,
+    opts: TriageOptions,
+) -> Result<TriageDecision, TriageError> {
+    // Short-circuit if claude binary is not configured.
+    let Some(claude_binary) = opts.claude_binary.clone() else {
+        return Ok(TriageDecision::Unclear {
+            question: "Claude binary not configured (set SURGE_CLAUDE_BINARY or install \
+                       claude-code); install to enable LLM-driven triage"
+                .into(),
+        });
+    };
+
+    // Build a fresh scratch dir for this top-level call.
+    let scratch_dir = opts.scratch_root.join(ulid::Ulid::new().to_string());
+    std::fs::create_dir_all(&scratch_dir)?;
+
+    let mut last_err: Option<String> = None;
+
+    for attempt in 1..=opts.max_attempts {
+        match try_one_attempt(
+            Arc::clone(&bridge),
+            &input,
+            &claude_binary,
+            &scratch_dir,
+            opts.attempt_timeout,
+            attempt,
+            last_err.as_deref(),
+        )
+        .await
+        {
+            Ok(decision) => {
+                if !opts.keep_scratch_on_failure
+                    && !matches!(decision, TriageDecision::Unclear { .. })
+                {
+                    let _ = std::fs::remove_dir_all(&scratch_dir);
+                }
+                return Ok(decision);
+            }
+            Err(AttemptError::Bridge(e)) => return Err(TriageError::Bridge(e)),
+            Err(AttemptError::Retryable(msg)) => {
+                tracing::warn!(attempt, error = %msg, "triage attempt failed; will retry");
+                last_err = Some(msg);
+            }
+        }
+    }
+
+    let question = format!(
+        "Triage failed after {} attempts: {}",
+        opts.max_attempts,
+        last_err.as_deref().unwrap_or("unknown error")
+    );
+    Ok(TriageDecision::Unclear { question })
 }
 
 #[cfg(test)]

--- a/crates/surge-orchestrator/src/triage.rs
+++ b/crates/surge-orchestrator/src/triage.rs
@@ -187,10 +187,31 @@ enum AttemptError {
     Retryable(String),
 }
 
+/// Extract just the `[prompt].system` field from the bundled Triage Author
+/// TOML profile, parsed once at first access.
+///
+/// We don't ship the whole TOML to Claude — only the natural-language
+/// instruction. The TOML's metadata (id, version, declared_outcomes, etc.)
+/// is bookkeeping for the engine, not content for the agent.
+fn triage_system_prompt() -> &'static str {
+    static CACHED: std::sync::LazyLock<String> = std::sync::LazyLock::new(|| {
+        let parsed: toml::Value = toml::from_str(crate::BOOTSTRAP_TRIAGE_AUTHOR_TOML).expect(
+            "bundled triage-author-1.0.toml is valid TOML — checked by bootstrap_profile_tests",
+        );
+        parsed
+            .get("prompt")
+            .and_then(|p| p.get("system"))
+            .and_then(|s| s.as_str())
+            .map(str::to_string)
+            .expect("triage-author-1.0.toml must have [prompt].system field — checked by bootstrap_profile_tests")
+    });
+    CACHED.as_str()
+}
+
 fn render_prompt(input: &TriageInput, feedback: Option<&str>) -> String {
     let json = serde_json::to_string_pretty(input).unwrap_or_else(|_| "{}".into());
     let mut out = String::new();
-    out.push_str(crate::BOOTSTRAP_TRIAGE_AUTHOR_TOML);
+    out.push_str(triage_system_prompt());
     out.push_str("\n\n# Inputs\n\nThe triage input is encoded as JSON. The shape is:\n");
     out.push_str(
         "- task: TaskDetails\n- candidates: TaskSummary[]\n- active_runs: ActiveRunSummary[]\n\n",
@@ -296,7 +317,9 @@ async fn try_one_attempt(
                             SessionEndReason::Timeout { .. } => {
                                 return Err("session timeout".into());
                             },
-                            _ => continue,
+                            SessionEndReason::Normal | SessionEndReason::ForcedClose => {
+                                return Err("session ended without outcome".into());
+                            },
                         },
                         _ => continue,
                     }
@@ -398,6 +421,10 @@ pub async fn dispatch_triage(
         .await
         {
             Ok(decision) => {
+                // Cleanup logic: remove scratch dir when we got a decisive outcome AND
+                // the caller didn't ask us to keep it. `Unclear` is treated as a non-decisive
+                // outcome (the agent expressed uncertainty), so we keep its artifacts for
+                // post-mortem regardless of `keep_scratch_on_failure`.
                 if !opts.keep_scratch_on_failure
                     && !matches!(decision, TriageDecision::Unclear { .. })
                 {
@@ -477,5 +504,22 @@ mod tests {
         let parsed: TriageJson = serde_json::from_str(raw).unwrap();
         let err = parsed.into_decision().unwrap_err();
         assert!(err.contains("unknown decision"));
+    }
+
+    #[test]
+    fn triage_system_prompt_extracts_only_prompt_section() {
+        let extracted = super::triage_system_prompt();
+        assert!(
+            !extracted.contains("declared_outcomes"),
+            "system prompt should not contain TOML metadata field"
+        );
+        assert!(
+            !extracted.contains("display_name"),
+            "system prompt should not contain TOML metadata field"
+        );
+        assert!(
+            extracted.contains("triage incoming tickets"),
+            "system prompt should contain the actual instruction text; got: {extracted}"
+        );
     }
 }

--- a/crates/surge-orchestrator/src/triage.rs
+++ b/crates/surge-orchestrator/src/triage.rs
@@ -1,9 +1,18 @@
-//! Triage Author dispatcher: assembles inputs, parses LLM output.
+//! Triage Author dispatcher: assembles inputs, dispatches via ACP,
+//! parses LLM output.
 //!
-//! This module owns the input/output schema for the bootstrap-stage 0
-//! Triage Author. The actual agent invocation (LLM call via ACP) will
-//! be wired in a follow-up polish task; for now this module provides
-//! the typed interface.
+//! Layer 1 of the two-layer plan in
+//! `docs/superpowers/specs/2026-05-06-triage-author-llm-dispatch-design.md`:
+//! standalone [`dispatch_triage`] function that opens an ACP session
+//! against the bundled `_bootstrap/triage-author@1.0` profile, sends
+//! a structured input, awaits the agent's `triage_decision.json`
+//! artifact, and returns a typed [`TriageDecision`].
+//!
+//! Layer 2 (separate RFC, deferred) will promote Triage Author to a
+//! first-class [`NodeKind::Agent`] inside the engine state machine.
+//! When that lands, [`dispatch_triage`]'s caller-visible surface
+//! does not change — the function is either inlined into the
+//! engine's stage handler or kept as a thin test wrapper.
 
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
@@ -42,7 +51,7 @@ pub struct ActiveRunSummary {
 /// `Option`/`#[serde(default)]`) so we can normalise into the strict
 /// [`TriageDecision`] enum via [`Self::into_decision`].
 #[derive(Debug, Clone, Deserialize)]
-pub struct TriageJson {
+pub(crate) struct TriageJson {
     pub decision: String,
     #[serde(default)]
     pub duplicate_of: Option<String>,
@@ -62,7 +71,7 @@ impl TriageJson {
     /// Returns `Err(message)` if required fields for the chosen decision
     /// are missing (e.g. `duplicate` without `duplicate_of`) or the
     /// decision/priority strings are unrecognised.
-    pub fn into_decision(self) -> Result<TriageDecision, String> {
+    pub(crate) fn into_decision(self) -> Result<TriageDecision, String> {
         let prio_str = self.priority.as_deref().unwrap_or("medium");
         let priority = match prio_str {
             "urgent" => Priority::Urgent,
@@ -105,6 +114,7 @@ impl TriageJson {
 /// Construct via [`Self::with_scratch_root`] for the typical case of
 /// passing only the per-task scratch root and Claude binary path.
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub struct TriageOptions {
     /// Resolved Claude binary path. If `None`, the dispatcher
     /// returns `Ok(TriageDecision::Unclear)` immediately on the
@@ -361,6 +371,10 @@ async fn try_one_attempt(
                         _ => continue,
                     }
                 },
+                // Lagged means the broadcast queue dropped events we didn't consume
+                // fast enough. We hold a session filter, so a missed OutcomeReported
+                // for our session would eventually trigger the attempt timeout and
+                // cause a retry — correctness is preserved at the cost of latency.
                 Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => continue,
                 Err(tokio::sync::broadcast::error::RecvError::Closed) => {
                     return Err("event stream closed".into());

--- a/crates/surge-orchestrator/src/triage.rs
+++ b/crates/surge-orchestrator/src/triage.rs
@@ -192,23 +192,29 @@ fn render_prompt(input: &TriageInput, feedback: Option<&str>) -> String {
     let mut out = String::new();
     out.push_str(crate::BOOTSTRAP_TRIAGE_AUTHOR_TOML);
     out.push_str("\n\n# Inputs\n\nThe triage input is encoded as JSON. The shape is:\n");
-    out.push_str("- task: TaskDetails\n- candidates: TaskSummary[]\n- active_runs: ActiveRunSummary[]\n\n");
+    out.push_str(
+        "- task: TaskDetails\n- candidates: TaskSummary[]\n- active_runs: ActiveRunSummary[]\n\n",
+    );
     out.push_str("The literal JSON follows:\n\n");
     out.push_str(&json);
-    out.push_str("\n\n# Task\n\nDecide whether this ticket is a duplicate, out-of-scope, unclear, \
+    out.push_str(
+        "\n\n# Task\n\nDecide whether this ticket is a duplicate, out-of-scope, unclear, \
                   or should be enqueued. Then, in your working directory:\n\n\
                   1. Write your structured decision to `triage_decision.json` (schema below).\n\
                   2. Write a 3-5 line markdown blurb to `inbox_summary.md` (used as the body of \
                      the inbox card on `enqueued`; safe to omit otherwise).\n\
                   3. Call `report_stage_outcome` with the matching `outcome` and \
-                     `artifacts_produced = [\"triage_decision.json\", \"inbox_summary.md\"]`.\n\n");
-    out.push_str("triage_decision.json schema:\n\
+                     `artifacts_produced = [\"triage_decision.json\", \"inbox_summary.md\"]`.\n\n",
+    );
+    out.push_str(
+        "triage_decision.json schema:\n\
                   - decision: \"enqueued\" | \"duplicate\" | \"out_of_scope\" | \"unclear\"\n\
                   - duplicate_of: string (task id) or null\n\
                   - priority: \"urgent\" | \"high\" | \"medium\" | \"low\"\n\
                   - priority_reasoning: one sentence\n\
                   - summary: one sentence\n\
-                  - question: string (only when decision = \"unclear\")\n");
+                  - question: string (only when decision = \"unclear\")\n",
+    );
     if let Some(fb) = feedback {
         out.push_str("\n# Feedback from previous attempt\n\n");
         out.push_str(fb);
@@ -240,7 +246,10 @@ async fn try_one_attempt(
     ];
 
     let mut bindings = BTreeMap::new();
-    bindings.insert("intake.task_id".into(), input.task.task_id.as_str().to_string());
+    bindings.insert(
+        "intake.task_id".into(),
+        input.task.task_id.as_str().to_string(),
+    );
     bindings.insert("intake.attempt".into(), attempt.to_string());
 
     let cfg = SessionConfig {
@@ -282,20 +291,20 @@ async fn try_one_attempt(
                         BridgeEvent::OutcomeReported { outcome, .. } => return Ok(outcome),
                         BridgeEvent::SessionEnded { reason, .. } => match reason {
                             SessionEndReason::AgentCrashed { .. } => {
-                                return Err(format!("agent crashed: {reason:?}"))
-                            }
+                                return Err(format!("agent crashed: {reason:?}"));
+                            },
                             SessionEndReason::Timeout { .. } => {
-                                return Err("session timeout".into())
-                            }
+                                return Err("session timeout".into());
+                            },
                             _ => continue,
                         },
                         _ => continue,
                     }
-                }
+                },
                 Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => continue,
                 Err(tokio::sync::broadcast::error::RecvError::Closed) => {
-                    return Err("event stream closed".into())
-                }
+                    return Err("event stream closed".into());
+                },
             }
         }
     })
@@ -395,12 +404,12 @@ pub async fn dispatch_triage(
                     let _ = std::fs::remove_dir_all(&scratch_dir);
                 }
                 return Ok(decision);
-            }
+            },
             Err(AttemptError::Bridge(e)) => return Err(TriageError::Bridge(e)),
             Err(AttemptError::Retryable(msg)) => {
                 tracing::warn!(attempt, error = %msg, "triage attempt failed; will retry");
                 last_err = Some(msg);
-            }
+            },
         }
     }
 

--- a/crates/surge-orchestrator/src/triage.rs
+++ b/crates/surge-orchestrator/src/triage.rs
@@ -6,6 +6,8 @@
 //! the typed interface.
 
 use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+use std::time::Duration;
 use surge_intake::types::{Priority, TaskDetails, TaskId, TaskSummary, TriageDecision};
 
 /// Full input bundle handed to Triage Author at the start of its session.
@@ -92,6 +94,59 @@ impl TriageJson {
             other => Err(format!("unknown decision: {other}")),
         }
     }
+}
+
+/// Tunable parameters for [`dispatch_triage`].
+///
+/// Construct via [`Self::with_scratch_root`] for the typical case of
+/// passing only the per-task scratch root and Claude binary path.
+#[derive(Debug, Clone)]
+pub struct TriageOptions {
+    /// Resolved Claude binary path. If `None`, the dispatcher
+    /// returns `Ok(TriageDecision::Unclear)` immediately on the
+    /// first attempt with a configuration-hint message.
+    pub claude_binary: Option<PathBuf>,
+    /// Per-attempt timeout. Default: 5 min (matches RFC-0010 §"Bootstrap stage failures").
+    pub attempt_timeout: Duration,
+    /// Maximum attempts before falling back to `Unclear`. Default: 3.
+    pub max_attempts: u32,
+    /// Root directory for per-call scratch dirs.
+    pub scratch_root: PathBuf,
+    /// Whether to keep scratch on Unclear / TriageError for post-mortem.
+    pub keep_scratch_on_failure: bool,
+}
+
+impl TriageOptions {
+    /// Build options with sensible defaults given a scratch root and
+    /// (optional) Claude binary path.
+    #[must_use]
+    pub fn with_scratch_root(scratch_root: PathBuf, claude_binary: Option<PathBuf>) -> Self {
+        Self {
+            claude_binary,
+            attempt_timeout: Duration::from_secs(300),
+            max_attempts: 3,
+            scratch_root,
+            keep_scratch_on_failure: true,
+        }
+    }
+}
+
+/// Errors returned from [`dispatch_triage`] for invariant violations.
+///
+/// Note: retry-eligible failures (timeout, agent crash, malformed JSON)
+/// are NOT surfaced as `TriageError` — they retry up to
+/// `opts.max_attempts` times and on exhaustion become
+/// `Ok(TriageDecision::Unclear { question })`. `TriageError` is
+/// reserved for failures that prevent any forward progress.
+#[derive(Debug, thiserror::Error)]
+pub enum TriageError {
+    /// Could not create or write to the per-call scratch directory.
+    #[error("scratch dir setup failed: {0}")]
+    Scratch(#[from] std::io::Error),
+    /// Bridge facade itself failed at the JSON-RPC / process level
+    /// (open_session / send_message / close_session).
+    #[error("acp bridge: {0}")]
+    Bridge(String),
 }
 
 #[cfg(test)]

--- a/crates/surge-orchestrator/src/triage.rs
+++ b/crates/surge-orchestrator/src/triage.rs
@@ -163,14 +163,6 @@ pub enum TriageError {
     Bridge(String),
 }
 
-/// Bridge-level sandbox for sessions where Surge delegates isolation
-/// to the agent itself (per Vision-2026 §"Sandbox-delegated").
-///
-/// Returns `AlwaysAllowSandbox` — the bridge applies no tool filtering,
-/// because each ACP-conformant agent (Claude Code, Codex CLI, etc.)
-/// already has its own native sandbox enforcement. The profile's
-/// `[sandbox] mode = ...` field is a semantic marker the agent reads,
-/// not a directive the bridge enforces.
 /// Best-effort discovery of the Claude binary path.
 ///
 /// Probe order:
@@ -208,6 +200,14 @@ pub fn find_claude_binary() -> Option<PathBuf> {
     None
 }
 
+/// Bridge-level sandbox for sessions where Surge delegates isolation
+/// to the agent itself (per Vision-2026 §"Sandbox-delegated").
+///
+/// Returns `AlwaysAllowSandbox` — the bridge applies no tool filtering,
+/// because each ACP-conformant agent (Claude Code, Codex CLI, etc.)
+/// already has its own native sandbox enforcement. The profile's
+/// `[sandbox] mode = ...` field is a semantic marker the agent reads,
+/// not a directive the bridge enforces.
 fn delegated_sandbox() -> Box<dyn surge_acp::bridge::sandbox::Sandbox> {
     Box::new(surge_acp::bridge::sandbox::AlwaysAllowSandbox)
 }
@@ -472,18 +472,26 @@ pub async fn dispatch_triage(
         .await
         {
             Ok(decision) => {
-                // Cleanup logic: remove scratch dir when we got a decisive outcome AND
-                // the caller didn't ask us to keep it. `Unclear` is treated as a non-decisive
-                // outcome (the agent expressed uncertainty), so we keep its artifacts for
-                // post-mortem regardless of `keep_scratch_on_failure`.
-                if !opts.keep_scratch_on_failure
-                    && !matches!(decision, TriageDecision::Unclear { .. })
-                {
+                // Cleanup policy:
+                // - Decisive success (Enqueued / Duplicate / OutOfScope): always
+                //   remove scratch (best-effort) so the per-call dir doesn't leak.
+                // - Unclear (agent-reported): keep iff `keep_scratch_on_failure`,
+                //   otherwise remove. Unclear is non-decisive — the operator may
+                //   want the artifacts for post-mortem.
+                let is_unclear = matches!(decision, TriageDecision::Unclear { .. });
+                if !is_unclear || !opts.keep_scratch_on_failure {
                     let _ = std::fs::remove_dir_all(&scratch_dir);
                 }
                 return Ok(decision);
             },
-            Err(AttemptError::Bridge(e)) => return Err(TriageError::Bridge(e)),
+            Err(AttemptError::Bridge(e)) => {
+                // Bridge invariant failure — keep scratch for post-mortem when
+                // the caller asked us to.
+                if !opts.keep_scratch_on_failure {
+                    let _ = std::fs::remove_dir_all(&scratch_dir);
+                }
+                return Err(TriageError::Bridge(e));
+            },
             Err(AttemptError::Retryable(msg)) => {
                 tracing::warn!(attempt, error = %msg, "triage attempt failed; will retry");
                 last_err = Some(msg);
@@ -491,6 +499,11 @@ pub async fn dispatch_triage(
         }
     }
 
+    // Retry exhaustion → synthetic Unclear. Same cleanup rule as agent-reported
+    // Unclear: keep artifacts iff `keep_scratch_on_failure`.
+    if !opts.keep_scratch_on_failure {
+        let _ = std::fs::remove_dir_all(&scratch_dir);
+    }
     let question = format!(
         "Triage failed after {} attempts: {}",
         opts.max_attempts,

--- a/crates/surge-orchestrator/tests/fixtures/mock_bridge.rs
+++ b/crates/surge-orchestrator/tests/fixtures/mock_bridge.rs
@@ -43,8 +43,9 @@ pub struct MockBridge {
     pub recorded_calls: Arc<Mutex<Vec<RecordedCall>>>,
     /// Broadcast channel.
     tx: broadcast::Sender<BridgeEvent>,
-    /// When set, `open_session` returns this id and clears it.
-    pinned_session_id: Mutex<Option<SessionId>>,
+    /// Queue of SessionIds to return from `open_session` calls.
+    /// When empty, `open_session` generates a fresh `SessionId::new()`.
+    pinned_session_ids: Mutex<VecDeque<SessionId>>,
 }
 
 impl MockBridge {
@@ -54,15 +55,25 @@ impl MockBridge {
             scripted_events: Mutex::new(VecDeque::new()),
             recorded_calls: Arc::new(Mutex::new(Vec::new())),
             tx,
-            pinned_session_id: Mutex::new(None),
+            pinned_session_ids: Mutex::new(VecDeque::new()),
         }
     }
 
     /// Pin the `SessionId` that the next `open_session` call will return.
-    /// The id is consumed (cleared) after one use.
+    /// The id is consumed (popped) after one use. Multiple calls queue them.
     #[allow(dead_code)]
     pub async fn pin_next_session_id(&self, id: SessionId) {
-        *self.pinned_session_id.lock().await = Some(id);
+        self.pinned_session_ids.lock().await.push_back(id);
+    }
+
+    /// Pin a sequence of `SessionId`s to be returned by successive `open_session` calls.
+    /// Ids are consumed (popped from the queue) in order.
+    #[allow(dead_code)]
+    pub async fn pin_session_ids(&self, ids: Vec<SessionId>) {
+        let mut q = self.pinned_session_ids.lock().await;
+        for id in ids {
+            q.push_back(id);
+        }
     }
 
     /// Queue an event to be broadcast on the next `pump_scripted_events()`.
@@ -95,8 +106,13 @@ impl BridgeFacade for MockBridge {
             .lock()
             .await
             .push(RecordedCall::OpenSession);
-        let pinned = self.pinned_session_id.lock().await.take();
-        Ok(pinned.unwrap_or_else(SessionId::new))
+        let id = self
+            .pinned_session_ids
+            .lock()
+            .await
+            .pop_front()
+            .unwrap_or_else(SessionId::new);
+        Ok(id)
     }
 
     async fn send_message(

--- a/crates/surge-orchestrator/tests/triage_dispatch.rs
+++ b/crates/surge-orchestrator/tests/triage_dispatch.rs
@@ -11,7 +11,7 @@ use surge_acp::bridge::event::BridgeEvent;
 use surge_acp::bridge::facade::BridgeFacade;
 use surge_core::{OutcomeKey, SessionId};
 use surge_intake::types::{Priority, TaskDetails, TaskId, TriageDecision};
-use surge_orchestrator::triage::{dispatch_triage, TriageInput, TriageOptions};
+use surge_orchestrator::triage::{TriageInput, TriageOptions, dispatch_triage};
 use tempfile::TempDir;
 
 fn task_details(id: &str) -> TaskDetails {
@@ -84,20 +84,16 @@ async fn enqueued_happy_path() {
         bridge_for_drive.pump_scripted_events().await;
     });
 
-    let result = dispatch_triage(
-        Arc::clone(&bridge) as Arc<dyn BridgeFacade>,
-        input(),
-        opts,
-    )
-    .await
-    .expect("dispatch_triage should succeed");
+    let result = dispatch_triage(Arc::clone(&bridge) as Arc<dyn BridgeFacade>, input(), opts)
+        .await
+        .expect("dispatch_triage should succeed");
 
     drive.await.unwrap();
 
     match result {
         TriageDecision::Enqueued { priority, .. } => {
             assert_eq!(priority, Priority::High);
-        }
+        },
         other => panic!("expected Enqueued, got {other:?}"),
     }
 }

--- a/crates/surge-orchestrator/tests/triage_dispatch.rs
+++ b/crates/surge-orchestrator/tests/triage_dispatch.rs
@@ -38,6 +38,40 @@ fn input() -> TriageInput {
     }
 }
 
+/// Reusable drive task: sleep, find the scratch sub-dir, write the
+/// supplied JSON (and optional summary), enqueue an OutcomeReported
+/// matching `outcome_key`, then pump events.
+async fn drive_one_attempt(
+    bridge: Arc<fixtures::mock_bridge::MockBridge>,
+    scratch_root: std::path::PathBuf,
+    session: SessionId,
+    outcome_key: &'static str,
+    decision_json: &'static str,
+    summary_md: &'static str,
+) {
+    tokio::time::sleep(Duration::from_millis(80)).await;
+    let scratch = std::fs::read_dir(&scratch_root)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .find(|e| e.file_type().map(|t| t.is_dir()).unwrap_or(false))
+        .expect("dispatcher should have created scratch subdir")
+        .path();
+
+    std::fs::write(scratch.join("triage_decision.json"), decision_json).unwrap();
+    if !summary_md.is_empty() {
+        std::fs::write(scratch.join("inbox_summary.md"), summary_md).unwrap();
+    }
+    bridge
+        .enqueue_event(BridgeEvent::OutcomeReported {
+            session,
+            outcome: OutcomeKey::from_str(outcome_key).unwrap(),
+            summary: format!("agent picked {outcome_key}"),
+            artifacts_produced: vec!["triage_decision.json".into(), "inbox_summary.md".into()],
+        })
+        .await;
+    bridge.pump_scripted_events().await;
+}
+
 #[tokio::test]
 async fn enqueued_happy_path() {
     let bridge = Arc::new(fixtures::mock_bridge::MockBridge::new());
@@ -53,36 +87,14 @@ async fn enqueued_happy_path() {
         keep_scratch_on_failure: false,
     };
 
-    // Drive task: wait for dispatcher to subscribe + create scratch dir,
-    // then write artifact and emit OutcomeReported.
-    let scratch_root = tmp.path().to_path_buf();
-    let bridge_for_drive = Arc::clone(&bridge);
-    let drive = tokio::spawn(async move {
-        // Sleep enough for dispatcher to call subscribe() + open_session() + send_message().
-        // The mock open_session is synchronous returning the pinned id, so 80ms is plenty.
-        tokio::time::sleep(Duration::from_millis(80)).await;
-
-        let scratch = std::fs::read_dir(&scratch_root)
-            .unwrap()
-            .filter_map(|e| e.ok())
-            .find(|e| e.file_type().map(|t| t.is_dir()).unwrap_or(false))
-            .expect("dispatcher should have created scratch subdir")
-            .path();
-
-        let decision = r#"{"decision":"enqueued","priority":"high","priority_reasoning":"prod crash","summary":"Fix panic"}"#;
-        let summary = "## Fix parser panic\n\nStack overflow at depth 16.";
-        std::fs::write(scratch.join("triage_decision.json"), decision).unwrap();
-        std::fs::write(scratch.join("inbox_summary.md"), summary).unwrap();
-        bridge_for_drive
-            .enqueue_event(BridgeEvent::OutcomeReported {
-                session,
-                outcome: OutcomeKey::from_str("enqueued").unwrap(),
-                summary: "agent picked enqueued".into(),
-                artifacts_produced: vec!["triage_decision.json".into(), "inbox_summary.md".into()],
-            })
-            .await;
-        bridge_for_drive.pump_scripted_events().await;
-    });
+    let drive = tokio::spawn(drive_one_attempt(
+        Arc::clone(&bridge),
+        tmp.path().to_path_buf(),
+        session,
+        "enqueued",
+        r#"{"decision":"enqueued","priority":"high","priority_reasoning":"prod crash","summary":"Fix panic"}"#,
+        "## Fix parser panic\n\nStack overflow at depth 16.",
+    ));
 
     let result = dispatch_triage(Arc::clone(&bridge) as Arc<dyn BridgeFacade>, input(), opts)
         .await
@@ -95,5 +107,111 @@ async fn enqueued_happy_path() {
             assert_eq!(priority, Priority::High);
         },
         other => panic!("expected Enqueued, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn duplicate_happy_path() {
+    let bridge = Arc::new(fixtures::mock_bridge::MockBridge::new());
+    let session = SessionId::new();
+    bridge.pin_next_session_id(session).await;
+
+    let tmp = TempDir::new().unwrap();
+    let opts = TriageOptions {
+        claude_binary: Some(std::path::PathBuf::from("/dev/null")),
+        attempt_timeout: Duration::from_secs(2),
+        max_attempts: 1,
+        scratch_root: tmp.path().to_path_buf(),
+        keep_scratch_on_failure: false,
+    };
+
+    let drive = tokio::spawn(drive_one_attempt(
+        Arc::clone(&bridge),
+        tmp.path().to_path_buf(),
+        session,
+        "duplicate",
+        r#"{"decision":"duplicate","duplicate_of":"mock:t#42","priority":"high","priority_reasoning":"same code path"}"#,
+        "",
+    ));
+
+    let result = dispatch_triage(Arc::clone(&bridge) as Arc<dyn BridgeFacade>, input(), opts)
+        .await
+        .unwrap();
+    drive.await.unwrap();
+
+    match result {
+        TriageDecision::Duplicate { of, .. } => {
+            assert_eq!(of.as_str(), "mock:t#42");
+        },
+        other => panic!("expected Duplicate, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn out_of_scope_happy_path() {
+    let bridge = Arc::new(fixtures::mock_bridge::MockBridge::new());
+    let session = SessionId::new();
+    bridge.pin_next_session_id(session).await;
+
+    let tmp = TempDir::new().unwrap();
+    let opts = TriageOptions {
+        claude_binary: Some(std::path::PathBuf::from("/dev/null")),
+        attempt_timeout: Duration::from_secs(2),
+        max_attempts: 1,
+        scratch_root: tmp.path().to_path_buf(),
+        keep_scratch_on_failure: false,
+    };
+
+    let drive = tokio::spawn(drive_one_attempt(
+        Arc::clone(&bridge),
+        tmp.path().to_path_buf(),
+        session,
+        "out_of_scope",
+        r#"{"decision":"out_of_scope","priority":"low","priority_reasoning":"hiring task"}"#,
+        "",
+    ));
+
+    let result = dispatch_triage(Arc::clone(&bridge) as Arc<dyn BridgeFacade>, input(), opts)
+        .await
+        .unwrap();
+    drive.await.unwrap();
+
+    assert!(matches!(result, TriageDecision::OutOfScope { .. }));
+}
+
+#[tokio::test]
+async fn unclear_happy_path() {
+    let bridge = Arc::new(fixtures::mock_bridge::MockBridge::new());
+    let session = SessionId::new();
+    bridge.pin_next_session_id(session).await;
+
+    let tmp = TempDir::new().unwrap();
+    let opts = TriageOptions {
+        claude_binary: Some(std::path::PathBuf::from("/dev/null")),
+        attempt_timeout: Duration::from_secs(2),
+        max_attempts: 1,
+        scratch_root: tmp.path().to_path_buf(),
+        keep_scratch_on_failure: false,
+    };
+
+    let drive = tokio::spawn(drive_one_attempt(
+        Arc::clone(&bridge),
+        tmp.path().to_path_buf(),
+        session,
+        "unclear",
+        r#"{"decision":"unclear","priority":"medium","question":"What does X mean here?"}"#,
+        "",
+    ));
+
+    let result = dispatch_triage(Arc::clone(&bridge) as Arc<dyn BridgeFacade>, input(), opts)
+        .await
+        .unwrap();
+    drive.await.unwrap();
+
+    match result {
+        TriageDecision::Unclear { question } => {
+            assert!(question.contains("What does X mean here"));
+        },
+        other => panic!("expected Unclear, got {other:?}"),
     }
 }

--- a/crates/surge-orchestrator/tests/triage_dispatch.rs
+++ b/crates/surge-orchestrator/tests/triage_dispatch.rs
@@ -72,6 +72,41 @@ async fn drive_one_attempt(
     bridge.pump_scripted_events().await;
 }
 
+/// Drive multiple sequential attempts. The dispatcher reuses the same
+/// scratch dir across retries (per spec), so we don't need to find a
+/// new sub-dir each time — just overwrite `triage_decision.json` and
+/// emit a fresh `OutcomeReported` per attempt.
+async fn drive_n_attempts(
+    bridge: Arc<fixtures::mock_bridge::MockBridge>,
+    scratch_root: std::path::PathBuf,
+    sessions: Vec<SessionId>,
+    outcomes_and_artifacts: Vec<(&'static str, &'static str)>,
+) {
+    assert_eq!(sessions.len(), outcomes_and_artifacts.len());
+    for (i, (outcome_key, decision_json)) in outcomes_and_artifacts.iter().enumerate() {
+        // Wait for the dispatcher to (re)create scratch and (re)open session.
+        // First attempt: dispatcher creates the per-call scratch sub-dir.
+        // Later attempts: scratch dir already exists, dispatcher opens new session.
+        tokio::time::sleep(Duration::from_millis(80)).await;
+        let scratch = std::fs::read_dir(&scratch_root)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .find(|e| e.file_type().map(|t| t.is_dir()).unwrap_or(false))
+            .expect("dispatcher created scratch subdir")
+            .path();
+        std::fs::write(scratch.join("triage_decision.json"), decision_json).unwrap();
+        bridge
+            .enqueue_event(BridgeEvent::OutcomeReported {
+                session: sessions[i],
+                outcome: OutcomeKey::from_str(outcome_key).unwrap(),
+                summary: format!("attempt {} → {outcome_key}", i + 1),
+                artifacts_produced: vec!["triage_decision.json".into()],
+            })
+            .await;
+        bridge.pump_scripted_events().await;
+    }
+}
+
 #[tokio::test]
 async fn enqueued_happy_path() {
     let bridge = Arc::new(fixtures::mock_bridge::MockBridge::new());
@@ -211,6 +246,87 @@ async fn unclear_happy_path() {
     match result {
         TriageDecision::Unclear { question } => {
             assert!(question.contains("What does X mean here"));
+        },
+        other => panic!("expected Unclear, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn bad_json_then_recovers() {
+    let bridge = Arc::new(fixtures::mock_bridge::MockBridge::new());
+    let session_a = SessionId::new();
+    let session_b = SessionId::new();
+    bridge.pin_session_ids(vec![session_a, session_b]).await;
+
+    let tmp = TempDir::new().unwrap();
+    let opts = TriageOptions {
+        claude_binary: Some(std::path::PathBuf::from("/dev/null")),
+        attempt_timeout: Duration::from_secs(2),
+        max_attempts: 3,
+        scratch_root: tmp.path().to_path_buf(),
+        keep_scratch_on_failure: false,
+    };
+
+    let drive = tokio::spawn(drive_n_attempts(
+        Arc::clone(&bridge),
+        tmp.path().to_path_buf(),
+        vec![session_a, session_b],
+        vec![
+            ("enqueued", "{ this is not valid json"),
+            (
+                "enqueued",
+                r#"{"decision":"enqueued","priority":"medium","priority_reasoning":"ok","summary":"fixed"}"#,
+            ),
+        ],
+    ));
+
+    let result = dispatch_triage(Arc::clone(&bridge) as Arc<dyn BridgeFacade>, input(), opts)
+        .await
+        .unwrap();
+    drive.await.unwrap();
+
+    assert!(matches!(result, TriageDecision::Enqueued { .. }));
+}
+
+#[tokio::test]
+async fn exhaust_retries_yields_unclear() {
+    let bridge = Arc::new(fixtures::mock_bridge::MockBridge::new());
+    let s1 = SessionId::new();
+    let s2 = SessionId::new();
+    let s3 = SessionId::new();
+    bridge.pin_session_ids(vec![s1, s2, s3]).await;
+
+    let tmp = TempDir::new().unwrap();
+    let opts = TriageOptions {
+        claude_binary: Some(std::path::PathBuf::from("/dev/null")),
+        attempt_timeout: Duration::from_secs(2),
+        max_attempts: 3,
+        scratch_root: tmp.path().to_path_buf(),
+        keep_scratch_on_failure: true,
+    };
+
+    let drive = tokio::spawn(drive_n_attempts(
+        Arc::clone(&bridge),
+        tmp.path().to_path_buf(),
+        vec![s1, s2, s3],
+        vec![
+            ("enqueued", "{ bad 1"),
+            ("enqueued", "{ bad 2"),
+            ("enqueued", "{ bad 3"),
+        ],
+    ));
+
+    let result = dispatch_triage(Arc::clone(&bridge) as Arc<dyn BridgeFacade>, input(), opts)
+        .await
+        .unwrap();
+    drive.await.unwrap();
+
+    match result {
+        TriageDecision::Unclear { question } => {
+            assert!(
+                question.contains("Triage failed after 3 attempts"),
+                "expected diagnostic text in question, got: {question}"
+            );
         },
         other => panic!("expected Unclear, got {other:?}"),
     }

--- a/crates/surge-orchestrator/tests/triage_dispatch.rs
+++ b/crates/surge-orchestrator/tests/triage_dispatch.rs
@@ -7,7 +7,7 @@ use chrono::Utc;
 use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;
-use surge_acp::bridge::event::BridgeEvent;
+use surge_acp::bridge::event::{BridgeEvent, SessionEndReason};
 use surge_acp::bridge::facade::BridgeFacade;
 use surge_core::{OutcomeKey, SessionId};
 use surge_intake::types::{Priority, TaskDetails, TaskId, TriageDecision};
@@ -330,4 +330,117 @@ async fn exhaust_retries_yields_unclear() {
         },
         other => panic!("expected Unclear, got {other:?}"),
     }
+}
+
+#[tokio::test]
+async fn timeout_yields_unclear() {
+    let bridge = Arc::new(fixtures::mock_bridge::MockBridge::new());
+    let s = SessionId::new();
+    bridge.pin_session_ids(vec![s]).await;
+
+    let tmp = TempDir::new().unwrap();
+    let opts = TriageOptions {
+        claude_binary: Some(std::path::PathBuf::from("/dev/null")),
+        attempt_timeout: Duration::from_millis(150),
+        max_attempts: 1,
+        scratch_root: tmp.path().to_path_buf(),
+        keep_scratch_on_failure: true,
+    };
+
+    // No drive task — bridge never emits OutcomeReported, so the
+    // dispatcher hits its tokio::time::timeout.
+    let result = dispatch_triage(Arc::clone(&bridge) as Arc<dyn BridgeFacade>, input(), opts)
+        .await
+        .unwrap();
+
+    match result {
+        TriageDecision::Unclear { question } => {
+            assert!(
+                question.contains("timeout"),
+                "expected 'timeout' in diagnostic, got: {question}"
+            );
+        },
+        other => panic!("expected Unclear, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn agent_crashed_yields_unclear() {
+    let bridge = Arc::new(fixtures::mock_bridge::MockBridge::new());
+    let s = SessionId::new();
+    bridge.pin_session_ids(vec![s]).await;
+
+    let tmp = TempDir::new().unwrap();
+    let opts = TriageOptions {
+        claude_binary: Some(std::path::PathBuf::from("/dev/null")),
+        attempt_timeout: Duration::from_secs(2),
+        max_attempts: 1,
+        scratch_root: tmp.path().to_path_buf(),
+        keep_scratch_on_failure: true,
+    };
+
+    let drive = {
+        let bridge = Arc::clone(&bridge);
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(80)).await;
+            bridge
+                .enqueue_event(BridgeEvent::SessionEnded {
+                    session: s,
+                    reason: SessionEndReason::AgentCrashed {
+                        exit_code: Some(137),
+                        stderr_tail: "killed".into(),
+                    },
+                })
+                .await;
+            bridge.pump_scripted_events().await;
+        })
+    };
+
+    let result = dispatch_triage(Arc::clone(&bridge) as Arc<dyn BridgeFacade>, input(), opts)
+        .await
+        .unwrap();
+    drive.await.unwrap();
+
+    match result {
+        TriageDecision::Unclear { question } => {
+            assert!(
+                question.contains("agent crashed") || question.contains("AgentCrashed"),
+                "expected 'agent crashed' in diagnostic, got: {question}"
+            );
+        },
+        other => panic!("expected Unclear, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn binary_missing_short_circuits() {
+    let bridge = Arc::new(fixtures::mock_bridge::MockBridge::new());
+
+    let tmp = TempDir::new().unwrap();
+    let opts = TriageOptions {
+        claude_binary: None, // explicit
+        attempt_timeout: Duration::from_secs(5),
+        max_attempts: 3,
+        scratch_root: tmp.path().to_path_buf(),
+        keep_scratch_on_failure: false,
+    };
+
+    let result = dispatch_triage(Arc::clone(&bridge) as Arc<dyn BridgeFacade>, input(), opts)
+        .await
+        .unwrap();
+
+    match &result {
+        TriageDecision::Unclear { question } => {
+            assert!(
+                question.to_lowercase().contains("claude binary"),
+                "expected 'claude binary' in hint, got: {question}"
+            );
+        },
+        other => panic!("expected Unclear, got {other:?}"),
+    }
+
+    // The bridge should NEVER have been called — the function returned
+    // before any open_session.
+    let calls = bridge.recorded_calls.lock().await;
+    assert!(calls.is_empty(), "no bridge calls expected, got {calls:?}");
 }

--- a/crates/surge-orchestrator/tests/triage_dispatch.rs
+++ b/crates/surge-orchestrator/tests/triage_dispatch.rs
@@ -1,0 +1,103 @@
+//! Unit tests for `triage::dispatch_triage` against `MockBridge`.
+
+#[path = "fixtures/mod.rs"]
+mod fixtures;
+
+use chrono::Utc;
+use std::str::FromStr;
+use std::sync::Arc;
+use std::time::Duration;
+use surge_acp::bridge::event::BridgeEvent;
+use surge_acp::bridge::facade::BridgeFacade;
+use surge_core::{OutcomeKey, SessionId};
+use surge_intake::types::{Priority, TaskDetails, TaskId, TriageDecision};
+use surge_orchestrator::triage::{dispatch_triage, TriageInput, TriageOptions};
+use tempfile::TempDir;
+
+fn task_details(id: &str) -> TaskDetails {
+    TaskDetails {
+        task_id: TaskId::try_new(id).unwrap(),
+        source_id: "mock:t".into(),
+        title: "Fix parser panic".into(),
+        description: "Stack overflow on nested JSON".into(),
+        status: "open".into(),
+        labels: vec!["surge:enabled".into()],
+        url: format!("https://x/{id}"),
+        created_at: Utc::now(),
+        updated_at: Utc::now(),
+        assignee: None,
+        raw_payload: serde_json::json!({}),
+    }
+}
+
+fn input() -> TriageInput {
+    TriageInput {
+        task: task_details("mock:t#1"),
+        candidates: vec![],
+        active_runs: vec![],
+    }
+}
+
+#[tokio::test]
+async fn enqueued_happy_path() {
+    let bridge = Arc::new(fixtures::mock_bridge::MockBridge::new());
+    let session = SessionId::new();
+    bridge.pin_next_session_id(session).await;
+
+    let tmp = TempDir::new().unwrap();
+    let opts = TriageOptions {
+        claude_binary: Some(std::path::PathBuf::from("/dev/null")),
+        attempt_timeout: Duration::from_secs(2),
+        max_attempts: 1,
+        scratch_root: tmp.path().to_path_buf(),
+        keep_scratch_on_failure: false,
+    };
+
+    // Drive task: wait for dispatcher to subscribe + create scratch dir,
+    // then write artifact and emit OutcomeReported.
+    let scratch_root = tmp.path().to_path_buf();
+    let bridge_for_drive = Arc::clone(&bridge);
+    let drive = tokio::spawn(async move {
+        // Sleep enough for dispatcher to call subscribe() + open_session() + send_message().
+        // The mock open_session is synchronous returning the pinned id, so 80ms is plenty.
+        tokio::time::sleep(Duration::from_millis(80)).await;
+
+        let scratch = std::fs::read_dir(&scratch_root)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .find(|e| e.file_type().map(|t| t.is_dir()).unwrap_or(false))
+            .expect("dispatcher should have created scratch subdir")
+            .path();
+
+        let decision = r#"{"decision":"enqueued","priority":"high","priority_reasoning":"prod crash","summary":"Fix panic"}"#;
+        let summary = "## Fix parser panic\n\nStack overflow at depth 16.";
+        std::fs::write(scratch.join("triage_decision.json"), decision).unwrap();
+        std::fs::write(scratch.join("inbox_summary.md"), summary).unwrap();
+        bridge_for_drive
+            .enqueue_event(BridgeEvent::OutcomeReported {
+                session,
+                outcome: OutcomeKey::from_str("enqueued").unwrap(),
+                summary: "agent picked enqueued".into(),
+                artifacts_produced: vec!["triage_decision.json".into(), "inbox_summary.md".into()],
+            })
+            .await;
+        bridge_for_drive.pump_scripted_events().await;
+    });
+
+    let result = dispatch_triage(
+        Arc::clone(&bridge) as Arc<dyn BridgeFacade>,
+        input(),
+        opts,
+    )
+    .await
+    .expect("dispatch_triage should succeed");
+
+    drive.await.unwrap();
+
+    match result {
+        TriageDecision::Enqueued { priority, .. } => {
+            assert_eq!(priority, Priority::High);
+        }
+        other => panic!("expected Enqueued, got {other:?}"),
+    }
+}

--- a/crates/surge-orchestrator/tests/triage_dispatch.rs
+++ b/crates/surge-orchestrator/tests/triage_dispatch.rs
@@ -114,13 +114,13 @@ async fn enqueued_happy_path() {
     bridge.pin_next_session_id(session).await;
 
     let tmp = TempDir::new().unwrap();
-    let opts = TriageOptions {
-        claude_binary: Some(std::path::PathBuf::from("/dev/null")),
-        attempt_timeout: Duration::from_secs(2),
-        max_attempts: 1,
-        scratch_root: tmp.path().to_path_buf(),
-        keep_scratch_on_failure: false,
-    };
+    let mut opts = TriageOptions::with_scratch_root(
+        tmp.path().to_path_buf(),
+        Some(std::path::PathBuf::from("/dev/null")),
+    );
+    opts.attempt_timeout = Duration::from_secs(2);
+    opts.max_attempts = 1;
+    opts.keep_scratch_on_failure = false;
 
     let drive = tokio::spawn(drive_one_attempt(
         Arc::clone(&bridge),
@@ -152,13 +152,13 @@ async fn duplicate_happy_path() {
     bridge.pin_next_session_id(session).await;
 
     let tmp = TempDir::new().unwrap();
-    let opts = TriageOptions {
-        claude_binary: Some(std::path::PathBuf::from("/dev/null")),
-        attempt_timeout: Duration::from_secs(2),
-        max_attempts: 1,
-        scratch_root: tmp.path().to_path_buf(),
-        keep_scratch_on_failure: false,
-    };
+    let mut opts = TriageOptions::with_scratch_root(
+        tmp.path().to_path_buf(),
+        Some(std::path::PathBuf::from("/dev/null")),
+    );
+    opts.attempt_timeout = Duration::from_secs(2);
+    opts.max_attempts = 1;
+    opts.keep_scratch_on_failure = false;
 
     let drive = tokio::spawn(drive_one_attempt(
         Arc::clone(&bridge),
@@ -189,13 +189,13 @@ async fn out_of_scope_happy_path() {
     bridge.pin_next_session_id(session).await;
 
     let tmp = TempDir::new().unwrap();
-    let opts = TriageOptions {
-        claude_binary: Some(std::path::PathBuf::from("/dev/null")),
-        attempt_timeout: Duration::from_secs(2),
-        max_attempts: 1,
-        scratch_root: tmp.path().to_path_buf(),
-        keep_scratch_on_failure: false,
-    };
+    let mut opts = TriageOptions::with_scratch_root(
+        tmp.path().to_path_buf(),
+        Some(std::path::PathBuf::from("/dev/null")),
+    );
+    opts.attempt_timeout = Duration::from_secs(2);
+    opts.max_attempts = 1;
+    opts.keep_scratch_on_failure = false;
 
     let drive = tokio::spawn(drive_one_attempt(
         Arc::clone(&bridge),
@@ -221,13 +221,13 @@ async fn unclear_happy_path() {
     bridge.pin_next_session_id(session).await;
 
     let tmp = TempDir::new().unwrap();
-    let opts = TriageOptions {
-        claude_binary: Some(std::path::PathBuf::from("/dev/null")),
-        attempt_timeout: Duration::from_secs(2),
-        max_attempts: 1,
-        scratch_root: tmp.path().to_path_buf(),
-        keep_scratch_on_failure: false,
-    };
+    let mut opts = TriageOptions::with_scratch_root(
+        tmp.path().to_path_buf(),
+        Some(std::path::PathBuf::from("/dev/null")),
+    );
+    opts.attempt_timeout = Duration::from_secs(2);
+    opts.max_attempts = 1;
+    opts.keep_scratch_on_failure = false;
 
     let drive = tokio::spawn(drive_one_attempt(
         Arc::clone(&bridge),
@@ -259,13 +259,13 @@ async fn bad_json_then_recovers() {
     bridge.pin_session_ids(vec![session_a, session_b]).await;
 
     let tmp = TempDir::new().unwrap();
-    let opts = TriageOptions {
-        claude_binary: Some(std::path::PathBuf::from("/dev/null")),
-        attempt_timeout: Duration::from_secs(2),
-        max_attempts: 3,
-        scratch_root: tmp.path().to_path_buf(),
-        keep_scratch_on_failure: false,
-    };
+    let mut opts = TriageOptions::with_scratch_root(
+        tmp.path().to_path_buf(),
+        Some(std::path::PathBuf::from("/dev/null")),
+    );
+    opts.attempt_timeout = Duration::from_secs(2);
+    opts.max_attempts = 3;
+    opts.keep_scratch_on_failure = false;
 
     let drive = tokio::spawn(drive_n_attempts(
         Arc::clone(&bridge),
@@ -297,13 +297,13 @@ async fn exhaust_retries_yields_unclear() {
     bridge.pin_session_ids(vec![s1, s2, s3]).await;
 
     let tmp = TempDir::new().unwrap();
-    let opts = TriageOptions {
-        claude_binary: Some(std::path::PathBuf::from("/dev/null")),
-        attempt_timeout: Duration::from_secs(2),
-        max_attempts: 3,
-        scratch_root: tmp.path().to_path_buf(),
-        keep_scratch_on_failure: true,
-    };
+    let mut opts = TriageOptions::with_scratch_root(
+        tmp.path().to_path_buf(),
+        Some(std::path::PathBuf::from("/dev/null")),
+    );
+    opts.attempt_timeout = Duration::from_secs(2);
+    opts.max_attempts = 3;
+    opts.keep_scratch_on_failure = true;
 
     let drive = tokio::spawn(drive_n_attempts(
         Arc::clone(&bridge),
@@ -339,13 +339,13 @@ async fn timeout_yields_unclear() {
     bridge.pin_session_ids(vec![s]).await;
 
     let tmp = TempDir::new().unwrap();
-    let opts = TriageOptions {
-        claude_binary: Some(std::path::PathBuf::from("/dev/null")),
-        attempt_timeout: Duration::from_millis(150),
-        max_attempts: 1,
-        scratch_root: tmp.path().to_path_buf(),
-        keep_scratch_on_failure: true,
-    };
+    let mut opts = TriageOptions::with_scratch_root(
+        tmp.path().to_path_buf(),
+        Some(std::path::PathBuf::from("/dev/null")),
+    );
+    opts.attempt_timeout = Duration::from_millis(150);
+    opts.max_attempts = 1;
+    opts.keep_scratch_on_failure = true;
 
     // No drive task — bridge never emits OutcomeReported, so the
     // dispatcher hits its tokio::time::timeout.
@@ -371,13 +371,13 @@ async fn agent_crashed_yields_unclear() {
     bridge.pin_session_ids(vec![s]).await;
 
     let tmp = TempDir::new().unwrap();
-    let opts = TriageOptions {
-        claude_binary: Some(std::path::PathBuf::from("/dev/null")),
-        attempt_timeout: Duration::from_secs(2),
-        max_attempts: 1,
-        scratch_root: tmp.path().to_path_buf(),
-        keep_scratch_on_failure: true,
-    };
+    let mut opts = TriageOptions::with_scratch_root(
+        tmp.path().to_path_buf(),
+        Some(std::path::PathBuf::from("/dev/null")),
+    );
+    opts.attempt_timeout = Duration::from_secs(2);
+    opts.max_attempts = 1;
+    opts.keep_scratch_on_failure = true;
 
     let drive = {
         let bridge = Arc::clone(&bridge);
@@ -417,13 +417,10 @@ async fn binary_missing_short_circuits() {
     let bridge = Arc::new(fixtures::mock_bridge::MockBridge::new());
 
     let tmp = TempDir::new().unwrap();
-    let opts = TriageOptions {
-        claude_binary: None, // explicit
-        attempt_timeout: Duration::from_secs(5),
-        max_attempts: 3,
-        scratch_root: tmp.path().to_path_buf(),
-        keep_scratch_on_failure: false,
-    };
+    let mut opts = TriageOptions::with_scratch_root(tmp.path().to_path_buf(), None);
+    opts.attempt_timeout = Duration::from_secs(5);
+    opts.max_attempts = 3;
+    opts.keep_scratch_on_failure = false;
 
     let result = dispatch_triage(Arc::clone(&bridge) as Arc<dyn BridgeFacade>, input(), opts)
         .await

--- a/crates/surge-orchestrator/tests/triage_llm.rs
+++ b/crates/surge-orchestrator/tests/triage_llm.rs
@@ -86,13 +86,13 @@ mod llm {
                 active_runs: vec![],
             };
             let tmp = tempfile::tempdir().unwrap();
-            let opts = TriageOptions {
-                claude_binary: surge_orchestrator::triage::find_claude_binary(),
-                attempt_timeout: Duration::from_secs(180),
-                max_attempts: 1,
-                scratch_root: tmp.path().to_path_buf(),
-                keep_scratch_on_failure: true,
-            };
+            let mut opts = TriageOptions::with_scratch_root(
+                tmp.path().to_path_buf(),
+                surge_orchestrator::triage::find_claude_binary(),
+            );
+            opts.attempt_timeout = Duration::from_secs(180);
+            opts.max_attempts = 1;
+            opts.keep_scratch_on_failure = true;
             let result = dispatch_triage(Arc::clone(&bridge) as Arc<dyn BridgeFacade>, input, opts)
                 .await
                 .expect("dispatch_triage");

--- a/crates/surge-orchestrator/tests/triage_llm.rs
+++ b/crates/surge-orchestrator/tests/triage_llm.rs
@@ -1,49 +1,144 @@
-//! Fixture-driven LLM test for Triage Author. Requires:
-//!   - ANTHROPIC_TEST_KEY env var (when feature enabled)
+//! Fixture-driven test for Triage Author. Two flavours:
 //!
-//! Run with: `cargo test -p surge-orchestrator --test triage_llm -- --ignored`
+//! 1. Default: smoke check that fixtures parse as TOML.
+//! 2. `--features _bootstrap_llm_test`: dispatch real Claude Haiku
+//!    against the fixtures and assert decision matches.
 //!
-//! Each fixture in `triage_fixtures/*.toml` provides an input ticket and
-//! candidate set, plus the expected decision/priority. The full LLM body
-//! invokes Claude Haiku at `temperature=0` and validates output against
-//! tolerance bands; for now it lives behind a feature flag so default
-//! builds do not pay for LLM calls.
-//!
-//! The smoke test below — always-on — confirms every fixture is valid TOML
-//! with the expected schema.
+//! Run feature-gated:
+//!   ANTHROPIC_TEST_KEY=sk-... cargo test -p surge-orchestrator \
+//!     --test triage_llm --features _bootstrap_llm_test -- --ignored
 
 #[test]
-fn fixtures_parse_as_valid_toml() {
+fn fixtures_compile() {
     use std::fs;
     let dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/triage_fixtures");
-    assert!(dir.is_dir(), "fixtures dir does not exist: {dir:?}");
-
     let mut count = 0;
     for entry in fs::read_dir(&dir).expect("fixtures dir") {
         let p = entry.unwrap().path();
         if p.extension().and_then(|s| s.to_str()) != Some("toml") {
             continue;
         }
-        let contents = fs::read_to_string(&p).unwrap_or_else(|e| panic!("read {p:?}: {e}"));
-        let value: toml::Value =
-            toml::from_str(&contents).unwrap_or_else(|e| panic!("invalid TOML {p:?}: {e}"));
-
-        // Schema spot-check: every fixture has [input.task].task_id and [expected].decision.
-        let task_id = value["input"]["task"]["task_id"]
-            .as_str()
-            .unwrap_or_else(|| panic!("missing input.task.task_id in {p:?}"));
-        assert!(!task_id.is_empty(), "input.task.task_id is empty in {p:?}");
-        let decision = value["expected"]["decision"]
-            .as_str()
-            .unwrap_or_else(|| panic!("missing expected.decision in {p:?}"));
-        assert!(
-            matches!(
-                decision,
-                "enqueued" | "duplicate" | "out_of_scope" | "unclear"
-            ),
-            "unknown expected.decision={decision} in {p:?}"
-        );
+        let contents = fs::read_to_string(&p).unwrap();
+        let _: toml::Value = toml::from_str(&contents).expect("valid TOML");
         count += 1;
     }
     assert!(count >= 3, "expected at least 3 fixtures, found {count}");
+}
+
+#[cfg(feature = "_bootstrap_llm_test")]
+mod llm {
+    use std::sync::Arc;
+    use std::time::Duration;
+    use surge_acp::bridge::acp_bridge::AcpBridge;
+    use surge_acp::bridge::facade::BridgeFacade;
+    use surge_intake::types::{Priority, TaskDetails, TaskSummary, TriageDecision};
+    use surge_orchestrator::triage::{TriageInput, TriageOptions, dispatch_triage};
+
+    fn priority_distance(a: Priority, b: Priority) -> u32 {
+        let rank = |p: Priority| -> u32 {
+            match p {
+                Priority::Low => 0,
+                Priority::Medium => 1,
+                Priority::High => 2,
+                Priority::Urgent => 3,
+            }
+        };
+        rank(a).abs_diff(rank(b))
+    }
+
+    #[derive(serde::Deserialize)]
+    struct Fixture {
+        input: FixtureInput,
+        expected: FixtureExpected,
+    }
+    #[derive(serde::Deserialize)]
+    struct FixtureInput {
+        task: TaskDetails,
+        #[serde(default)]
+        candidates: Vec<TaskSummary>,
+    }
+    #[derive(serde::Deserialize)]
+    struct FixtureExpected {
+        decision: String,
+        #[serde(default)]
+        priority: Option<String>,
+        #[serde(default)]
+        duplicate_of: Option<String>,
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    #[ignore = "requires ANTHROPIC_TEST_KEY and a real claude binary"]
+    async fn fixtures_against_real_haiku() {
+        let bridge = Arc::new(AcpBridge::with_defaults().expect("AcpBridge"));
+        let dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/triage_fixtures");
+
+        for entry in std::fs::read_dir(&dir).unwrap() {
+            let path = entry.unwrap().path();
+            if path.extension().and_then(|s| s.to_str()) != Some("toml") {
+                continue;
+            }
+            let raw = std::fs::read_to_string(&path).unwrap();
+            let fixture: Fixture = toml::from_str(&raw).unwrap();
+
+            let input = TriageInput {
+                task: fixture.input.task,
+                candidates: fixture.input.candidates,
+                active_runs: vec![],
+            };
+            let tmp = tempfile::tempdir().unwrap();
+            let opts = TriageOptions {
+                claude_binary: surge_orchestrator::triage::find_claude_binary(),
+                attempt_timeout: Duration::from_secs(180),
+                max_attempts: 1,
+                scratch_root: tmp.path().to_path_buf(),
+                keep_scratch_on_failure: true,
+            };
+            let result = dispatch_triage(Arc::clone(&bridge) as Arc<dyn BridgeFacade>, input, opts)
+                .await
+                .expect("dispatch_triage");
+
+            let actual_decision = match &result {
+                TriageDecision::Enqueued { .. } => "enqueued",
+                TriageDecision::Duplicate { .. } => "duplicate",
+                TriageDecision::OutOfScope { .. } => "out_of_scope",
+                TriageDecision::Unclear { .. } => "unclear",
+            };
+            assert_eq!(
+                actual_decision, fixture.expected.decision,
+                "fixture {:?}: decision mismatch",
+                path
+            );
+
+            if let (Some(exp_p), TriageDecision::Enqueued { priority, .. }) =
+                (fixture.expected.priority.as_deref(), &result)
+            {
+                let exp = match exp_p {
+                    "urgent" => Priority::Urgent,
+                    "high" => Priority::High,
+                    "medium" => Priority::Medium,
+                    "low" => Priority::Low,
+                    other => panic!("fixture has unknown priority: {other}"),
+                };
+                let dist = priority_distance(exp, *priority);
+                assert!(
+                    dist <= 1,
+                    "fixture {:?}: priority {:?} too far from expected {:?}",
+                    path,
+                    priority,
+                    exp
+                );
+            }
+
+            if let (Some(exp_dup), TriageDecision::Duplicate { of, .. }) =
+                (fixture.expected.duplicate_of.as_deref(), &result)
+            {
+                assert_eq!(
+                    of.as_str(),
+                    exp_dup,
+                    "fixture {:?}: duplicate_of mismatch",
+                    path
+                );
+            }
+        }
+    }
 }

--- a/crates/surge-persistence/src/runs/mod.rs
+++ b/crates/surge-persistence/src/runs/mod.rs
@@ -69,7 +69,7 @@ pub use reader::{ReadEvent, RunReader};
 pub use registry::{RunFilter, RunSummary};
 pub use run_writer::RunWriter;
 pub use seq::EventSeq;
-pub use storage::Storage;
+pub use storage::{ActiveRunRow, Storage};
 pub use subscribe::SUBSCRIBE_BATCH_MAX;
 pub use types::{ArtifactRecord, CostSummary, PendingApproval, StageExecution};
 pub use writer::{DEFAULT_CHANNEL_CAPACITY, WriterCommand, WriterConfig};

--- a/crates/surge-persistence/src/runs/storage.rs
+++ b/crates/surge-persistence/src/runs/storage.rs
@@ -265,27 +265,26 @@ impl Storage {
             .registry_pool
             .get()
             .map_err(|e| crate::runs::error::StorageError::Pool(e.to_string()))?;
-        let mut stmt = conn
-            .prepare(
-                "SELECT id, status, started_at FROM runs
-                 WHERE status IN ('Running', 'Bootstrapping')
-                 ORDER BY started_at DESC
-                 LIMIT ?1",
-            )
-            .map_err(|e| crate::runs::error::StorageError::Pool(e.to_string()))?;
-        let rows = stmt
-            .query_map([limit as i64], |row| {
-                Ok(ActiveRunRow {
-                    run_id: row.get::<_, String>(0)?,
-                    task_id: None,
-                    status: row.get::<_, String>(1)?,
-                    started_at_ms: row.get::<_, i64>(2)?,
-                })
+        // SQLite errors propagate via the `From<rusqlite::Error>` impl on
+        // `StorageError`, surfacing as `StorageError::Sqlite`. Pool-acquire
+        // failures above keep the `StorageError::Pool` mapping.
+        let mut stmt = conn.prepare(
+            "SELECT id, status, started_at FROM runs
+             WHERE status IN ('Running', 'Bootstrapping')
+             ORDER BY started_at DESC
+             LIMIT ?1",
+        )?;
+        let rows = stmt.query_map([limit as i64], |row| {
+            Ok(ActiveRunRow {
+                run_id: row.get::<_, String>(0)?,
+                task_id: None,
+                status: row.get::<_, String>(1)?,
+                started_at_ms: row.get::<_, i64>(2)?,
             })
-            .map_err(|e| crate::runs::error::StorageError::Pool(e.to_string()))?;
+        })?;
         let mut out = Vec::new();
         for r in rows {
-            out.push(r.map_err(|e| crate::runs::error::StorageError::Pool(e.to_string()))?);
+            out.push(r?);
         }
         Ok(out)
     }

--- a/crates/surge-persistence/src/runs/storage.rs
+++ b/crates/surge-persistence/src/runs/storage.rs
@@ -378,8 +378,9 @@ mod snapshot_active_runs_tests {
 
         let snap = storage.snapshot_active_runs(32).await.unwrap();
         assert_eq!(snap.len(), 2, "only Running + Bootstrapping should appear");
-        assert!(snap.iter().all(|r| matches!(
-            r.status.as_str(), "Running" | "Bootstrapping"
-        )));
+        assert!(
+            snap.iter()
+                .all(|r| matches!(r.status.as_str(), "Running" | "Bootstrapping"))
+        );
     }
 }

--- a/crates/surge-persistence/src/runs/storage.rs
+++ b/crates/surge-persistence/src/runs/storage.rs
@@ -105,6 +105,22 @@ use crate::runs::registry::{self, RunFilter, RunSummary};
 use crate::runs::run_writer::RunWriter;
 use crate::runs::writer::{WriterConfig, spawn_writer};
 
+/// Lightweight active-run row for Triage Author's `active_runs` input.
+///
+/// Returned by [`Storage::snapshot_active_runs`]. Carries only fields
+/// useful for dedup hints — full run metadata stays inside `RunSummary`.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct ActiveRunRow {
+    /// The run ID.
+    pub run_id: String,
+    /// The task ID, populated by Layer 2 engine integration (None for Layer 1).
+    pub task_id: Option<String>,
+    /// Current run status as a string (e.g., "Running", "Bootstrapping").
+    pub status: String,
+    /// Unix epoch milliseconds of run creation.
+    pub started_at_ms: i64,
+}
+
 impl Storage {
     /// Create a new run: insert into registry, init per-run DB with migrations,
     /// open the worktree-anchored writer.
@@ -232,6 +248,48 @@ impl Storage {
         Ok(runs)
     }
 
+    /// Snapshot of currently active runs (status Running or Bootstrapping).
+    ///
+    /// Bounded by `limit` rows. Used by Triage Author to reason about
+    /// dedup against in-flight work.
+    ///
+    /// Layer 1 leaves `task_id` as `None` for all rows because the
+    /// `ticket_index` join would require resolving cross-table foreign
+    /// keys not yet materialised in this code path. Layer 2's engine
+    /// integration will populate it.
+    pub async fn snapshot_active_runs(
+        &self,
+        limit: usize,
+    ) -> Result<Vec<ActiveRunRow>, crate::runs::error::StorageError> {
+        let conn = self
+            .registry_pool
+            .get()
+            .map_err(|e| crate::runs::error::StorageError::Pool(e.to_string()))?;
+        let mut stmt = conn
+            .prepare(
+                "SELECT id, status, started_at FROM runs
+                 WHERE status IN ('Running', 'Bootstrapping')
+                 ORDER BY started_at DESC
+                 LIMIT ?1",
+            )
+            .map_err(|e| crate::runs::error::StorageError::Pool(e.to_string()))?;
+        let rows = stmt
+            .query_map([limit as i64], |row| {
+                Ok(ActiveRunRow {
+                    run_id: row.get::<_, String>(0)?,
+                    task_id: None,
+                    status: row.get::<_, String>(1)?,
+                    started_at_ms: row.get::<_, i64>(2)?,
+                })
+            })
+            .map_err(|e| crate::runs::error::StorageError::Pool(e.to_string()))?;
+        let mut out = Vec::new();
+        for r in rows {
+            out.push(r.map_err(|e| crate::runs::error::StorageError::Pool(e.to_string()))?);
+        }
+        Ok(out)
+    }
+
     /// Get a single run summary, with stale-pid detection.
     pub async fn get_run(
         &self,
@@ -284,5 +342,44 @@ impl Storage {
             std::fs::remove_dir_all(&dir)?;
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod snapshot_active_runs_tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn snapshot_returns_active_runs_only() {
+        let dir = tempdir().unwrap();
+        let storage = Storage::open(dir.path()).await.unwrap();
+
+        // Insert one Running, one Bootstrapping, one Completed.
+        let pool = storage.registry_pool.clone();
+        let conn = pool.get().unwrap();
+        for (id, status) in [
+            ("01HXX0000000000000000RUN1", "Running"),
+            ("01HXX0000000000000000BTS1", "Bootstrapping"),
+            ("01HXX0000000000000000DONE", "Completed"),
+        ] {
+            conn.execute(
+                "INSERT INTO runs (id, project_path, pipeline_template, status, started_at, ended_at, daemon_pid)
+                 VALUES (?1, ?2, NULL, ?3, ?4, NULL, NULL)",
+                rusqlite::params![
+                    id,
+                    "/tmp/proj",
+                    status,
+                    1_700_000_000_000_i64,
+                ],
+            ).unwrap();
+        }
+        drop(conn);
+
+        let snap = storage.snapshot_active_runs(32).await.unwrap();
+        assert_eq!(snap.len(), 2, "only Running + Bootstrapping should appear");
+        assert!(snap.iter().all(|r| matches!(
+            r.status.as_str(), "Running" | "Bootstrapping"
+        )));
     }
 }

--- a/docs/03-ROADMAP.md
+++ b/docs/03-ROADMAP.md
@@ -282,7 +282,7 @@ Implemented over 13 task commits.
 
 RFC-0010 implementation is functionally complete — all decisions assigned to Plans A/B/C are delivered. Decisions assigned to RFC-0014 (webhook ingestion, embedding-based dedup), RFC-0006 refactor (sandbox tier 3+4 deprecation), and RFC-0004 refactor (vertical-slice mandate, token-budget guard-rail) remain out of scope for RFC-0010.
 
-## RFC-0010 — Plan-C-polish ✅ (5 of 6)
+## RFC-0010 — Plan-C-polish ✅ (6 of 6)
 
 Refinements on top of Plans A+B+C, delivered to harden the implementation.
 
@@ -291,10 +291,7 @@ Refinements on top of Plans A+B+C, delivered to harden the implementation.
 - [x] **Source registry → comment-on-dup** — surge-daemon now keeps `Arc<HashMap<String, Arc<dyn TaskSource>>>` alongside the router and posts a "duplicate of run #N" comment to the originating tracker on `RouterOutput::EarlyDuplicate`. Closes the dedup-side of acceptance #6. Commit: `619f917`.
 - [x] **NotifyMultiplexer InboxCard delivery** — `RouterOutput::Triage` events render an `InboxCardPayload` to a `RenderedNotification` (title + body) and dispatch via `MultiplexingNotifier::deliver` against `NotifyChannel::Desktop`. `ChannelNotConfigured` is logged at debug; real deliverers receive the notification when configured. Closes the delivery-side of acceptance #3. Commit: `08eade5`.
 - [x] **Persistent dedup connection** — `TaskRouter` now reads from a `Connection` opened directly to the daemon's registry DB file (using a new `Storage::registry_db_path()` accessor). State survives restarts and stays in sync with engine writes. Closes the T9.2 in-memory concern. Commit: `2d5cd61`.
-
-### Remaining (deferred to its own session)
-
-- [ ] **Triage Author LLM dispatch via ACP** — surge-daemon currently uses `Priority::Medium` placeholder when constructing inbox cards. Wiring the actual LLM call requires loading `BOOTSTRAP_TRIAGE_AUTHOR_TOML`, spawning an ACP session, rendering `TriageInput` as JSON, awaiting the agent's `triage_decision.json` output, and parsing via `TriageJson::into_decision`. Substantial enough to warrant its own session — bundled into the post-RFC-0010 follow-up backlog. Acceptance #3 fully passes (priority becomes LLM-derived) once this lands.
+- [x] **Triage Author LLM dispatch via ACP** — Replaces the `Priority::Medium` placeholder in surge-daemon with a real ACP-driven Triage Author call. File-artifact return path (`triage_decision.json` + `inbox_summary.md`) matching the Description Author pattern. Layer 1 of two-layer plan; Layer 2 promotes Triage to a graph node (separate RFC). See: [docs/superpowers/specs/2026-05-06-triage-author-llm-dispatch-design.md](superpowers/specs/2026-05-06-triage-author-llm-dispatch-design.md).
 
 After polish, RFC-0010 implementation status:
 - **3 acceptance criteria fully pass** (#1 surge-intake compiles, #2 sources poll, #11 clippy clean).

--- a/docs/superpowers/plans/2026-05-06-triage-author-llm-dispatch.md
+++ b/docs/superpowers/plans/2026-05-06-triage-author-llm-dispatch.md
@@ -1,0 +1,2776 @@
+# Triage Author LLM Dispatch Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the `Priority::Medium` placeholder in `surge-daemon` with a real ACP-driven Triage Author call that returns a typed `TriageDecision` and routes to one of four destinations (real InboxCard / duplicate-comment / out-of-scope-comment / Unclear notification).
+
+**Architecture:** A standalone `dispatch_triage(...)` async function lives in `surge-orchestrator/src/triage.rs`, opens an ACP session via `BridgeFacade`, sends the system prompt + serialized `TriageInput`, awaits `OutcomeReported`, reads `triage_decision.json` + `inbox_summary.md` from a per-call scratch directory, and returns `TriageDecision`. Retry-up-to-3 with `Unclear` fallback keeps daemon match arms total. Daemon mapping replaces the `RouterOutput::Triage` arm in `crates/surge-daemon/src/main.rs`.
+
+**Tech Stack:** Rust 2024, tokio, `agent-client-protocol`, `surge-acp::bridge::facade::BridgeFacade`, `surge-intake::types`, `serde_json`, `thiserror`, `ulid`, `tempfile` (test-only), `insta` (snapshot tests).
+
+**Spec:** [docs/superpowers/specs/2026-05-06-triage-author-llm-dispatch-design.md](../specs/2026-05-06-triage-author-llm-dispatch-design.md)
+
+---
+
+## File structure
+
+### Created
+
+- `crates/surge-orchestrator/tests/triage_dispatch.rs` — six unit-test scenarios for `dispatch_triage` against `MockBridge`.
+- `crates/surge-daemon/tests/triage_wiring.rs` — daemon-level smoke test wiring `dispatch_triage` to `RouterOutput::Triage` consumer.
+
+### Modified
+
+- `crates/surge-intake/src/candidates.rs` — add `build_for_task` async helper.
+- `crates/surge-persistence/src/runs/storage.rs` — add `snapshot_active_runs` method returning a new `ActiveRunRow` row type.
+- `crates/surge-persistence/src/runs/mod.rs` — re-export `ActiveRunRow`.
+- `crates/surge-orchestrator/src/triage.rs` — extend with `TriageError`, `TriageOptions`, `dispatch_triage`, prompt rendering, scratch dir lifecycle, retry loop, claude-binary discovery helper, `ActiveRunSummary::from_row` mapping.
+- `crates/surge-orchestrator/Cargo.toml` — add `tempfile` (dev), `insta` (dev), `ulid` to dev-dependencies if absent; add `_bootstrap_llm_test` feature.
+- `crates/surge-orchestrator/tests/triage_llm.rs` — replace skeleton smoke with feature-gated real-LLM body.
+- `crates/surge-daemon/src/main.rs` — extract `deliver_fallback_inbox` helper; replace the placeholder `RouterOutput::Triage` arm with `dispatch_triage` call + four-way decision routing.
+- `crates/surge-daemon/Cargo.toml` — confirm `surge-orchestrator` already in deps.
+- `docs/03-ROADMAP.md` — strike "Triage Author LLM dispatch via ACP" from Plan-C-polish remaining list; mark Plan-C-polish complete.
+
+### File responsibilities
+
+| File | Responsibility |
+|---|---|
+| `surge-intake/src/candidates.rs` | candidate-set assembly: `build_for_task` calls `source.list_open_tasks` and reduces via `top_by_keyword_overlap` to `Vec<TaskSummary>` |
+| `surge-persistence/src/runs/storage.rs` | persistent run snapshot: `snapshot_active_runs` returns `Vec<ActiveRunRow>` for Triage's `active_runs` field |
+| `surge-orchestrator/src/triage.rs` | LLM dispatch: types, errors, options, retry loop, scratch lifecycle, claude binary discovery, file-artifact reading |
+| `surge-daemon/src/main.rs` | wiring: assemble `TriageInput`, call `dispatch_triage`, route four decisions; preserves existing fallback-inbox path on provider errors |
+
+---
+
+## Task 1: `surge-intake::candidates::build_for_task` helper
+
+**Files:**
+- Modify: `crates/surge-intake/src/candidates.rs`
+- Test: `crates/surge-intake/src/candidates.rs` (in-module `#[cfg(test)] mod build_for_task_tests`)
+
+- [ ] **Step 1: Read existing module to find the right insertion point**
+
+```bash
+sed -n '1,50p' crates/surge-intake/src/candidates.rs
+```
+
+You'll see `pub fn top_by_keyword_overlap(target, candidates, limit) -> Vec<ScoredCandidate>` and `pub struct CandidateInput { task_id, title, summary }` with `from_summary(s: &TaskSummary) -> Self`.
+
+- [ ] **Step 2: Append the failing test at end of file**
+
+Append to `crates/surge-intake/src/candidates.rs`:
+
+```rust
+#[cfg(test)]
+mod build_for_task_tests {
+    use super::*;
+    use crate::testing::MockTaskSource;
+    use crate::types::{TaskDetails, TaskId, TaskSummary};
+    use chrono::Utc;
+    use std::sync::Arc;
+
+    fn td(id: &str, title: &str, body: &str) -> TaskDetails {
+        TaskDetails {
+            task_id: TaskId::try_new(id).unwrap(),
+            source_id: "mock:t".into(),
+            title: title.into(),
+            description: body.into(),
+            status: "open".into(),
+            labels: vec![],
+            url: format!("https://x/{id}"),
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+            assignee: None,
+            raw_payload: serde_json::json!({}),
+        }
+    }
+
+    fn ts(id: &str, title: &str) -> TaskSummary {
+        TaskSummary {
+            task_id: TaskId::try_new(id).unwrap(),
+            title: title.into(),
+            status: "open".into(),
+            url: format!("https://x/{id}"),
+            updated_at: Utc::now(),
+        }
+    }
+
+    #[tokio::test]
+    async fn returns_top_n_by_jaccard_similarity() {
+        let src = Arc::new(MockTaskSource::new("mock:t", "mock"));
+        // Two candidates exist: one closely related, one unrelated.
+        src.put_task(td("mock:t#10", "fix parser panic on nested objects", "stack overflow")).await;
+        src.put_task(td("mock:t#20", "update readme typo", "docs only")).await;
+
+        let target = td(
+            "mock:t#100",
+            "parser crashes with deeply nested json",
+            "stack overflow when JSON has more than 16 nested levels",
+        );
+
+        let arc: Arc<dyn crate::TaskSource> = src.clone();
+        let result = build_for_task(&arc, &target, 5).await.unwrap();
+
+        // The semantically-close candidate should appear; readme typo should not
+        // (Jaccard score = 0 against parser/json/nested tokens).
+        let ids: Vec<&str> = result.iter().map(|s| s.task_id.as_str()).collect();
+        assert!(ids.contains(&"mock:t#10"));
+        assert!(!ids.contains(&"mock:t#20"));
+    }
+
+    #[tokio::test]
+    async fn excludes_target_itself() {
+        let src = Arc::new(MockTaskSource::new("mock:t", "mock"));
+        // Insert the target as if it's also "open" — common in real trackers.
+        src.put_task(td("mock:t#100", "parser crash", "nested json")).await;
+
+        let target = td("mock:t#100", "parser crash", "nested json");
+
+        let arc: Arc<dyn crate::TaskSource> = src.clone();
+        let result = build_for_task(&arc, &target, 5).await.unwrap();
+        assert!(result.iter().all(|s| s.task_id.as_str() != "mock:t#100"));
+    }
+
+    #[tokio::test]
+    async fn empty_open_set_returns_empty() {
+        let src = Arc::new(MockTaskSource::new("mock:t", "mock"));
+        let target = td("mock:t#1", "anything", "");
+        let arc: Arc<dyn crate::TaskSource> = src.clone();
+        let result = build_for_task(&arc, &target, 5).await.unwrap();
+        assert!(result.is_empty());
+    }
+}
+```
+
+- [ ] **Step 3: Run the test — should fail to compile (function missing)**
+
+```bash
+cargo test -p surge-intake --lib candidates::build_for_task_tests 2>&1 | head -20
+```
+
+Expected: error[E0425]: cannot find function `build_for_task` in this scope.
+
+- [ ] **Step 4: Implement `build_for_task` above the `#[cfg(test)] mod build_for_task_tests`**
+
+Add right after the existing `CandidateInput::from_summary`/`from_details` impls in `candidates.rs`:
+
+```rust
+/// Build a top-`limit` candidate set for a given task by calling the
+/// source's `list_open_tasks` and filtering via Jaccard similarity.
+///
+/// The source's full open-task list is bounded by the source impl
+/// (typically ≤200 entries); this helper reduces to the top `limit`.
+pub async fn build_for_task(
+    source: &std::sync::Arc<dyn crate::TaskSource>,
+    target: &crate::types::TaskDetails,
+    limit: usize,
+) -> crate::Result<Vec<crate::types::TaskSummary>> {
+    let open = source.list_open_tasks().await?;
+    let inputs: Vec<CandidateInput> = open.iter().map(CandidateInput::from_summary).collect();
+    let scored = top_by_keyword_overlap(target, &inputs, limit);
+    Ok(scored
+        .into_iter()
+        .filter_map(|s| {
+            open.iter()
+                .find(|t| t.task_id.as_str() == s.task_id)
+                .cloned()
+        })
+        .collect())
+}
+```
+
+- [ ] **Step 5: Run the test — should pass**
+
+```bash
+cargo test -p surge-intake --lib candidates::build_for_task_tests
+```
+
+Expected: `test result: ok. 3 passed`.
+
+- [ ] **Step 6: Run full crate test to ensure no regression**
+
+```bash
+cargo test -p surge-intake
+```
+
+Expected: all green.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/surge-intake/src/candidates.rs
+git commit -m "$(cat <<'EOF'
+feat(intake): add candidates::build_for_task helper for triage
+
+Reduces source.list_open_tasks() to top-N by Jaccard similarity for
+inclusion in TriageInput. Excludes the target task itself.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: `Storage::snapshot_active_runs` in `surge-persistence`
+
+**Files:**
+- Modify: `crates/surge-persistence/src/runs/storage.rs`
+- Modify: `crates/surge-persistence/src/runs/mod.rs` (re-export `ActiveRunRow`)
+- Test: `crates/surge-persistence/src/runs/storage.rs` (in-file `#[cfg(test)] mod snapshot_active_runs_tests`)
+
+- [ ] **Step 1: Locate `Storage::list_runs` to understand patterns**
+
+```bash
+grep -n "pub async fn list_runs\|pub async fn get_run" crates/surge-persistence/src/runs/storage.rs | head
+```
+
+The `list_runs(filter)` method exists. We add a sibling `snapshot_active_runs(limit)`.
+
+- [ ] **Step 2: Write the failing test**
+
+Append to `crates/surge-persistence/src/runs/storage.rs`:
+
+```rust
+#[cfg(test)]
+mod snapshot_active_runs_tests {
+    use super::*;
+    use crate::runs::registry::{insert_run, RunStatus};
+    use std::path::PathBuf;
+    use surge_core::id::RunId;
+
+    #[tokio::test]
+    async fn snapshot_returns_active_runs_only() {
+        let dir = tempfile::tempdir().unwrap();
+        let storage = Storage::open(dir.path()).await.unwrap();
+
+        // Insert one Running, one Bootstrapping, one Completed.
+        let pool = storage.registry_pool().clone();
+        let conn = pool.get().unwrap();
+        for (id, status) in [
+            ("01HXX0000000000000000RUN1", RunStatus::Running),
+            ("01HXX0000000000000000BTS1", RunStatus::Bootstrapping),
+            ("01HXX0000000000000000DONE", RunStatus::Completed),
+        ] {
+            conn.execute(
+                "INSERT INTO runs (id, project_path, pipeline_template, status, started_at_ms, ended_at_ms, daemon_pid)
+                 VALUES (?1, ?2, NULL, ?3, ?4, NULL, NULL)",
+                rusqlite::params![
+                    id,
+                    "/tmp/proj",
+                    format!("{:?}", status),
+                    1_700_000_000_000_i64,
+                ],
+            ).unwrap();
+        }
+        drop(conn);
+
+        let snap = storage.snapshot_active_runs(32).await.unwrap();
+        assert_eq!(snap.len(), 2, "only Running + Bootstrapping should appear");
+        assert!(snap.iter().all(|r| matches!(
+            r.status.as_str(), "Running" | "Bootstrapping"
+        )));
+    }
+}
+```
+
+- [ ] **Step 3: Run the test — should fail to compile**
+
+```bash
+cargo test -p surge-persistence --lib runs::storage::snapshot_active_runs_tests 2>&1 | head -20
+```
+
+Expected: errors about `snapshot_active_runs` and `ActiveRunRow` missing.
+
+- [ ] **Step 4: Add the row type at the top of `crates/surge-persistence/src/runs/storage.rs`**
+
+After existing imports (around line 1-30), add:
+
+```rust
+/// Lightweight active-run row for Triage Author's `active_runs` input.
+///
+/// Returned by [`Storage::snapshot_active_runs`]. Carries only fields
+/// useful for dedup hints — full run metadata stays inside `RunSummary`.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct ActiveRunRow {
+    pub run_id: String,
+    pub task_id: Option<String>,
+    pub status: String,
+    pub started_at_ms: i64,
+}
+```
+
+- [ ] **Step 5: Implement `snapshot_active_runs` on `impl Storage`**
+
+In the same file, inside `impl Storage`, add (after `list_runs`):
+
+```rust
+/// Snapshot of currently active runs (status Running or Bootstrapping).
+///
+/// Bounded by `limit` rows. Used by Triage Author to reason about
+/// dedup against in-flight work.
+///
+/// Layer 1 leaves `task_id` as `None` for all rows because the
+/// `ticket_index` join would require resolving cross-table foreign
+/// keys not yet materialised in this code path. Layer 2's engine
+/// integration will populate it.
+pub async fn snapshot_active_runs(
+    &self,
+    limit: usize,
+) -> Result<Vec<ActiveRunRow>, crate::runs::error::StorageError> {
+    let conn = self
+        .registry_pool
+        .get()
+        .map_err(|e| crate::runs::error::StorageError::Other(e.to_string()))?;
+    let mut stmt = conn
+        .prepare(
+            "SELECT id, status, started_at_ms FROM runs
+             WHERE status IN ('Running', 'Bootstrapping')
+             ORDER BY started_at_ms DESC
+             LIMIT ?1",
+        )
+        .map_err(|e| crate::runs::error::StorageError::Other(e.to_string()))?;
+    let rows = stmt
+        .query_map([limit as i64], |row| {
+            Ok(ActiveRunRow {
+                run_id: row.get::<_, String>(0)?,
+                task_id: None,
+                status: row.get::<_, String>(1)?,
+                started_at_ms: row.get::<_, i64>(2)?,
+            })
+        })
+        .map_err(|e| crate::runs::error::StorageError::Other(e.to_string()))?;
+    let mut out = Vec::new();
+    for r in rows {
+        out.push(r.map_err(|e| crate::runs::error::StorageError::Other(e.to_string()))?);
+    }
+    Ok(out)
+}
+```
+
+- [ ] **Step 6: Re-export `ActiveRunRow`**
+
+Edit `crates/surge-persistence/src/runs/mod.rs`:
+
+```rust
+pub use storage::{ActiveRunRow, Storage};
+```
+
+(Adjust to match the existing re-export style — likely already `pub use storage::Storage;`. Add `ActiveRunRow` to the export.)
+
+- [ ] **Step 7: Run test**
+
+```bash
+cargo test -p surge-persistence --lib runs::storage::snapshot_active_runs_tests
+```
+
+Expected: `test result: ok. 1 passed`.
+
+- [ ] **Step 8: Run full crate test**
+
+```bash
+cargo test -p surge-persistence
+```
+
+Expected: all green.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add crates/surge-persistence/src/runs/storage.rs crates/surge-persistence/src/runs/mod.rs
+git commit -m "$(cat <<'EOF'
+feat(persistence): add Storage::snapshot_active_runs accessor
+
+Returns currently active (Running/Bootstrapping) runs as a lightweight
+ActiveRunRow snapshot for Triage Author's active_runs input. task_id
+is None at Layer 1; Layer 2 will populate from ticket_index join.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: `TriageError` and `TriageOptions` types
+
+**Files:**
+- Modify: `crates/surge-orchestrator/src/triage.rs`
+- Modify: `crates/surge-orchestrator/Cargo.toml` (add `tempfile` to dev, ensure `ulid` is available)
+
+- [ ] **Step 1: Check current `triage.rs` imports and end-of-file**
+
+```bash
+sed -n '1,15p' crates/surge-orchestrator/src/triage.rs
+```
+
+You'll see the existing `use surge_intake::types::...` imports. We'll add `std::path::PathBuf`, `std::sync::Arc`, `std::time::Duration`, and the `BridgeFacade` import.
+
+- [ ] **Step 2: Add new types above the existing `TriageInput` struct**
+
+In `crates/surge-orchestrator/src/triage.rs`, after the doc-comment block at top (around line 7), insert new imports and types:
+
+```rust
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+use surge_acp::bridge::facade::BridgeFacade;
+use surge_intake::types::{Priority, TaskDetails, TaskId, TaskSummary, TriageDecision};
+```
+
+Keep the existing `use serde::{Deserialize, Serialize};` and `use surge_intake::types::...` lines if already present — collapse duplicates.
+
+Then add (after existing struct defs, before `#[cfg(test)] mod tests`):
+
+```rust
+/// Tunable parameters for [`dispatch_triage`].
+///
+/// Construct via [`Self::with_scratch_root`] for the typical case of
+/// passing only the per-task scratch root and Claude binary path.
+#[derive(Debug, Clone)]
+pub struct TriageOptions {
+    /// Resolved Claude binary path. If `None`, the dispatcher
+    /// returns `Ok(TriageDecision::Unclear)` immediately on the
+    /// first attempt with a configuration-hint message.
+    pub claude_binary: Option<PathBuf>,
+    /// Per-attempt timeout. Default: 5 min (matches RFC-0010 §"Bootstrap stage failures").
+    pub attempt_timeout: Duration,
+    /// Maximum attempts before falling back to `Unclear`. Default: 3.
+    pub max_attempts: u32,
+    /// Root directory for per-call scratch dirs.
+    pub scratch_root: PathBuf,
+    /// Whether to keep scratch on Unclear / TriageError for post-mortem.
+    pub keep_scratch_on_failure: bool,
+}
+
+impl TriageOptions {
+    /// Build options with sensible defaults given a scratch root and
+    /// (optional) Claude binary path.
+    #[must_use]
+    pub fn with_scratch_root(scratch_root: PathBuf, claude_binary: Option<PathBuf>) -> Self {
+        Self {
+            claude_binary,
+            attempt_timeout: Duration::from_secs(300),
+            max_attempts: 3,
+            scratch_root,
+            keep_scratch_on_failure: true,
+        }
+    }
+}
+
+/// Errors returned from [`dispatch_triage`] for invariant violations.
+///
+/// Note: retry-eligible failures (timeout, agent crash, malformed JSON)
+/// are NOT surfaced as `TriageError` — they retry up to
+/// `opts.max_attempts` times and on exhaustion become
+/// `Ok(TriageDecision::Unclear { question })`. `TriageError` is
+/// reserved for failures that prevent any forward progress.
+#[derive(Debug, thiserror::Error)]
+pub enum TriageError {
+    #[error("scratch dir setup failed: {0}")]
+    Scratch(#[from] std::io::Error),
+    #[error("acp bridge: {0}")]
+    Bridge(String),
+}
+```
+
+- [ ] **Step 3: Confirm dev-dependencies**
+
+Open `crates/surge-orchestrator/Cargo.toml`. Confirm `tempfile` is in `[dev-dependencies]` (it already is per current state) and add `ulid` to runtime dependencies if absent:
+
+```bash
+grep -n "ulid\|tempfile" crates/surge-orchestrator/Cargo.toml
+```
+
+If `ulid` is missing from `[dependencies]`, add:
+
+```toml
+ulid = { workspace = true }
+```
+
+- [ ] **Step 4: Build to verify types compile**
+
+```bash
+cargo build -p surge-orchestrator
+```
+
+Expected: success.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/surge-orchestrator/src/triage.rs crates/surge-orchestrator/Cargo.toml
+git commit -m "$(cat <<'EOF'
+feat(orchestrator): add TriageOptions and TriageError types
+
+Foundation for dispatch_triage. TriageError covers invariant
+violations only; retry-eligible failures fall back to Unclear.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: `dispatch_triage` Enqueued happy path
+
+**Files:**
+- Modify: `crates/surge-orchestrator/src/triage.rs`
+- Test: `crates/surge-orchestrator/tests/triage_dispatch.rs` (new)
+- Modify: `crates/surge-orchestrator/tests/fixtures/mod.rs` (re-export `mock_bridge` if needed)
+
+- [ ] **Step 1: Confirm fixtures module re-exports mock_bridge**
+
+```bash
+cat crates/surge-orchestrator/tests/fixtures/mod.rs
+```
+
+If `pub mod mock_bridge;` is present, no change needed. Otherwise add it.
+
+- [ ] **Step 2: Write the failing happy-path test**
+
+Create `crates/surge-orchestrator/tests/triage_dispatch.rs`:
+
+```rust
+//! Unit tests for `triage::dispatch_triage` against `MockBridge`.
+
+#[path = "fixtures/mod.rs"]
+mod fixtures;
+
+use chrono::Utc;
+use std::str::FromStr;
+use std::sync::Arc;
+use std::time::Duration;
+use surge_acp::bridge::event::{BridgeEvent, SessionEndReason};
+use surge_acp::bridge::facade::BridgeFacade;
+use surge_core::{OutcomeKey, SessionId};
+use surge_intake::types::{Priority, TaskDetails, TaskId, TriageDecision};
+use surge_orchestrator::triage::{dispatch_triage, TriageInput, TriageOptions};
+use tempfile::TempDir;
+
+fn task_details(id: &str) -> TaskDetails {
+    TaskDetails {
+        task_id: TaskId::try_new(id).unwrap(),
+        source_id: "mock:t".into(),
+        title: "Fix parser panic".into(),
+        description: "Stack overflow on nested JSON".into(),
+        status: "open".into(),
+        labels: vec!["surge:enabled".into()],
+        url: format!("https://x/{id}"),
+        created_at: Utc::now(),
+        updated_at: Utc::now(),
+        assignee: None,
+        raw_payload: serde_json::json!({}),
+    }
+}
+
+fn input() -> TriageInput {
+    TriageInput {
+        task: task_details("mock:t#1"),
+        candidates: vec![],
+        active_runs: vec![],
+    }
+}
+
+/// Test harness: drives the mock bridge by writing the artifact files
+/// into the scratch dir and emitting the OutcomeReported event.
+async fn drive_enqueued(
+    bridge: Arc<fixtures::mock_bridge::MockBridge>,
+    scratch: &std::path::Path,
+    session: SessionId,
+    decision_json: &str,
+    summary_md: &str,
+) {
+    // Write artifacts as if the agent had done so.
+    std::fs::write(scratch.join("triage_decision.json"), decision_json).unwrap();
+    std::fs::write(scratch.join("inbox_summary.md"), summary_md).unwrap();
+    bridge
+        .enqueue_event(BridgeEvent::OutcomeReported {
+            session,
+            outcome: OutcomeKey::from_str("enqueued").unwrap(),
+            summary: "agent picked enqueued".into(),
+            artifacts_produced: vec![
+                "triage_decision.json".into(),
+                "inbox_summary.md".into(),
+            ],
+        })
+        .await;
+}
+
+#[tokio::test]
+async fn enqueued_happy_path() {
+    let bridge = Arc::new(fixtures::mock_bridge::MockBridge::new());
+    let session = SessionId::new();
+    bridge.pin_next_session_id(session).await;
+
+    let tmp = TempDir::new().unwrap();
+    let opts = TriageOptions {
+        // Use a non-None binary so dispatcher proceeds to open_session.
+        // MockBridge ignores the actual path.
+        claude_binary: Some(std::path::PathBuf::from("/dev/null")),
+        attempt_timeout: Duration::from_secs(2),
+        max_attempts: 1,
+        scratch_root: tmp.path().to_path_buf(),
+        keep_scratch_on_failure: false,
+    };
+
+    // Spawn a side task that drives the mock bridge once it has subscribers.
+    // We need the dispatcher to subscribe before enqueueing; do this by
+    // sleeping briefly then writing artifacts + pumping events.
+    let scratch_root = tmp.path().to_path_buf();
+    let bridge_for_drive = Arc::clone(&bridge);
+    let drive = tokio::spawn(async move {
+        // Wait long enough for dispatcher to call subscribe + open_session.
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        // The dispatcher creates one scratch subdir per call; find it.
+        let entries: Vec<_> = std::fs::read_dir(&scratch_root)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .collect();
+        let scratch = entries
+            .iter()
+            .find(|e| e.file_type().map(|t| t.is_dir()).unwrap_or(false))
+            .expect("dispatcher should have created scratch subdir")
+            .path();
+
+        let decision = r#"{"decision":"enqueued","priority":"high","priority_reasoning":"prod crash","summary":"Fix panic"}"#;
+        let summary = "## Fix parser panic\n\nStack overflow at depth 16.";
+        drive_enqueued(bridge_for_drive, &scratch, session, decision, summary).await;
+        // Pump after artifacts are in place so dispatcher reads them post-event.
+        let bridge_pump = Arc::clone(&fixtures::mock_bridge::Arc_clone_workaround(/* see below */));
+    });
+
+    let result = dispatch_triage(
+        Arc::clone(&bridge) as Arc<dyn BridgeFacade>,
+        input(),
+        opts,
+    )
+    .await
+    .expect("dispatch_triage should succeed");
+
+    drive.await.unwrap();
+
+    match result {
+        TriageDecision::Enqueued { priority, .. } => {
+            assert_eq!(priority, Priority::High);
+        }
+        other => panic!("expected Enqueued, got {other:?}"),
+    }
+}
+```
+
+Note the placeholder `Arc_clone_workaround` — the test is written before the real code; you'll iterate. The cleaner pattern is to call `bridge.pump_scripted_events()` from the same scope that owns `Arc<MockBridge>`. Refactor:
+
+```rust
+// Replace the previous `drive` task with:
+let scratch_root = tmp.path().to_path_buf();
+let bridge_for_drive = Arc::clone(&bridge);
+let drive = tokio::spawn(async move {
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    let entries: Vec<_> = std::fs::read_dir(&scratch_root)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .collect();
+    let scratch = entries
+        .iter()
+        .find(|e| e.file_type().map(|t| t.is_dir()).unwrap_or(false))
+        .expect("dispatcher should have created scratch subdir")
+        .path();
+
+    let decision = r#"{"decision":"enqueued","priority":"high","priority_reasoning":"prod crash","summary":"Fix panic"}"#;
+    let summary = "## Fix parser panic\n\nStack overflow at depth 16.";
+    std::fs::write(scratch.join("triage_decision.json"), decision).unwrap();
+    std::fs::write(scratch.join("inbox_summary.md"), summary).unwrap();
+    bridge_for_drive
+        .enqueue_event(BridgeEvent::OutcomeReported {
+            session,
+            outcome: OutcomeKey::from_str("enqueued").unwrap(),
+            summary: "agent picked enqueued".into(),
+            artifacts_produced: vec!["triage_decision.json".into(), "inbox_summary.md".into()],
+        })
+        .await;
+    bridge_for_drive.pump_scripted_events().await;
+});
+```
+
+Remove the helper `drive_enqueued` and the `Arc_clone_workaround` reference. Final test body uses the inline `drive` task.
+
+- [ ] **Step 3: Run the test — should fail (function not implemented)**
+
+```bash
+cargo test -p surge-orchestrator --test triage_dispatch enqueued_happy_path 2>&1 | head -20
+```
+
+Expected: error[E0432]: unresolved import `surge_orchestrator::triage::dispatch_triage`.
+
+- [ ] **Step 4: Implement `dispatch_triage` in `triage.rs`**
+
+Add after `TriageError` definition:
+
+```rust
+/// Dispatch a Triage Author session against the supplied bridge.
+///
+/// Returns `Ok(TriageDecision)` even on retry exhaustion (materialises
+/// as `Unclear` with a diagnostic question). `Err(TriageError)` is
+/// reserved for invariant violations that prevent any forward progress.
+///
+/// # Errors
+/// - [`TriageError::Scratch`] if the per-call scratch directory
+///   cannot be created.
+/// - [`TriageError::Bridge`] for facade-level dead-bridge or
+///   handshake failures.
+pub async fn dispatch_triage(
+    bridge: Arc<dyn BridgeFacade>,
+    input: TriageInput,
+    opts: TriageOptions,
+) -> Result<TriageDecision, TriageError> {
+    // Short-circuit if claude binary is not configured.
+    let Some(claude_binary) = opts.claude_binary.clone() else {
+        return Ok(TriageDecision::Unclear {
+            question: "Claude binary not configured (set SURGE_CLAUDE_BINARY or install \
+                       claude-code); install to enable LLM-driven triage"
+                .into(),
+        });
+    };
+
+    // Build a fresh scratch dir for this top-level call.
+    let scratch_dir = opts
+        .scratch_root
+        .join(ulid::Ulid::new().to_string());
+    std::fs::create_dir_all(&scratch_dir)?;
+
+    let mut last_err: Option<String> = None;
+
+    for attempt in 1..=opts.max_attempts {
+        match try_one_attempt(
+            Arc::clone(&bridge),
+            &input,
+            &claude_binary,
+            &scratch_dir,
+            opts.attempt_timeout,
+            attempt,
+            last_err.as_deref(),
+        )
+        .await
+        {
+            Ok(decision) => {
+                if !opts.keep_scratch_on_failure
+                    && !matches!(decision, TriageDecision::Unclear { .. })
+                {
+                    let _ = std::fs::remove_dir_all(&scratch_dir);
+                }
+                return Ok(decision);
+            }
+            Err(AttemptError::Bridge(e)) => return Err(TriageError::Bridge(e)),
+            Err(AttemptError::Retryable(msg)) => {
+                tracing::warn!(attempt, error = %msg, "triage attempt failed; will retry");
+                last_err = Some(msg);
+            }
+        }
+    }
+
+    let question = format!(
+        "Triage failed after {} attempts: {}",
+        opts.max_attempts,
+        last_err.as_deref().unwrap_or("unknown error")
+    );
+    Ok(TriageDecision::Unclear { question })
+}
+
+/// Per-attempt error type — distinguishes retryable from fatal.
+enum AttemptError {
+    /// Bridge facade itself failed (open/send/close); fatal.
+    Bridge(String),
+    /// Retryable: timeout, agent crash, malformed artifact.
+    Retryable(String),
+}
+
+/// Bridge-level sandbox for sessions where Surge delegates isolation
+/// to the agent itself (per Vision-2026 §"Sandbox-delegated").
+///
+/// Returns `AlwaysAllowSandbox` — the bridge applies no tool filtering,
+/// because each ACP-conformant agent (Claude Code, Codex CLI, etc.)
+/// already has its own native sandbox enforcement. The profile's
+/// `[sandbox] mode = ...` field is a semantic marker the agent reads,
+/// not a directive the bridge enforces.
+///
+/// Globalising this convention (toggle in `SurgeConfig`, removal of
+/// `DenyListSandbox` surface) is the RFC-0006 refactor; for Layer 1
+/// we lock in the convention via this helper.
+fn delegated_sandbox() -> Box<dyn surge_acp::bridge::sandbox::Sandbox> {
+    Box::new(surge_acp::bridge::sandbox::AlwaysAllowSandbox)
+}
+
+async fn try_one_attempt(
+    bridge: Arc<dyn BridgeFacade>,
+    input: &TriageInput,
+    claude_binary: &PathBuf,
+    scratch_dir: &std::path::Path,
+    attempt_timeout: Duration,
+    attempt: u32,
+    feedback: Option<&str>,
+) -> Result<TriageDecision, AttemptError> {
+    use std::collections::BTreeMap;
+    use surge_acp::bridge::session::{AgentKind, MessageContent, SessionConfig};
+    use surge_acp::client::PermissionPolicy;
+
+    let prompt_text = render_prompt(input, feedback);
+
+    let declared_outcomes = vec![
+        OutcomeKey::try_from("enqueued").map_err(|e| AttemptError::Bridge(e.to_string()))?,
+        OutcomeKey::try_from("duplicate").map_err(|e| AttemptError::Bridge(e.to_string()))?,
+        OutcomeKey::try_from("out_of_scope").map_err(|e| AttemptError::Bridge(e.to_string()))?,
+        OutcomeKey::try_from("unclear").map_err(|e| AttemptError::Bridge(e.to_string()))?,
+    ];
+
+    let mut bindings = BTreeMap::new();
+    bindings.insert("intake.task_id".into(), input.task.task_id.as_str().to_string());
+    bindings.insert("intake.attempt".into(), attempt.to_string());
+
+    let cfg = SessionConfig {
+        agent_kind: AgentKind::ClaudeCode {
+            binary: claude_binary.clone(),
+            extra_args: vec![],
+        },
+        working_dir: scratch_dir.to_path_buf(),
+        system_prompt: prompt_text.clone(),
+        declared_outcomes,
+        allows_escalation: false,
+        tools: vec![],
+        sandbox: delegated_sandbox(),
+        permission_policy: PermissionPolicy::default(),
+        bindings,
+    };
+
+    let mut events = bridge.subscribe();
+
+    let session_id = bridge
+        .open_session(cfg)
+        .await
+        .map_err(|e| AttemptError::Bridge(format!("open_session: {e}")))?;
+
+    bridge
+        .send_message(session_id, MessageContent::Text(prompt_text))
+        .await
+        .map_err(|e| AttemptError::Bridge(format!("send_message: {e}")))?;
+
+    // Drive the event loop with a single timeout.
+    let outcome_result = tokio::time::timeout(attempt_timeout, async {
+        loop {
+            match events.recv().await {
+                Ok(ev) => {
+                    if event_session_id(&ev) != Some(session_id) {
+                        continue;
+                    }
+                    match ev {
+                        BridgeEvent::OutcomeReported { outcome, .. } => return Ok(outcome),
+                        BridgeEvent::SessionEnded { reason, .. } => match reason {
+                            SessionEndReason::AgentCrashed { .. } => {
+                                return Err(format!("agent crashed: {reason:?}"))
+                            }
+                            SessionEndReason::Timeout { .. } => {
+                                return Err("session timeout".into())
+                            }
+                            _ => continue,
+                        },
+                        _ => continue,
+                    }
+                }
+                Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => continue,
+                Err(tokio::sync::broadcast::error::RecvError::Closed) => {
+                    return Err("event stream closed".into())
+                }
+            }
+        }
+    })
+    .await;
+
+    let _ = bridge.close_session(session_id).await;
+
+    let outcome = match outcome_result {
+        Err(_elapsed) => return Err(AttemptError::Retryable("timeout".into())),
+        Ok(Err(msg)) => return Err(AttemptError::Retryable(msg)),
+        Ok(Ok(outcome)) => outcome,
+    };
+
+    // Read the artifact and parse.
+    let json_path = scratch_dir.join("triage_decision.json");
+    let raw = std::fs::read(&json_path).map_err(|e| {
+        AttemptError::Retryable(format!("triage_decision.json missing: {e}"))
+    })?;
+    let parsed: TriageJson = serde_json::from_slice(&raw).map_err(|e| {
+        AttemptError::Retryable(format!("triage_decision.json malformed: {e}"))
+    })?;
+    let mut decision = parsed
+        .into_decision()
+        .map_err(|e| AttemptError::Retryable(format!("decision rejected: {e}")))?;
+
+    // For Enqueued, splice in the inbox_summary.md if present.
+    if let TriageDecision::Enqueued { summary, .. } = &mut decision {
+        if summary.is_empty() {
+            if let Ok(md) = std::fs::read_to_string(scratch_dir.join("inbox_summary.md")) {
+                *summary = md;
+            }
+        }
+    }
+
+    // Sanity-check against the agent's reported outcome string.
+    let outcome_str = outcome.as_str();
+    let decision_kind = match &decision {
+        TriageDecision::Enqueued { .. } => "enqueued",
+        TriageDecision::Duplicate { .. } => "duplicate",
+        TriageDecision::OutOfScope { .. } => "out_of_scope",
+        TriageDecision::Unclear { .. } => "unclear",
+    };
+    if outcome_str != decision_kind {
+        return Err(AttemptError::Retryable(format!(
+            "outcome ({outcome_str}) mismatch with decision ({decision_kind})"
+        )));
+    }
+
+    Ok(decision)
+}
+
+fn render_prompt(input: &TriageInput, feedback: Option<&str>) -> String {
+    let json = serde_json::to_string_pretty(input)
+        .unwrap_or_else(|_| "{}".into());
+    let mut out = String::new();
+    out.push_str(crate::BOOTSTRAP_TRIAGE_AUTHOR_TOML);
+    out.push_str("\n\n# Inputs\n\nThe triage input is encoded as JSON. The shape is:\n");
+    out.push_str("- task: TaskDetails\n- candidates: TaskSummary[]\n- active_runs: ActiveRunSummary[]\n\n");
+    out.push_str("The literal JSON follows:\n\n");
+    out.push_str(&json);
+    out.push_str("\n\n# Task\n\nDecide whether this ticket is a duplicate, out-of-scope, unclear, \
+                  or should be enqueued. Then, in your working directory:\n\n\
+                  1. Write your structured decision to `triage_decision.json` (schema below).\n\
+                  2. Write a 3-5 line markdown blurb to `inbox_summary.md` (used as the body of \
+                     the inbox card on `enqueued`; safe to omit otherwise).\n\
+                  3. Call `report_stage_outcome` with the matching `outcome` and \
+                     `artifacts_produced = [\"triage_decision.json\", \"inbox_summary.md\"]`.\n\n");
+    out.push_str("triage_decision.json schema:\n\
+                  - decision: \"enqueued\" | \"duplicate\" | \"out_of_scope\" | \"unclear\"\n\
+                  - duplicate_of: string (task id) or null\n\
+                  - priority: \"urgent\" | \"high\" | \"medium\" | \"low\"\n\
+                  - priority_reasoning: one sentence\n\
+                  - summary: one sentence\n\
+                  - question: string (only when decision = \"unclear\")\n");
+    if let Some(fb) = feedback {
+        out.push_str("\n# Feedback from previous attempt\n\n");
+        out.push_str(fb);
+        out.push('\n');
+    }
+    out
+}
+
+fn event_session_id(event: &BridgeEvent) -> Option<SessionId> {
+    match event {
+        BridgeEvent::SessionEstablished { session, .. }
+        | BridgeEvent::AgentMessage { session, .. }
+        | BridgeEvent::TokenUsage { session, .. }
+        | BridgeEvent::ToolCall { session, .. }
+        | BridgeEvent::ToolResult { session, .. }
+        | BridgeEvent::OutcomeReported { session, .. }
+        | BridgeEvent::HumanInputRequested { session, .. }
+        | BridgeEvent::SessionEnded { session, .. } => Some(*session),
+        BridgeEvent::Error { session, .. } => *session,
+    }
+}
+```
+
+Add the `BridgeEvent` and `OutcomeKey` imports at top of file:
+
+```rust
+use surge_acp::bridge::event::{BridgeEvent, SessionEndReason};
+use surge_core::{OutcomeKey, SessionId};
+```
+
+- [ ] **Step 5: Run the test — should pass**
+
+```bash
+cargo test -p surge-orchestrator --test triage_dispatch enqueued_happy_path
+```
+
+Expected: `test result: ok. 1 passed`.
+
+If it hangs: the test scratch-dir polling is racy. Increase the `tokio::time::sleep(Duration::from_millis(50))` to 200ms, or add an explicit synchronisation pattern via `tokio::sync::Notify` between the dispatcher's subscribe and the drive task's pump.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/surge-orchestrator/src/triage.rs crates/surge-orchestrator/tests/triage_dispatch.rs
+git commit -m "$(cat <<'EOF'
+feat(orchestrator): dispatch_triage Enqueued happy path
+
+Adds the core dispatch loop: open ACP session, send prompt, await
+OutcomeReported, read triage_decision.json + inbox_summary.md from
+scratch dir, parse via TriageJson::into_decision. Layer 1 of the
+two-layer plan in 2026-05-06-triage-author-llm-dispatch-design.md.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: Decision-variant tests (Duplicate / OutOfScope / Unclear)
+
+**Files:**
+- Modify: `crates/surge-orchestrator/tests/triage_dispatch.rs`
+
+- [ ] **Step 1: Extract a shared `drive_one_attempt` helper at the top of the test file**
+
+Add right after the `input()` helper:
+
+```rust
+/// Reusable driver: writes JSON + summary into the scratch sub-dir
+/// the dispatcher created, then enqueues an OutcomeReported event
+/// matching `outcome_key`.
+async fn drive_one_attempt(
+    bridge: Arc<fixtures::mock_bridge::MockBridge>,
+    scratch_root: std::path::PathBuf,
+    session: SessionId,
+    outcome_key: &str,
+    decision_json: &str,
+    summary_md: &str,
+) {
+    tokio::time::sleep(Duration::from_millis(80)).await;
+    let scratch = std::fs::read_dir(&scratch_root)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .find(|e| e.file_type().map(|t| t.is_dir()).unwrap_or(false))
+        .expect("dispatcher created scratch subdir")
+        .path();
+
+    std::fs::write(scratch.join("triage_decision.json"), decision_json).unwrap();
+    if !summary_md.is_empty() {
+        std::fs::write(scratch.join("inbox_summary.md"), summary_md).unwrap();
+    }
+    bridge
+        .enqueue_event(BridgeEvent::OutcomeReported {
+            session,
+            outcome: OutcomeKey::from_str(outcome_key).unwrap(),
+            summary: format!("agent picked {outcome_key}"),
+            artifacts_produced: vec!["triage_decision.json".into(), "inbox_summary.md".into()],
+        })
+        .await;
+    bridge.pump_scripted_events().await;
+}
+```
+
+Refactor `enqueued_happy_path` to use `drive_one_attempt`. Then add the next three tests:
+
+- [ ] **Step 2: Add `duplicate_happy_path`**
+
+```rust
+#[tokio::test]
+async fn duplicate_happy_path() {
+    let bridge = Arc::new(fixtures::mock_bridge::MockBridge::new());
+    let session = SessionId::new();
+    bridge.pin_next_session_id(session).await;
+
+    let tmp = TempDir::new().unwrap();
+    let opts = TriageOptions {
+        claude_binary: Some(std::path::PathBuf::from("/dev/null")),
+        attempt_timeout: Duration::from_secs(2),
+        max_attempts: 1,
+        scratch_root: tmp.path().to_path_buf(),
+        keep_scratch_on_failure: false,
+    };
+
+    let drive = tokio::spawn(drive_one_attempt(
+        Arc::clone(&bridge),
+        tmp.path().to_path_buf(),
+        session,
+        "duplicate",
+        r#"{"decision":"duplicate","duplicate_of":"mock:t#42","priority":"high","priority_reasoning":"same code path"}"#,
+        "",
+    ));
+
+    let result = dispatch_triage(
+        Arc::clone(&bridge) as Arc<dyn BridgeFacade>,
+        input(),
+        opts,
+    )
+    .await
+    .unwrap();
+    drive.await.unwrap();
+
+    match result {
+        TriageDecision::Duplicate { of, .. } => {
+            assert_eq!(of.as_str(), "mock:t#42");
+        }
+        other => panic!("expected Duplicate, got {other:?}"),
+    }
+}
+```
+
+- [ ] **Step 3: Add `out_of_scope_happy_path`**
+
+```rust
+#[tokio::test]
+async fn out_of_scope_happy_path() {
+    let bridge = Arc::new(fixtures::mock_bridge::MockBridge::new());
+    let session = SessionId::new();
+    bridge.pin_next_session_id(session).await;
+
+    let tmp = TempDir::new().unwrap();
+    let opts = TriageOptions {
+        claude_binary: Some(std::path::PathBuf::from("/dev/null")),
+        attempt_timeout: Duration::from_secs(2),
+        max_attempts: 1,
+        scratch_root: tmp.path().to_path_buf(),
+        keep_scratch_on_failure: false,
+    };
+
+    let drive = tokio::spawn(drive_one_attempt(
+        Arc::clone(&bridge),
+        tmp.path().to_path_buf(),
+        session,
+        "out_of_scope",
+        r#"{"decision":"out_of_scope","priority":"low","priority_reasoning":"hiring task"}"#,
+        "",
+    ));
+
+    let result = dispatch_triage(
+        Arc::clone(&bridge) as Arc<dyn BridgeFacade>,
+        input(),
+        opts,
+    )
+    .await
+    .unwrap();
+    drive.await.unwrap();
+
+    assert!(matches!(result, TriageDecision::OutOfScope { .. }));
+}
+```
+
+- [ ] **Step 4: Add `unclear_happy_path`**
+
+```rust
+#[tokio::test]
+async fn unclear_happy_path() {
+    let bridge = Arc::new(fixtures::mock_bridge::MockBridge::new());
+    let session = SessionId::new();
+    bridge.pin_next_session_id(session).await;
+
+    let tmp = TempDir::new().unwrap();
+    let opts = TriageOptions {
+        claude_binary: Some(std::path::PathBuf::from("/dev/null")),
+        attempt_timeout: Duration::from_secs(2),
+        max_attempts: 1,
+        scratch_root: tmp.path().to_path_buf(),
+        keep_scratch_on_failure: false,
+    };
+
+    let drive = tokio::spawn(drive_one_attempt(
+        Arc::clone(&bridge),
+        tmp.path().to_path_buf(),
+        session,
+        "unclear",
+        r#"{"decision":"unclear","priority":"medium","question":"What does X mean here?"}"#,
+        "",
+    ));
+
+    let result = dispatch_triage(
+        Arc::clone(&bridge) as Arc<dyn BridgeFacade>,
+        input(),
+        opts,
+    )
+    .await
+    .unwrap();
+    drive.await.unwrap();
+
+    match result {
+        TriageDecision::Unclear { question } => {
+            assert!(question.contains("What does X mean here"));
+        }
+        other => panic!("expected Unclear, got {other:?}"),
+    }
+}
+```
+
+- [ ] **Step 5: Run all four tests**
+
+```bash
+cargo test -p surge-orchestrator --test triage_dispatch
+```
+
+Expected: `4 passed`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/surge-orchestrator/tests/triage_dispatch.rs
+git commit -m "$(cat <<'EOF'
+test(orchestrator): triage decision variants Duplicate/OOS/Unclear
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 6: Retry mechanics — bad JSON recovers; exhaustion → Unclear
+
+**Files:**
+- Modify: `crates/surge-orchestrator/tests/triage_dispatch.rs`
+
+- [ ] **Step 1: Add helper for multi-attempt scripting**
+
+We need to drive multiple attempts. Each attempt opens a new session (the dispatcher closes between retries). So the helper writes to whichever scratch sub-dir exists most recently and emits one event per attempt.
+
+Add to `triage_dispatch.rs`:
+
+```rust
+/// Drive `n_attempts` sequential attempts. For each, write the
+/// supplied (decision_json, summary_md) into the latest scratch
+/// sub-dir and emit OutcomeReported for `outcome_keys[i]`.
+async fn drive_n_attempts(
+    bridge: Arc<fixtures::mock_bridge::MockBridge>,
+    scratch_root: std::path::PathBuf,
+    sessions: Vec<SessionId>,
+    outcomes_and_artifacts: Vec<(&'static str, &'static str)>,
+) {
+    assert_eq!(sessions.len(), outcomes_and_artifacts.len());
+    for (i, (outcome_key, decision_json)) in outcomes_and_artifacts.iter().enumerate() {
+        // Wait for dispatcher to create a new scratch dir for this attempt
+        // (only true for the first attempt — later attempts reuse the
+        // top-level scratch dir; the inner attempt logic runs against
+        // the same scratch_dir).
+        tokio::time::sleep(Duration::from_millis(80)).await;
+        let scratch = std::fs::read_dir(&scratch_root)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .find(|e| e.file_type().map(|t| t.is_dir()).unwrap_or(false))
+            .expect("dispatcher created scratch subdir")
+            .path();
+        std::fs::write(scratch.join("triage_decision.json"), decision_json).unwrap();
+        bridge
+            .enqueue_event(BridgeEvent::OutcomeReported {
+                session: sessions[i],
+                outcome: OutcomeKey::from_str(outcome_key).unwrap(),
+                summary: format!("attempt {} → {outcome_key}", i + 1),
+                artifacts_produced: vec!["triage_decision.json".into()],
+            })
+            .await;
+        bridge.pump_scripted_events().await;
+    }
+}
+```
+
+Note: per the implementation in Task 4, the scratch dir is created **once per `dispatch_triage` call** (top-level), and reused across retries — see the `for attempt in 1..=opts.max_attempts` loop. So we only need one scratch sub-dir, not one per attempt.
+
+- [ ] **Step 2: Pin a sequence of session ids on MockBridge**
+
+`MockBridge::pin_next_session_id` consumes one id per call. To pin a sequence, extend `MockBridge` with `pin_session_ids(Vec<SessionId>)` that pops from a queue.
+
+Modify `crates/surge-orchestrator/tests/fixtures/mock_bridge.rs`:
+
+```rust
+// Replace `pinned_session_id: Mutex<Option<SessionId>>` with:
+pinned_session_ids: Mutex<VecDeque<SessionId>>,
+```
+
+Update `MockBridge::new`:
+```rust
+pinned_session_ids: Mutex::new(VecDeque::new()),
+```
+
+Replace `pin_next_session_id`:
+```rust
+#[allow(dead_code)]
+pub async fn pin_next_session_id(&self, id: SessionId) {
+    self.pinned_session_ids.lock().await.push_back(id);
+}
+
+#[allow(dead_code)]
+pub async fn pin_session_ids(&self, ids: Vec<SessionId>) {
+    let mut q = self.pinned_session_ids.lock().await;
+    for id in ids {
+        q.push_back(id);
+    }
+}
+```
+
+Update the `open_session` impl in the same file:
+```rust
+async fn open_session(&self, _: SessionConfig) -> Result<SessionId, OpenSessionError> {
+    self.recorded_calls.lock().await.push(RecordedCall::OpenSession);
+    let id = self
+        .pinned_session_ids
+        .lock()
+        .await
+        .pop_front()
+        .unwrap_or_else(SessionId::new);
+    Ok(id)
+}
+```
+
+Run the existing orchestrator tests to make sure nothing else broke:
+
+```bash
+cargo test -p surge-orchestrator --tests 2>&1 | tail -20
+```
+
+Expected: existing tests still pass. (The single-session `pin_next_session_id` is now backed by the queue; behaviour is identical for tests that pin only one.)
+
+- [ ] **Step 3: Write `bad_json_then_recovers`**
+
+Add to `triage_dispatch.rs`:
+
+```rust
+#[tokio::test]
+async fn bad_json_then_recovers() {
+    let bridge = Arc::new(fixtures::mock_bridge::MockBridge::new());
+    let session_a = SessionId::new();
+    let session_b = SessionId::new();
+    bridge.pin_session_ids(vec![session_a, session_b]).await;
+
+    let tmp = TempDir::new().unwrap();
+    let opts = TriageOptions {
+        claude_binary: Some(std::path::PathBuf::from("/dev/null")),
+        attempt_timeout: Duration::from_secs(2),
+        max_attempts: 3,
+        scratch_root: tmp.path().to_path_buf(),
+        keep_scratch_on_failure: false,
+    };
+
+    let drive = tokio::spawn(drive_n_attempts(
+        Arc::clone(&bridge),
+        tmp.path().to_path_buf(),
+        vec![session_a, session_b],
+        vec![
+            ("enqueued", "{ this is not valid json"),
+            ("enqueued", r#"{"decision":"enqueued","priority":"medium","priority_reasoning":"ok","summary":"fixed"}"#),
+        ],
+    ));
+
+    let result = dispatch_triage(
+        Arc::clone(&bridge) as Arc<dyn BridgeFacade>,
+        input(),
+        opts,
+    )
+    .await
+    .unwrap();
+    drive.await.unwrap();
+
+    assert!(matches!(result, TriageDecision::Enqueued { .. }));
+}
+```
+
+- [ ] **Step 4: Write `exhaust_retries_yields_unclear`**
+
+```rust
+#[tokio::test]
+async fn exhaust_retries_yields_unclear() {
+    let bridge = Arc::new(fixtures::mock_bridge::MockBridge::new());
+    let s1 = SessionId::new();
+    let s2 = SessionId::new();
+    let s3 = SessionId::new();
+    bridge.pin_session_ids(vec![s1, s2, s3]).await;
+
+    let tmp = TempDir::new().unwrap();
+    let opts = TriageOptions {
+        claude_binary: Some(std::path::PathBuf::from("/dev/null")),
+        attempt_timeout: Duration::from_secs(2),
+        max_attempts: 3,
+        scratch_root: tmp.path().to_path_buf(),
+        keep_scratch_on_failure: true,
+    };
+
+    let drive = tokio::spawn(drive_n_attempts(
+        Arc::clone(&bridge),
+        tmp.path().to_path_buf(),
+        vec![s1, s2, s3],
+        vec![
+            ("enqueued", "{ bad 1"),
+            ("enqueued", "{ bad 2"),
+            ("enqueued", "{ bad 3"),
+        ],
+    ));
+
+    let result = dispatch_triage(
+        Arc::clone(&bridge) as Arc<dyn BridgeFacade>,
+        input(),
+        opts,
+    )
+    .await
+    .unwrap();
+    drive.await.unwrap();
+
+    match result {
+        TriageDecision::Unclear { question } => {
+            assert!(question.contains("Triage failed after 3 attempts"));
+        }
+        other => panic!("expected Unclear, got {other:?}"),
+    }
+}
+```
+
+- [ ] **Step 5: Run the new tests**
+
+```bash
+cargo test -p surge-orchestrator --test triage_dispatch bad_json_then_recovers exhaust_retries_yields_unclear
+```
+
+Expected: `2 passed`.
+
+- [ ] **Step 6: Run full triage_dispatch suite**
+
+```bash
+cargo test -p surge-orchestrator --test triage_dispatch
+```
+
+Expected: `6 passed`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/surge-orchestrator/tests/triage_dispatch.rs crates/surge-orchestrator/tests/fixtures/mock_bridge.rs
+git commit -m "$(cat <<'EOF'
+test(orchestrator): triage retry mechanics — bad JSON + exhaustion
+
+Adds two retry tests: malformed JSON on attempt 1 recovers on attempt 2;
+three malformed attempts yield Unclear with diagnostic question.
+Extends MockBridge to support pinning a sequence of session ids.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 7: Timeout and AgentCrashed retry tests
+
+**Files:**
+- Modify: `crates/surge-orchestrator/tests/triage_dispatch.rs`
+
+- [ ] **Step 1: Write `timeout_yields_unclear`**
+
+Append to `triage_dispatch.rs`:
+
+```rust
+#[tokio::test]
+async fn timeout_yields_unclear() {
+    let bridge = Arc::new(fixtures::mock_bridge::MockBridge::new());
+    let s = SessionId::new();
+    bridge.pin_session_ids(vec![s]).await;
+
+    let tmp = TempDir::new().unwrap();
+    let opts = TriageOptions {
+        claude_binary: Some(std::path::PathBuf::from("/dev/null")),
+        attempt_timeout: Duration::from_millis(150),
+        max_attempts: 1,
+        scratch_root: tmp.path().to_path_buf(),
+        keep_scratch_on_failure: true,
+    };
+
+    // No drive task — bridge never emits OutcomeReported, so the
+    // dispatcher hits its tokio::time::timeout.
+    let result = dispatch_triage(
+        Arc::clone(&bridge) as Arc<dyn BridgeFacade>,
+        input(),
+        opts,
+    )
+    .await
+    .unwrap();
+
+    match result {
+        TriageDecision::Unclear { question } => assert!(question.contains("timeout")),
+        other => panic!("expected Unclear, got {other:?}"),
+    }
+}
+```
+
+- [ ] **Step 2: Write `agent_crashed_yields_unclear`**
+
+```rust
+#[tokio::test]
+async fn agent_crashed_yields_unclear() {
+    let bridge = Arc::new(fixtures::mock_bridge::MockBridge::new());
+    let s = SessionId::new();
+    bridge.pin_session_ids(vec![s]).await;
+
+    let tmp = TempDir::new().unwrap();
+    let opts = TriageOptions {
+        claude_binary: Some(std::path::PathBuf::from("/dev/null")),
+        attempt_timeout: Duration::from_secs(2),
+        max_attempts: 1,
+        scratch_root: tmp.path().to_path_buf(),
+        keep_scratch_on_failure: true,
+    };
+
+    let drive = {
+        let bridge = Arc::clone(&bridge);
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(80)).await;
+            bridge
+                .enqueue_event(BridgeEvent::SessionEnded {
+                    session: s,
+                    reason: SessionEndReason::AgentCrashed {
+                        exit_code: Some(137),
+                        stderr_tail: "killed".into(),
+                    },
+                })
+                .await;
+            bridge.pump_scripted_events().await;
+        })
+    };
+
+    let result = dispatch_triage(
+        Arc::clone(&bridge) as Arc<dyn BridgeFacade>,
+        input(),
+        opts,
+    )
+    .await
+    .unwrap();
+    drive.await.unwrap();
+
+    match result {
+        TriageDecision::Unclear { question } => {
+            assert!(question.contains("agent crashed") || question.contains("AgentCrashed"));
+        }
+        other => panic!("expected Unclear, got {other:?}"),
+    }
+}
+```
+
+- [ ] **Step 3: Write `binary_missing_short_circuits`**
+
+```rust
+#[tokio::test]
+async fn binary_missing_short_circuits() {
+    let bridge = Arc::new(fixtures::mock_bridge::MockBridge::new());
+
+    let tmp = TempDir::new().unwrap();
+    let opts = TriageOptions {
+        claude_binary: None, // explicit
+        attempt_timeout: Duration::from_secs(5),
+        max_attempts: 3,
+        scratch_root: tmp.path().to_path_buf(),
+        keep_scratch_on_failure: false,
+    };
+
+    let result = dispatch_triage(
+        Arc::clone(&bridge) as Arc<dyn BridgeFacade>,
+        input(),
+        opts,
+    )
+    .await
+    .unwrap();
+
+    match result {
+        TriageDecision::Unclear { question } => {
+            assert!(question.to_lowercase().contains("claude binary"));
+        }
+        other => panic!("expected Unclear, got {other:?}"),
+    }
+
+    // The bridge should NEVER have been called — the function returned
+    // before any open_session.
+    let calls = bridge.recorded_calls.lock().await;
+    assert!(calls.is_empty(), "no bridge calls expected, got {calls:?}");
+}
+```
+
+- [ ] **Step 4: Run the three tests**
+
+```bash
+cargo test -p surge-orchestrator --test triage_dispatch timeout_yields_unclear agent_crashed_yields_unclear binary_missing_short_circuits
+```
+
+Expected: `3 passed`.
+
+- [ ] **Step 5: Run full triage_dispatch suite**
+
+```bash
+cargo test -p surge-orchestrator --test triage_dispatch
+```
+
+Expected: `9 passed`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/surge-orchestrator/tests/triage_dispatch.rs
+git commit -m "$(cat <<'EOF'
+test(orchestrator): triage timeout/agent-crash/binary-missing paths
+
+Validates that exhausted timeout/crash retries yield Unclear, and
+that a None claude_binary short-circuits without touching the bridge.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 8: Initial-message snapshot test
+
+**Files:**
+- Modify: `crates/surge-orchestrator/src/triage.rs`
+- Confirm: `insta` is in dev-dependencies (it should be — used elsewhere in workspace)
+
+- [ ] **Step 1: Confirm `insta` is available**
+
+```bash
+grep -n "insta" crates/surge-orchestrator/Cargo.toml
+```
+
+If not present in `[dev-dependencies]`, add it:
+
+```toml
+insta = { workspace = true }
+```
+
+- [ ] **Step 2: Add the snapshot test in the existing `tests` module**
+
+Append inside the existing `#[cfg(test)] mod tests { ... }` block (the parser tests at the bottom of `triage.rs`):
+
+```rust
+#[test]
+fn render_prompt_snapshot() {
+    use chrono::TimeZone;
+    let task = TaskDetails {
+        task_id: TaskId::try_new("github_issues:test/repo#42").unwrap(),
+        source_id: "github_issues:test/repo".into(),
+        title: "Add tracing to auth middleware".into(),
+        description: "We have no observability into the auth flow.".into(),
+        status: "open".into(),
+        labels: vec!["surge:enabled".into(), "area/auth".into()],
+        url: "https://github.com/test/repo/issues/42".into(),
+        created_at: chrono::Utc.with_ymd_and_hms(2026, 5, 1, 10, 0, 0).unwrap(),
+        updated_at: chrono::Utc.with_ymd_and_hms(2026, 5, 5, 12, 0, 0).unwrap(),
+        assignee: None,
+        raw_payload: serde_json::json!({}),
+    };
+    let candidates = vec![
+        TaskSummary {
+            task_id: TaskId::try_new("github_issues:test/repo#10").unwrap(),
+            title: "Update README".into(),
+            status: "open".into(),
+            url: "https://github.com/test/repo/issues/10".into(),
+            updated_at: chrono::Utc.with_ymd_and_hms(2026, 4, 28, 9, 0, 0).unwrap(),
+        },
+    ];
+    let active_runs = vec![ActiveRunSummary {
+        run_id: "01HXX0000000000000000RUN1".into(),
+        task_id: Some("github_issues:test/repo#9".into()),
+        status: "Running".into(),
+        started_at: "2026-05-06T10:00:00Z".into(),
+    }];
+    let input = TriageInput {
+        task,
+        candidates,
+        active_runs,
+    };
+    let rendered = super::render_prompt(&input, None);
+    insta::assert_snapshot!("triage_initial_prompt", rendered);
+}
+
+#[test]
+fn render_prompt_with_feedback_includes_feedback_block() {
+    let task = TaskDetails {
+        task_id: TaskId::try_new("github_issues:t/r#1").unwrap(),
+        source_id: "github_issues:t/r".into(),
+        title: "x".into(),
+        description: "y".into(),
+        status: "open".into(),
+        labels: vec![],
+        url: "https://x".into(),
+        created_at: chrono::Utc::now(),
+        updated_at: chrono::Utc::now(),
+        assignee: None,
+        raw_payload: serde_json::json!({}),
+    };
+    let input = TriageInput {
+        task,
+        candidates: vec![],
+        active_runs: vec![],
+    };
+    let rendered = super::render_prompt(&input, Some("previous attempt malformed JSON"));
+    assert!(rendered.contains("# Feedback from previous attempt"));
+    assert!(rendered.contains("previous attempt malformed JSON"));
+}
+```
+
+- [ ] **Step 3: Run the test, accept the snapshot**
+
+```bash
+cargo test -p surge-orchestrator --lib triage::tests::render_prompt_snapshot
+```
+
+Expected on first run: snapshot review prompted (test fails or pending).
+
+```bash
+cargo insta accept --package surge-orchestrator
+```
+
+Then re-run:
+
+```bash
+cargo test -p surge-orchestrator --lib triage::tests::render_prompt_snapshot
+```
+
+Expected: pass.
+
+- [ ] **Step 4: Run the feedback-block test**
+
+```bash
+cargo test -p surge-orchestrator --lib triage::tests::render_prompt_with_feedback_includes_feedback_block
+```
+
+Expected: pass.
+
+- [ ] **Step 5: Commit (include the snapshot file)**
+
+```bash
+git add crates/surge-orchestrator/src/triage.rs crates/surge-orchestrator/src/snapshots/
+git commit -m "$(cat <<'EOF'
+test(orchestrator): snapshot test for triage prompt rendering
+
+Catches prompt regressions at PR review time. Also asserts feedback
+block is appended on retry attempts.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 9: Claude-binary discovery helper
+
+**Files:**
+- Modify: `crates/surge-orchestrator/src/triage.rs`
+
+- [ ] **Step 1: Write the failing helper test**
+
+Append to the existing `#[cfg(test)] mod tests` in `triage.rs`:
+
+```rust
+#[test]
+fn find_claude_binary_returns_env_when_set() {
+    let tmp = tempfile::tempdir().unwrap();
+    let fake = tmp.path().join("claude-fake");
+    std::fs::write(&fake, b"#!/bin/sh\necho fake\n").unwrap();
+    // SAFETY: setting an env var in a single-threaded test is fine.
+    // Tests in the same crate that touch this var should be #[serial].
+    unsafe { std::env::set_var("SURGE_CLAUDE_BINARY", &fake); }
+    let result = super::find_claude_binary();
+    unsafe { std::env::remove_var("SURGE_CLAUDE_BINARY"); }
+    assert_eq!(result, Some(fake));
+}
+
+#[test]
+fn find_claude_binary_returns_none_when_not_found() {
+    unsafe { std::env::remove_var("SURGE_CLAUDE_BINARY"); }
+    unsafe { std::env::remove_var("CLAUDE_PATH"); }
+    // We can't 100% guarantee `claude` isn't on PATH; relax the assertion to
+    // "function returns Some-or-None without panicking and the result is a
+    // valid file path if Some".
+    if let Some(p) = super::find_claude_binary() {
+        assert!(p.exists(), "discovery returned a non-existent path: {p:?}");
+    }
+}
+```
+
+- [ ] **Step 2: Run — should fail to compile**
+
+```bash
+cargo test -p surge-orchestrator --lib triage::tests::find_claude_binary 2>&1 | head -10
+```
+
+Expected: function `find_claude_binary` not found.
+
+- [ ] **Step 3: Implement `find_claude_binary` in `triage.rs`**
+
+Add at module scope (sibling of `dispatch_triage`):
+
+```rust
+/// Best-effort discovery of the Claude binary path.
+///
+/// Probe order:
+/// 1. `SURGE_CLAUDE_BINARY` env var (must point to an existing file).
+/// 2. `CLAUDE_PATH` env var (existing convention from `surge-acp::discovery`).
+/// 3. Standard install locations for the current platform: e.g.
+///    `/usr/local/bin/claude`, `/opt/homebrew/bin/claude`, `~/.local/bin/claude`,
+///    `%USERPROFILE%\AppData\Local\Programs\claude\claude.exe`.
+///
+/// Returns `None` if no candidate exists. The dispatcher then surfaces
+/// a configuration-hint Unclear notification.
+#[must_use]
+pub fn find_claude_binary() -> Option<PathBuf> {
+    for var in ["SURGE_CLAUDE_BINARY", "CLAUDE_PATH"] {
+        if let Ok(v) = std::env::var(var) {
+            let p = PathBuf::from(v);
+            if p.is_file() {
+                return Some(p);
+            }
+        }
+    }
+
+    // Standard paths probe via surge_acp::discovery::Platform.
+    use surge_acp::discovery::Platform;
+    let bin_name = if cfg!(windows) { "claude.exe" } else { "claude" };
+    for base in Platform::current().standard_paths() {
+        let candidate = base.join(bin_name);
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+    }
+    None
+}
+```
+
+- [ ] **Step 4: Run the tests**
+
+```bash
+cargo test -p surge-orchestrator --lib triage::tests::find_claude_binary
+```
+
+Expected: `2 passed`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/surge-orchestrator/src/triage.rs
+git commit -m "$(cat <<'EOF'
+feat(orchestrator): triage::find_claude_binary helper
+
+Probes SURGE_CLAUDE_BINARY, CLAUDE_PATH, then platform-standard
+install locations. Returns None for missing — dispatcher then
+short-circuits to Unclear with a configuration hint.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 10: Daemon helper extraction — `deliver_fallback_inbox`
+
+**Files:**
+- Modify: `crates/surge-daemon/src/main.rs`
+
+- [ ] **Step 1: Open `crates/surge-daemon/src/main.rs` and locate the existing `RouterOutput::Triage` arm (around lines 311–394)**
+
+```bash
+grep -n "RouterOutput::Triage\|Priority::Medium" crates/surge-daemon/src/main.rs
+```
+
+- [ ] **Step 2: Extract the InboxCard-building + delivery logic into a helper at module scope**
+
+After the existing `surge_runs_dir()` helper near the top of `main.rs`, add:
+
+```rust
+/// Deliver a Medium-priority placeholder InboxCard for `event`.
+///
+/// Used as the fallback path when (a) the source registry doesn't
+/// know `event.source_id`, (b) `source.fetch_task` fails, or (c)
+/// `dispatch_triage` returns `TriageError`. Preserves Plan-C-MVP
+/// behaviour for unrecoverable provider errors.
+async fn deliver_fallback_inbox(
+    notifier: &Arc<dyn surge_notify::NotifyDeliverer>,
+    event: &surge_intake::types::TaskEvent,
+) {
+    let title = event
+        .raw_payload
+        .get("title")
+        .and_then(|v| v.as_str())
+        .unwrap_or("New ticket")
+        .to_string();
+    let task_url = event
+        .raw_payload
+        .get("url")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+    let provider = event
+        .task_id
+        .as_str()
+        .split(':')
+        .next()
+        .unwrap_or("unknown")
+        .to_string();
+    let run_id_str = ulid::Ulid::new().to_string();
+    let payload = surge_notify::messages::InboxCardPayload {
+        task_id: event.task_id.clone(),
+        source_id: event.source_id.clone(),
+        provider,
+        title,
+        summary: String::new(),
+        priority: surge_intake::types::Priority::Medium,
+        task_url,
+        run_id: run_id_str.clone(),
+    };
+    let rendered_desktop = surge_notify::desktop::format_inbox_card_desktop(&payload);
+    let rendered = surge_notify::RenderedNotification {
+        severity: surge_core::notify_config::NotifySeverity::Info,
+        title: rendered_desktop.title.clone(),
+        body: rendered_desktop.body.clone(),
+        artifact_paths: vec![],
+    };
+    let run_id = match run_id_str.parse::<surge_core::id::RunId>() {
+        Ok(id) => id,
+        Err(e) => {
+            tracing::warn!(error = %e, "failed to parse run_id; skipping fallback delivery");
+            return;
+        }
+    };
+    let node_key = match surge_core::keys::NodeKey::try_new("intake") {
+        Ok(key) => key,
+        Err(e) => {
+            tracing::warn!(error = %e, "failed to construct intake NodeKey");
+            return;
+        }
+    };
+    let channel = surge_core::notify_config::NotifyChannel::Desktop;
+    let ctx = surge_notify::NotifyDeliveryContext {
+        run_id,
+        node: &node_key,
+    };
+    match notifier.deliver(&ctx, &channel, &rendered).await {
+        Ok(()) => tracing::info!(task_id = %event.task_id, "fallback InboxCard delivered"),
+        Err(surge_notify::NotifyError::ChannelNotConfigured) => {
+            tracing::debug!(task_id = %event.task_id, "Desktop channel not configured")
+        }
+        Err(e) => tracing::warn!(error = %e, task_id = %event.task_id, "fallback delivery failed"),
+    }
+}
+```
+
+- [ ] **Step 3: Build to confirm helper compiles in isolation**
+
+```bash
+cargo build -p surge-daemon
+```
+
+Expected: success (the function isn't called yet — that's Task 11).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/surge-daemon/src/main.rs
+git commit -m "$(cat <<'EOF'
+refactor(daemon): extract deliver_fallback_inbox helper
+
+Pulls Medium-priority placeholder InboxCard logic out of the
+RouterOutput::Triage arm. Reused in the next commit for two
+distinct error paths (no source / fetch_task fail).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 11: Daemon — replace placeholder with `dispatch_triage`
+
+**Files:**
+- Modify: `crates/surge-daemon/src/main.rs`
+
+- [ ] **Step 1: Locate the exact `RouterOutput::Triage { event } => { ... }` arm**
+
+```bash
+grep -n "RouterOutput::Triage\|RouterOutput::EarlyDuplicate" crates/surge-daemon/src/main.rs
+```
+
+You'll see the arm starts around line 311 inside `tokio::spawn(async move { while let Some(out) = rx.recv().await { match out { ... } } })`.
+
+- [ ] **Step 2: Determine what the consumer task captures**
+
+Currently it captures `notifier`, `source_map_for_consumer`. We need to also capture `bridge` and `storage` (both are `Arc<...>` — clone them into the spawn block).
+
+In `spawn_task_router`, accept `bridge` and `storage` as parameters and clone into the closure. Update the function signature:
+
+```rust
+async fn spawn_task_router(
+    sources: Vec<Arc<dyn TaskSource>>,
+    source_map: HashMap<String, Arc<dyn TaskSource>>,
+    notifier: Arc<dyn surge_notify::NotifyDeliverer>,
+    storage: Arc<Storage>,
+    bridge: Arc<dyn surge_acp::bridge::facade::BridgeFacade>,
+) {
+```
+
+And inside, when spawning the consumer:
+
+```rust
+let source_map_for_consumer = Arc::new(source_map);
+let bridge_for_consumer = Arc::clone(&bridge);
+let storage_for_consumer = Arc::clone(&storage);
+let notifier_for_consumer = Arc::clone(&notifier);
+tokio::spawn(async move {
+    while let Some(out) = rx.recv().await {
+        match out {
+            // ... new Triage arm below ...
+        }
+    }
+});
+```
+
+In `main`, update the call:
+
+```rust
+spawn_task_router(
+    sources,
+    source_map,
+    Arc::clone(&notifier),
+    Arc::clone(&storage),
+    Arc::clone(&bridge),
+).await;
+```
+
+- [ ] **Step 3: Replace the `RouterOutput::Triage` arm body**
+
+Replace the existing block (lines 311–394) with:
+
+```rust
+surge_intake::router::RouterOutput::Triage { event } => {
+    let Some(source) = source_map_for_consumer.get(&event.source_id).cloned() else {
+        tracing::warn!(
+            source_id = %event.source_id,
+            "no source registered for triage event; falling back"
+        );
+        deliver_fallback_inbox(&notifier_for_consumer, &event).await;
+        continue;
+    };
+
+    // Fetch full task details — raw_payload alone is too thin for Triage.
+    let task_details = match source.fetch_task(&event.task_id).await {
+        Ok(td) => td,
+        Err(e) => {
+            tracing::warn!(error = %e, task_id = %event.task_id, "fetch_task failed; falling back");
+            deliver_fallback_inbox(&notifier_for_consumer, &event).await;
+            continue;
+        }
+    };
+
+    let candidates = surge_intake::candidates::build_for_task(&source, &task_details, 15)
+        .await
+        .unwrap_or_default();
+    let active_run_rows = storage_for_consumer
+        .snapshot_active_runs(32)
+        .await
+        .unwrap_or_default();
+    let active_runs: Vec<surge_orchestrator::triage::ActiveRunSummary> = active_run_rows
+        .into_iter()
+        .map(|r| surge_orchestrator::triage::ActiveRunSummary {
+            run_id: r.run_id,
+            task_id: r.task_id,
+            status: r.status,
+            started_at: chrono::DateTime::<chrono::Utc>::from_timestamp_millis(r.started_at_ms)
+                .map(|dt| dt.to_rfc3339())
+                .unwrap_or_default(),
+        })
+        .collect();
+
+    let input = surge_orchestrator::triage::TriageInput {
+        task: task_details.clone(),
+        candidates,
+        active_runs,
+    };
+    let scratch_root = surge_runs_dir().join("intake").join("triage");
+    let opts = surge_orchestrator::triage::TriageOptions::with_scratch_root(
+        scratch_root,
+        surge_orchestrator::triage::find_claude_binary(),
+    );
+
+    match surge_orchestrator::triage::dispatch_triage(
+        Arc::clone(&bridge_for_consumer),
+        input,
+        opts,
+    )
+    .await
+    {
+        Err(e) => {
+            tracing::warn!(error = %e, task_id = %event.task_id, "triage invariant failure; falling back");
+            deliver_fallback_inbox(&notifier_for_consumer, &event).await;
+        }
+        Ok(surge_intake::types::TriageDecision::Enqueued { priority, summary, .. }) => {
+            // Build a real InboxCardPayload using LLM-derived priority + summary.
+            let provider = event
+                .task_id
+                .as_str()
+                .split(':')
+                .next()
+                .unwrap_or("unknown")
+                .to_string();
+            let run_id_str = ulid::Ulid::new().to_string();
+            let payload = surge_notify::messages::InboxCardPayload {
+                task_id: event.task_id.clone(),
+                source_id: event.source_id.clone(),
+                provider,
+                title: task_details.title.clone(),
+                summary,
+                priority,
+                task_url: task_details.url.clone(),
+                run_id: run_id_str.clone(),
+            };
+            let rendered_desktop = surge_notify::desktop::format_inbox_card_desktop(&payload);
+            let rendered = surge_notify::RenderedNotification {
+                severity: surge_core::notify_config::NotifySeverity::Info,
+                title: rendered_desktop.title,
+                body: rendered_desktop.body,
+                artifact_paths: vec![],
+            };
+            let run_id = match run_id_str.parse::<surge_core::id::RunId>() {
+                Ok(id) => id,
+                Err(e) => {
+                    tracing::warn!(error = %e, "skipping delivery: bad run_id");
+                    continue;
+                }
+            };
+            let node_key = match surge_core::keys::NodeKey::try_new("intake") {
+                Ok(k) => k,
+                Err(e) => {
+                    tracing::warn!(error = %e, "skipping delivery: bad NodeKey");
+                    continue;
+                }
+            };
+            let channel = surge_core::notify_config::NotifyChannel::Desktop;
+            let ctx = surge_notify::NotifyDeliveryContext {
+                run_id,
+                node: &node_key,
+            };
+            match notifier_for_consumer.deliver(&ctx, &channel, &rendered).await {
+                Ok(()) => tracing::info!(task_id = %event.task_id, priority = ?payload.priority, "InboxCard delivered (LLM-derived)"),
+                Err(surge_notify::NotifyError::ChannelNotConfigured) => {
+                    tracing::debug!(task_id = %event.task_id, "Desktop channel not configured")
+                }
+                Err(e) => tracing::warn!(error = %e, task_id = %event.task_id, "InboxCard delivery failed"),
+            }
+        }
+        Ok(surge_intake::types::TriageDecision::Duplicate { of, reasoning }) => {
+            let body = format!(
+                "Surge: detected duplicate of {}. {}",
+                of.as_str(),
+                reasoning
+            );
+            if let Err(e) = source.post_comment(&event.task_id, &body).await {
+                tracing::warn!(error = %e, task_id = %event.task_id, "duplicate comment post failed");
+            } else {
+                tracing::info!(task_id = %event.task_id, duplicate_of = %of, "duplicate comment posted");
+            }
+        }
+        Ok(surge_intake::types::TriageDecision::OutOfScope { reasoning }) => {
+            let body = format!("Surge: out of scope. {}", reasoning);
+            if let Err(e) = source.post_comment(&event.task_id, &body).await {
+                tracing::warn!(error = %e, task_id = %event.task_id, "out_of_scope comment post failed");
+            } else {
+                tracing::info!(task_id = %event.task_id, "out_of_scope comment posted");
+            }
+        }
+        Ok(surge_intake::types::TriageDecision::Unclear { question }) => {
+            let rendered = surge_notify::RenderedNotification {
+                severity: surge_core::notify_config::NotifySeverity::Warn,
+                title: format!("Triage unclear · {}", event.task_id.as_str()),
+                body: question,
+                artifact_paths: vec![],
+            };
+            let run_id_str = ulid::Ulid::new().to_string();
+            let run_id = match run_id_str.parse::<surge_core::id::RunId>() {
+                Ok(id) => id,
+                Err(e) => {
+                    tracing::warn!(error = %e, "skipping unclear delivery: bad run_id");
+                    continue;
+                }
+            };
+            let node_key = match surge_core::keys::NodeKey::try_new("intake") {
+                Ok(k) => k,
+                Err(e) => {
+                    tracing::warn!(error = %e, "skipping unclear delivery: bad NodeKey");
+                    continue;
+                }
+            };
+            let channel = surge_core::notify_config::NotifyChannel::Desktop;
+            let ctx = surge_notify::NotifyDeliveryContext {
+                run_id,
+                node: &node_key,
+            };
+            match notifier_for_consumer.deliver(&ctx, &channel, &rendered).await {
+                Ok(()) => tracing::info!(task_id = %event.task_id, "Unclear notification delivered"),
+                Err(surge_notify::NotifyError::ChannelNotConfigured) => {
+                    tracing::debug!(task_id = %event.task_id, "Desktop channel not configured")
+                }
+                Err(e) => tracing::warn!(error = %e, task_id = %event.task_id, "Unclear delivery failed"),
+            }
+        }
+    }
+}
+```
+
+Keep the existing `surge_intake::router::RouterOutput::EarlyDuplicate { event, run_id }` arm unchanged.
+
+- [ ] **Step 4: Build the daemon**
+
+```bash
+cargo build -p surge-daemon
+```
+
+Expected: success.
+
+If `Storage` import is missing, add `use surge_persistence::runs::Storage;` near top of main.rs.
+
+- [ ] **Step 5: Run the existing daemon tests to confirm no regression**
+
+```bash
+cargo test -p surge-daemon
+```
+
+Expected: all green (existing tests don't exercise the Triage arm).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/surge-daemon/src/main.rs
+git commit -m "$(cat <<'EOF'
+feat(daemon): wire dispatch_triage to RouterOutput::Triage
+
+Replaces the Priority::Medium placeholder with a real ACP-driven
+Triage Author call. Routes the four TriageDecision variants:
+- Enqueued → InboxCard with LLM-derived priority + summary
+- Duplicate → tracker comment, no inbox
+- OutOfScope → tracker comment, no inbox
+- Unclear → Warn-severity desktop notification
+
+Falls back to deliver_fallback_inbox on (a) unknown source_id, (b)
+fetch_task failure, (c) TriageError invariant violation. Preserves
+Plan-C-MVP behaviour for unrecoverable provider errors.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 12: Daemon smoke test
+
+**Files:**
+- Create: `crates/surge-daemon/tests/triage_wiring.rs`
+- Confirm: `crates/surge-daemon/Cargo.toml` `[dev-dependencies]` has `surge-orchestrator` (likely missing — add)
+
+- [ ] **Step 1: Add surge-orchestrator and tempfile to daemon dev-deps**
+
+```bash
+grep -n "surge-orchestrator\|tempfile\|surge-intake" crates/surge-daemon/Cargo.toml
+```
+
+Add under `[dev-dependencies]`:
+
+```toml
+surge-orchestrator = { workspace = true }
+tempfile = { workspace = true }
+```
+
+(if any are absent — be additive, don't replace).
+
+- [ ] **Step 2: Write the test**
+
+Create `crates/surge-daemon/tests/triage_wiring.rs`:
+
+```rust
+//! Daemon smoke test: end-to-end wiring of dispatch_triage into the
+//! `RouterOutput::Triage` consumer. Uses MockBridge + MockTaskSource
+//! to validate the InboxCardPayload constructed for an Enqueued
+//! decision carries a non-Medium (LLM-derived) priority.
+//!
+//! This test does NOT exercise the consumer task in `main.rs`
+//! directly (it's tightly coupled to daemon lifecycle); instead we
+//! reproduce the four-arm match logic against an in-process channel.
+//! The cost is some duplication of branching, but it catches
+//! signature drift between dispatch_triage and the daemon's expected
+//! inputs.
+
+use chrono::Utc;
+use std::sync::Arc;
+use std::time::Duration;
+use surge_acp::bridge::event::BridgeEvent;
+use surge_acp::bridge::facade::BridgeFacade;
+use surge_core::{OutcomeKey, SessionId};
+use surge_intake::testing::MockTaskSource;
+use surge_intake::types::{TaskDetails, TaskId, Priority, TriageDecision};
+use tempfile::TempDir;
+use std::str::FromStr;
+
+#[path = "../../surge-orchestrator/tests/fixtures/mod.rs"]
+mod fixtures;
+
+#[tokio::test]
+async fn triage_enqueued_yields_real_priority() {
+    // Arrange: mock task source with one task.
+    let src = Arc::new(MockTaskSource::new("mock:t", "mock"));
+    let task = TaskDetails {
+        task_id: TaskId::try_new("mock:t#1").unwrap(),
+        source_id: "mock:t".into(),
+        title: "Fix parser panic".into(),
+        description: "Stack overflow".into(),
+        status: "open".into(),
+        labels: vec!["surge:enabled".into()],
+        url: "https://x/1".into(),
+        created_at: Utc::now(),
+        updated_at: Utc::now(),
+        assignee: None,
+        raw_payload: serde_json::json!({}),
+    };
+    src.put_task(task.clone()).await;
+
+    // Mock bridge scripted to return Enqueued{priority: Urgent}.
+    let bridge = Arc::new(fixtures::mock_bridge::MockBridge::new());
+    let session = SessionId::new();
+    bridge.pin_next_session_id(session).await;
+
+    let tmp = TempDir::new().unwrap();
+    let scratch_root = tmp.path().to_path_buf();
+    let bridge_drive = Arc::clone(&bridge);
+    let drive = tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_millis(80)).await;
+        let scratch = std::fs::read_dir(&scratch_root)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .find(|e| e.file_type().map(|t| t.is_dir()).unwrap_or(false))
+            .unwrap()
+            .path();
+        std::fs::write(
+            scratch.join("triage_decision.json"),
+            r#"{"decision":"enqueued","priority":"urgent","priority_reasoning":"prod crash","summary":"hot fix"}"#,
+        ).unwrap();
+        bridge_drive
+            .enqueue_event(BridgeEvent::OutcomeReported {
+                session,
+                outcome: OutcomeKey::from_str("enqueued").unwrap(),
+                summary: "agent".into(),
+                artifacts_produced: vec!["triage_decision.json".into()],
+            })
+            .await;
+        bridge_drive.pump_scripted_events().await;
+    });
+
+    let opts = surge_orchestrator::triage::TriageOptions {
+        claude_binary: Some(std::path::PathBuf::from("/dev/null")),
+        attempt_timeout: Duration::from_secs(2),
+        max_attempts: 1,
+        scratch_root: tmp.path().to_path_buf(),
+        keep_scratch_on_failure: false,
+    };
+    let input = surge_orchestrator::triage::TriageInput {
+        task: task.clone(),
+        candidates: vec![],
+        active_runs: vec![],
+    };
+
+    let result = surge_orchestrator::triage::dispatch_triage(
+        Arc::clone(&bridge) as Arc<dyn BridgeFacade>,
+        input,
+        opts,
+    )
+    .await
+    .unwrap();
+    drive.await.unwrap();
+
+    // Assert: not Medium, and priority round-trips into payload.
+    match result {
+        TriageDecision::Enqueued { priority, .. } => {
+            assert_eq!(priority, Priority::Urgent);
+            assert_ne!(priority, Priority::Medium, "must NOT regress to Medium placeholder");
+        }
+        other => panic!("expected Enqueued, got {other:?}"),
+    }
+}
+```
+
+- [ ] **Step 3: Run the test**
+
+```bash
+cargo test -p surge-daemon --test triage_wiring
+```
+
+Expected: `1 passed`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/surge-daemon/Cargo.toml crates/surge-daemon/tests/triage_wiring.rs
+git commit -m "$(cat <<'EOF'
+test(daemon): smoke test for triage Enqueued → real priority
+
+Validates the wiring without daemon lifecycle: MockTaskSource +
+MockBridge scripted to Enqueued{Urgent} → dispatch_triage returns
+Urgent, asserting we no longer regress to the Medium placeholder.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 13: Feature-gated LLM E2E test
+
+**Files:**
+- Modify: `crates/surge-orchestrator/Cargo.toml`
+- Modify: `crates/surge-orchestrator/tests/triage_llm.rs`
+
+- [ ] **Step 1: Confirm feature flag exists**
+
+```bash
+grep -n "_bootstrap_llm_test\|\\[features\\]" crates/surge-orchestrator/Cargo.toml
+```
+
+If absent, add to `[features]`:
+
+```toml
+[features]
+_bootstrap_llm_test = []
+```
+
+- [ ] **Step 2: Replace `triage_llm.rs` body with feature-gated real-LLM test**
+
+Open `crates/surge-orchestrator/tests/triage_llm.rs`. The file currently has a smoke that confirms fixtures parse. Keep that smoke (it runs in default builds) and add a feature-gated module that runs the real LLM:
+
+```rust
+//! Fixture-driven test for Triage Author. Two flavours:
+//!
+//! 1. Default: smoke check that fixtures parse as TOML.
+//! 2. `--features _bootstrap_llm_test`: dispatch real Claude Haiku
+//!    against the fixtures and assert decision matches.
+//!
+//! Run feature-gated:
+//!   ANTHROPIC_TEST_KEY=sk-... cargo test -p surge-orchestrator \
+//!     --test triage_llm --features _bootstrap_llm_test -- --ignored
+
+#[test]
+fn fixtures_compile() {
+    use std::fs;
+    let dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/triage_fixtures");
+    let mut count = 0;
+    for entry in fs::read_dir(&dir).expect("fixtures dir") {
+        let p = entry.unwrap().path();
+        if p.extension().and_then(|s| s.to_str()) != Some("toml") {
+            continue;
+        }
+        let contents = fs::read_to_string(&p).unwrap();
+        let _: toml::Value = toml::from_str(&contents).expect("valid TOML");
+        count += 1;
+    }
+    assert!(count >= 3, "expected at least 3 fixtures, found {count}");
+}
+
+#[cfg(feature = "_bootstrap_llm_test")]
+mod llm {
+    use std::path::PathBuf;
+    use std::sync::Arc;
+    use std::time::Duration;
+    use surge_acp::bridge::acp_bridge::AcpBridge;
+    use surge_acp::bridge::facade::BridgeFacade;
+    use surge_intake::types::{Priority, TaskDetails, TaskId, TaskSummary, TriageDecision};
+    use surge_orchestrator::triage::{dispatch_triage, TriageInput, TriageOptions};
+
+    fn priority_distance(a: Priority, b: Priority) -> u32 {
+        let rank = |p: Priority| -> u32 {
+            match p {
+                Priority::Low => 0,
+                Priority::Medium => 1,
+                Priority::High => 2,
+                Priority::Urgent => 3,
+            }
+        };
+        rank(a).abs_diff(rank(b))
+    }
+
+    #[derive(serde::Deserialize)]
+    struct Fixture {
+        input: FixtureInput,
+        expected: FixtureExpected,
+    }
+    #[derive(serde::Deserialize)]
+    struct FixtureInput {
+        task: TaskDetails,
+        #[serde(default)]
+        candidates: Vec<TaskSummary>,
+    }
+    #[derive(serde::Deserialize)]
+    struct FixtureExpected {
+        decision: String,
+        #[serde(default)]
+        priority: Option<String>,
+        #[serde(default)]
+        duplicate_of: Option<String>,
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    #[ignore = "requires ANTHROPIC_TEST_KEY and a real claude binary"]
+    async fn fixtures_against_real_haiku() {
+        let bridge = Arc::new(AcpBridge::with_defaults().expect("AcpBridge"));
+        let dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/triage_fixtures");
+
+        for entry in std::fs::read_dir(&dir).unwrap() {
+            let path = entry.unwrap().path();
+            if path.extension().and_then(|s| s.to_str()) != Some("toml") {
+                continue;
+            }
+            let raw = std::fs::read_to_string(&path).unwrap();
+            let fixture: Fixture = toml::from_str(&raw).unwrap();
+
+            let input = TriageInput {
+                task: fixture.input.task,
+                candidates: fixture.input.candidates,
+                active_runs: vec![],
+            };
+            let tmp = tempfile::tempdir().unwrap();
+            let opts = TriageOptions {
+                claude_binary: surge_orchestrator::triage::find_claude_binary(),
+                attempt_timeout: Duration::from_secs(180),
+                max_attempts: 1,
+                scratch_root: tmp.path().to_path_buf(),
+                keep_scratch_on_failure: true,
+            };
+            let result = dispatch_triage(
+                Arc::clone(&bridge) as Arc<dyn BridgeFacade>,
+                input,
+                opts,
+            )
+            .await
+            .expect("dispatch_triage");
+
+            let actual_decision = match &result {
+                TriageDecision::Enqueued { .. } => "enqueued",
+                TriageDecision::Duplicate { .. } => "duplicate",
+                TriageDecision::OutOfScope { .. } => "out_of_scope",
+                TriageDecision::Unclear { .. } => "unclear",
+            };
+            assert_eq!(
+                actual_decision, fixture.expected.decision,
+                "fixture {:?}: decision mismatch", path
+            );
+
+            if let (Some(exp_p), TriageDecision::Enqueued { priority, .. }) =
+                (fixture.expected.priority.as_deref(), &result)
+            {
+                let exp = match exp_p {
+                    "urgent" => Priority::Urgent,
+                    "high" => Priority::High,
+                    "medium" => Priority::Medium,
+                    "low" => Priority::Low,
+                    other => panic!("fixture has unknown priority: {other}"),
+                };
+                let dist = priority_distance(exp, *priority);
+                assert!(
+                    dist <= 1,
+                    "fixture {:?}: priority {:?} too far from expected {:?}",
+                    path, priority, exp
+                );
+            }
+
+            if let (Some(exp_dup), TriageDecision::Duplicate { of, .. }) =
+                (fixture.expected.duplicate_of.as_deref(), &result)
+            {
+                assert_eq!(of.as_str(), exp_dup, "fixture {:?}: duplicate_of mismatch", path);
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 3: Verify default build still passes**
+
+```bash
+cargo test -p surge-orchestrator --test triage_llm
+```
+
+Expected: smoke `fixtures_compile` passes; LLM module not compiled.
+
+- [ ] **Step 4: Verify feature build compiles (without running)**
+
+```bash
+cargo build -p surge-orchestrator --tests --features _bootstrap_llm_test
+```
+
+Expected: success.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/surge-orchestrator/Cargo.toml crates/surge-orchestrator/tests/triage_llm.rs
+git commit -m "$(cat <<'EOF'
+test(orchestrator): feature-gated LLM E2E for triage fixtures
+
+Adds --features _bootstrap_llm_test that runs real Claude Haiku
+against the three triage fixtures. Decision must match exactly;
+priority is allowed ±1 step. Default workspace test still runs the
+fixtures-parse smoke check only — no API key required.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 14: Final QA — clippy, fmt, roadmap
+
+**Files:**
+- Modify: `docs/03-ROADMAP.md`
+
+- [ ] **Step 1: Run workspace build**
+
+```bash
+cargo build --workspace
+```
+
+Expected: success.
+
+- [ ] **Step 2: Run workspace clippy with `-D warnings`**
+
+```bash
+cargo clippy --workspace --all-targets -- -D warnings
+```
+
+Expected: no warnings.
+
+If clippy fires on the new code, fix inline. Common likely culprits:
+- `clippy::needless_pass_by_value` — change `Arc<dyn …>` parameter to `&Arc<dyn …>` in helpers if flagged.
+- `clippy::missing_errors_doc` — add `# Errors` doc to public functions returning `Result`.
+
+- [ ] **Step 3: Run full workspace test**
+
+```bash
+cargo test --workspace
+```
+
+Expected: all green.
+
+- [ ] **Step 4: Run fmt**
+
+```bash
+task fmt 2>/dev/null || cargo +nightly fmt --all || cargo fmt --all
+```
+
+If `task fmt` requires nightly rustfmt and isn't available, document this in the commit message and fall back to `cargo fmt --all` (stable).
+
+- [ ] **Step 5: Update `docs/03-ROADMAP.md`**
+
+Open `docs/03-ROADMAP.md` and locate the Plan-C-polish section (around the line with "5 of 6"). Strike the deferred line and update the status:
+
+```bash
+grep -n "5 of 6\|Triage Author LLM dispatch\|Plan-C-polish" docs/03-ROADMAP.md | head
+```
+
+Edit:
+
+- Change `## RFC-0010 — Plan-C-polish ✅ (5 of 6)` → `## RFC-0010 — Plan-C-polish ✅ (6 of 6)`.
+- Move the "Triage Author LLM dispatch via ACP" item from "Remaining (deferred to its own session)" to the completed list with a checkbox `[x]` and a one-line note linking to the design spec and this plan.
+
+```markdown
+- [x] **Triage Author LLM dispatch via ACP** — Replaces the
+      `Priority::Medium` placeholder in surge-daemon with a real
+      ACP-driven Triage Author call. File-artifact return path
+      (`triage_decision.json` + `inbox_summary.md`) matching the
+      Description Author pattern. Layer 1 of two-layer plan; Layer 2
+      promotes Triage to a graph node (separate RFC).
+      See: [docs/superpowers/specs/2026-05-06-triage-author-llm-dispatch-design.md](superpowers/specs/2026-05-06-triage-author-llm-dispatch-design.md).
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add docs/03-ROADMAP.md
+git commit -m "$(cat <<'EOF'
+docs(rfc-0010): mark Plan-C-polish #6 (Triage LLM dispatch) complete
+
+All 6 Plan-C-polish items now shipped. RFC-0010 acceptance criterion
+#3 fully passes (priority is LLM-derived). Layer 2 (Triage as graph
+node) tracked separately as a future RFC.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Final verification
+
+- [ ] **Step 1: Verify everything green**
+
+```bash
+cargo build --workspace && \
+cargo clippy --workspace --all-targets -- -D warnings && \
+cargo test --workspace
+```
+
+Expected: all green.
+
+- [ ] **Step 2: Verify the LLM-gated path compiles independently**
+
+```bash
+cargo build -p surge-orchestrator --tests --features _bootstrap_llm_test
+```
+
+Expected: success.
+
+- [ ] **Step 3: Print the diff summary**
+
+```bash
+git log --oneline main..HEAD
+git diff --stat main..HEAD
+```
+
+Expected: ~14 commits, ~640 LOC across `surge-intake`, `surge-persistence`, `surge-orchestrator`, `surge-daemon`, plus the docs update.
+
+---
+
+## Plan self-review
+
+**1. Spec coverage:**
+
+| Spec section | Implemented in |
+|---|---|
+| §1.1 dispatch_triage async function | T3 (types), T4 (skeleton + happy path) |
+| §1.1 file-artifact return path | T4 (read scratch_dir/{decision.json,summary.md}) |
+| §1.1 retry semantics | T6 (bad JSON), T7 (timeout, agent crash, binary missing) |
+| §1.1 daemon mapping (4 arms) | T11 (Enqueued/Duplicate/OutOfScope/Unclear) |
+| §1.1 candidate-set assembly | T1 (`candidates::build_for_task`) |
+| §1.1 active-runs snapshot | T2 (`Storage::snapshot_active_runs`) |
+| §1.1 explicit handling missing claude binary | T9 (`find_claude_binary`) + T7 (binary_missing test) |
+| §1.1 feature-gated LLM E2E | T13 |
+| §3.5 deliver_fallback_inbox helper | T10 (extraction) + T11 (use sites) |
+| §4.1 prompt rendering | T4 (`render_prompt` impl) |
+| §4.3 event loop | T4 (try_one_attempt impl) |
+| §5.1 retry table | T6 + T7 (covers timeout/crash/bad-json/missing-file) |
+| §5.2 final fallback (Unclear) | T6 (exhaustion test), T7 (timeout/crash tests) |
+| §5.3 scratch dir lifecycle | T4 (cleanup on success), T7 (keep_on_failure verification) |
+| §5.4 daemon-side fallback | T10 + T11 (deliver_fallback_inbox calls on errors) |
+| §6.1 unit tests on mock | T4, T5, T6, T7 (9 tests total) |
+| §6.2 prompt snapshot test | T8 |
+| §6.3 LLM E2E feature-gated | T13 |
+| §6.4 daemon smoke | T12 |
+| §10 acceptance criteria | T14 (clippy + fmt + roadmap) |
+
+All spec sections covered. **Forward-compat (§7)** is naturally preserved by file artifacts + standard `report_stage_outcome` flow — no specific task needed.
+
+**2. Placeholder scan:** No "TBD", "TODO", or "fill in details" in the plan. Each step has actual code. The one place where I write "iterate" is in T4 step 2's harness skeleton — it's annotated with the cleaner pattern immediately below, so the engineer reading it sees both the rough shape and the concrete refactor target.
+
+**3. Type consistency:**
+- `dispatch_triage(bridge: Arc<dyn BridgeFacade>, input: TriageInput, opts: TriageOptions) -> Result<TriageDecision, TriageError>` — consistent across T3 (signature), T4 (impl), T11 (call site), T12 (smoke), T13 (E2E).
+- `TriageOptions::with_scratch_root(scratch_root, claude_binary)` — used in T11.
+- `find_claude_binary() -> Option<PathBuf>` — defined T9, used T11, T13.
+- `ActiveRunRow { run_id, task_id, status, started_at_ms }` — defined T2, mapped to `ActiveRunSummary` in T11 via `from_timestamp_millis(...).to_rfc3339()`.
+- `MockBridge::pin_session_ids(Vec<SessionId>)` — added T6, used T6/T7.
+- `deliver_fallback_inbox(notifier, event)` — defined T10, called T11 (three sites).
+
+All names match across tasks.
+
+**4. Scope check:** Layer 1 only. Layer 2 (Triage as graph node) is explicitly out of scope per spec §1.2. Plan does not touch `RunState`, `EventPayload`, or engine state machine.
+
+---

--- a/docs/superpowers/specs/2026-05-06-triage-author-llm-dispatch-design.md
+++ b/docs/superpowers/specs/2026-05-06-triage-author-llm-dispatch-design.md
@@ -1,0 +1,801 @@
+# Triage Author LLM Dispatch — Design
+
+**Status:** Design (drafted 2026-05-06)
+**Predecessor:** RFC-0010 Plan-C-polish (5/6 items shipped, this is item 6)
+**Successor:** Layer 2 — Triage Author as graph node (separate RFC, deferred)
+**Owner:** vanya · `feat(orchestrator): Triage Author LLM dispatch via ACP`
+
+> **Scope summary.** Replace the `Priority::Medium` placeholder in
+> `surge-daemon/src/main.rs` with a real ACP-driven Triage Author call.
+> When `RouterOutput::Triage { event }` arrives, the daemon assembles
+> a `TriageInput`, opens an ACP session against the bundled
+> `_bootstrap/triage-author@1.0` profile, awaits a `triage_decision.json`
+> artifact, parses via `TriageJson::into_decision`, and routes the
+> resulting `TriageDecision` to one of four destinations: real
+> `InboxCardPayload`, duplicate-comment-on-tracker, out-of-scope-comment,
+> or HumanGate notification.
+>
+> Closes RFC-0010 acceptance criterion #3 ("priority becomes
+> LLM-derived") and unblocks #11 ("clippy clean across the full LLM path").
+
+---
+
+## 1. Goals and non-goals
+
+### 1.1 In scope
+
+- **`dispatch_triage(...)` async function** in
+  `crates/surge-orchestrator/src/triage.rs` that opens an ACP session,
+  sends a structured input, awaits the agent's decision, parses it,
+  and returns a typed `TriageDecision`.
+- **File-artifact return path** — agent writes
+  `triage_decision.json` and `inbox_summary.md` to its session
+  scratch directory. The dispatcher reads these after
+  `BridgeEvent::OutcomeReported` fires. This matches the established
+  bootstrap-stage pattern (see Description Author in
+  `docs/revision/components/profiles.md`) and RFC-0010 acceptance
+  criterion #8 (SIGKILL recovery via persisted artifacts).
+- **Retry semantics** — three attempts per call with three distinct
+  failure modes (timeout, agent crash, malformed JSON). Final fallback
+  is `TriageDecision::Unclear { question: "<diagnostic>" }` so the
+  daemon can always make forward progress.
+- **Daemon mapping** — the existing `RouterOutput::Triage { event }`
+  arm in `crates/surge-daemon/src/main.rs` routes to one of four
+  destinations based on the parsed decision.
+- **Candidate-set assembly** — small helper in
+  `surge-intake::candidates` that calls `source.list_open_tasks()`
+  and reduces via the existing `top_by_keyword_overlap` to top-15.
+- **Active-runs snapshot** — `Storage::snapshot_active_runs()`
+  accessor (added if absent) that lists currently active runs as
+  `ActiveRunSummary` for inclusion in `TriageInput`.
+- **Explicit handling when Claude binary is missing** —
+  `surge_acp::discovery` finds the `claude` binary; if unavailable,
+  the dispatcher returns
+  `Ok(TriageDecision::Unclear { question: "Claude binary not configured (set SURGE_CLAUDE_BINARY or install claude); install to enable LLM-driven triage" })`
+  on the first attempt without spinning up an ACP session. This
+  surfaces the misconfiguration to the user via the standard Unclear
+  notification path. **No silent fallback to a Mock agent in
+  production code paths** — Mock is reserved for tests.
+- **Feature-gated end-to-end LLM test** — under `--features
+  _bootstrap_llm_test`, run real Claude Haiku against the three
+  existing fixtures (`enqueue_001.toml`, `duplicate_001.toml`,
+  `out_of_scope_001.toml`). Decision must match exactly; priority
+  ±1 tolerance.
+
+### 1.2 Out of scope (deferred to Layer 2 RFC)
+
+- **Triage Author as `NodeKind::Agent` inside the engine state
+  machine.** This requires extending `RunState::Bootstrapping`,
+  introducing a "shadow run" or "intake run" lifecycle, persisting
+  triage as event-log entries, and wiring crash recovery through the
+  engine's `recover_runs` path. That work is a separate RFC of
+  comparable size to RFC-0010 itself.
+- **Embedding-based candidate selection.** RFC-0014 deliverable.
+- **Persistent triage event log.** Layer 1 keeps triage outside the
+  event-sourced run history. Layer 2 promotes it.
+- **Web-search MCP for triage.** Profile sandbox stays read-only;
+  triage works strictly from supplied inputs.
+- **HumanGate-as-graph-node for `Unclear`.** Layer 1 surfaces
+  `Unclear` via a one-shot `RenderedNotification` on the desktop
+  channel; full inbox-cycle handling is a separate concern.
+
+### 1.3 Why two layers
+
+Promoting Triage Author to a real graph node is the architecturally
+correct end state — see RFC-0010 §"Bootstrap-as-graph-nodes" and
+RFC-0004 §"Bootstrap stages as graph nodes". But it requires:
+
+1. New `RunState` variant covering pre-Description triage.
+2. Run-creation-on-incoming-ticket logic in the daemon.
+3. Engine-level dispatch of `_bootstrap/triage-author` profile via
+   the existing `execute_agent_stage` machinery.
+4. New `EventPayload` variants for triage decisions.
+5. Crash recovery covering the new state.
+6. Acceptance-criterion #8 requires the artifact-recovery path.
+
+That work is a separate RFC. **Layer 1 deliberately picks a surface
+that does not paint Layer 2 into a corner**: file artifacts, standard
+`report_stage_outcome` flow, and `BridgeFacade` usage are all
+compatible with the future migration. When Layer 2 lands,
+`dispatch_triage` either becomes a thin test wrapper around the
+engine's executor or its body is inlined into the Triage stage's
+profile-handler. No API of `TriageInput` / `TriageJson` /
+`TriageDecision` changes.
+
+---
+
+## 2. Architecture decision
+
+### 2.1 The three rejected alternatives
+
+| Alternative | Why rejected |
+|---|---|
+| **A. JSON-into-`summary` field** of `report_stage_outcome` | `summary` is contractually a 1-3 sentence rationale (see `crates/surge-acp/src/bridge/tools.rs:97-99`). Repurposing it abuses the contract, requires retry-with-prompt-feedback when the agent ignores the convention, and forces every future bootstrap stage to invent its own JSON convention. |
+| **B. Custom tool `submit_triage_decision`** with `TriageJson` schema | Type-safe at the ACP wire level, but introduces a tool category specific to one stage. Description / Roadmap / Flow Authors would then need their own custom tools for their own structured outputs, fragmenting the bootstrap stage protocol. |
+| **C-naive. Replace `[sandbox] mode = "read-only"` with writable** | Profile semantics matter: read-only declares intent ("don't touch the project source"). Changing it solves nothing — agents can already write to their own working directory regardless of project sandbox mode. |
+
+### 2.2 The chosen approach: artifact files via session scratch directory
+
+**Triage Author writes `triage_decision.json` and `inbox_summary.md`
+to its session working directory using ACP-native filesystem tools.
+After `report_stage_outcome` fires, the dispatcher reads the files,
+parses the JSON, and returns a typed `TriageDecision`.**
+
+Why this matches the long-term architecture:
+
+1. **Uniform with Description / Roadmap / Flow Author.** All four
+   bootstrap stages produce file artifacts (`description.md`,
+   `roadmap.md`, `flow.toml`, `triage_decision.json`). One pattern,
+   four instances.
+2. **Read-only sandbox is consistent.** The sandbox's `read-only`
+   mode protects the *project source*, not the agent's own working
+   directory. Description Author already writes `description.md`
+   under `default_mode = "read-only"` (see
+   `docs/revision/components/profiles.md`).
+3. **Crash recovery is intrinsic.** Acceptance criterion #8 of
+   RFC-0010 asks: "Daemon SIGKILL during Triage Author is recovered
+   on restart; re-running Triage is skipped if `triage_decision.json`
+   is already in the run's artifacts." The file-artifact path
+   delivers this for free in Layer 2 (Layer 1 keeps triage outside
+   run history, so crash-recovery defers).
+4. **Layer 2 migration is a no-op for the public surface.** The
+   scratch directory becomes `$WORKTREE/.vibe/runs/$RUN_ID/artifacts/`
+   without any change to `dispatch_triage`'s caller-visible types.
+
+### 2.3 Where the dispatcher lives
+
+`crates/surge-orchestrator/src/triage.rs` — same module as
+`TriageInput` / `TriageJson`. The orchestrator crate already depends
+on `surge-acp` (for `BridgeFacade`) and `surge-intake` (for the
+typed decision and provider trait). Daemon stays a thin wiring
+layer; the actual LLM call lives in the orchestrator alongside the
+typed contract.
+
+### 2.4 Session lifetime
+
+**Short-lived per call.** Triage runs are infrequent (≥60s between
+successive calls per `task_source` due to polling intervals;
+duplicates are filtered by Tier-1 dedup before reaching Triage).
+Session-pool overhead (idle timeouts, bindings churn, connection
+reuse) buys nothing here — subprocess spawn is dwarfed by LLM
+latency. Each call: open → send → await outcome → close.
+
+---
+
+## 3. Components
+
+### 3.1 `triage::dispatch_triage`
+
+```rust
+// crates/surge-orchestrator/src/triage.rs
+
+pub async fn dispatch_triage(
+    bridge: Arc<dyn BridgeFacade>,
+    input: TriageInput,
+    opts: TriageOptions,
+) -> Result<TriageDecision, TriageError>;
+
+pub struct TriageOptions {
+    /// Resolved Claude (or other ACP-agent) binary path. If absent,
+    /// the dispatcher falls back to `AgentKind::Mock` with a warn.
+    pub claude_binary: Option<PathBuf>,
+    /// Per-attempt timeout. Spec §"Bootstrap stage failures" → 5 min.
+    pub attempt_timeout: Duration,        // default: 5 min
+    /// Maximum attempts before falling back to `Unclear`.
+    pub max_attempts: u32,                // default: 3
+    /// Root for per-call scratch directories.
+    pub scratch_root: PathBuf,            // default: ~/.surge/intake/triage
+    /// Whether to keep scratch on Unclear / failure for debugging.
+    pub keep_scratch_on_failure: bool,    // default: true
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum TriageError {
+    #[error("scratch dir setup failed: {0}")]
+    Scratch(#[from] std::io::Error),
+    #[error("acp bridge: {0}")]
+    Bridge(String),
+    #[error("artifact malformed: {path}: {error}")]
+    Artifact { path: PathBuf, error: String },
+}
+```
+
+**`Ok(TriageDecision)` is always returned even on retry exhaustion.**
+Exhausted retries materialise as `TriageDecision::Unclear { question:
+"Triage failed after N attempts: <last error>" }` so the daemon's
+match branches stay total. `TriageError` is reserved for invariant
+violations (cannot create scratch dir, bridge facade is dead) — these
+shouldn't happen in practice and propagate as errors.
+
+### 3.2 `triage::SUBMIT_TRIAGE_TOOL` (constant) — **dropped**
+
+The brainstorming session considered a custom tool; the final design
+uses standard `report_stage_outcome` + file artifacts only. No new
+constants needed.
+
+### 3.3 `surge_intake::candidates::build_for_task`
+
+```rust
+// crates/surge-intake/src/candidates.rs (existing module, new fn)
+
+pub async fn build_for_task(
+    source: &Arc<dyn TaskSource>,
+    target: &TaskDetails,
+    limit: usize,
+) -> Result<Vec<TaskSummary>, Error> {
+    let open = source.list_open_tasks().await?;
+    let inputs: Vec<CandidateInput> = open
+        .iter()
+        .map(CandidateInput::from_summary)
+        .collect();
+    let scored = top_by_keyword_overlap(target, &inputs, limit);
+    Ok(scored
+        .into_iter()
+        .filter_map(|s| open.iter().find(|t| t.task_id.as_str() == s.task_id).cloned())
+        .collect())
+}
+```
+
+Bridges between the existing `top_by_keyword_overlap` (which works
+on `CandidateInput`) and the daemon's needed `Vec<TaskSummary>` for
+`TriageInput`.
+
+### 3.4 `Storage::snapshot_active_runs` and the type-location wrinkle
+
+`ActiveRunSummary` is defined in `surge-orchestrator/src/triage.rs`,
+but `Storage` lives in `surge-persistence`. A direct
+`Storage::snapshot_active_runs() -> Vec<ActiveRunSummary>` would
+create a circular dependency (orchestrator already depends on
+persistence). **Resolution: Storage exposes its own row type;
+the dispatcher does the mapping.**
+
+```rust
+// crates/surge-persistence/src/runs/active.rs (new fn or method)
+
+pub struct ActiveRunRow {
+    pub run_id: String,
+    pub task_id: Option<String>,
+    pub status: String,
+    pub started_at: chrono::DateTime<chrono::Utc>,
+}
+
+impl Storage {
+    pub async fn snapshot_active_runs(&self, limit: usize) -> Result<Vec<ActiveRunRow>, Error>;
+}
+```
+
+```rust
+// crates/surge-orchestrator/src/triage.rs (mapping helper)
+
+impl ActiveRunSummary {
+    pub(crate) fn from_row(row: surge_persistence::runs::ActiveRunRow) -> Self {
+        Self {
+            run_id: row.run_id,
+            task_id: row.task_id,
+            status: row.status,
+            started_at: row.started_at.to_rfc3339(),
+        }
+    }
+}
+```
+
+Implementation: `SELECT id, task_id, status, started_at FROM runs
+WHERE status IN ('Bootstrapping', 'Running') ORDER BY started_at DESC
+LIMIT ?`. The `task_id` column is sourced from `ticket_index` joined
+on `run_id` (or directly stored on `runs` if that's where the schema
+already keeps it — confirm during T2 implementation).
+Bounded by `LIMIT 32` — Triage doesn't need exhaustive enumeration
+of every active run, just a representative sample for dedup hints.
+
+If a similar accessor already exists in `surge-persistence`, it is
+reused; if not, the new method ships alongside this change
+(~30 LOC plus one in-memory unit test).
+
+### 3.5 Daemon mapping
+
+The existing arm at `crates/surge-daemon/src/main.rs:311` is
+replaced. The new shape:
+
+```rust
+RouterOutput::Triage { event } => {
+    let Some(source) = source_map_for_consumer.get(&event.source_id) else {
+        warn!(source_id = %event.source_id, "no source registered; dropping triage");
+        continue;
+    };
+
+    // Fetch full task details (raw_payload alone is insufficient for Triage).
+    let task_details = match source.fetch_task(&event.task_id).await {
+        Ok(td) => td,
+        Err(e) => {
+            warn!(error = %e, task_id = %event.task_id, "fetch_task failed; surfacing fallback inbox");
+            // Fall through to a Medium-priority placeholder InboxCard
+            // (preserves Plan-C MVP behaviour for unrecoverable provider errors).
+            deliver_fallback_inbox(&notifier, &event).await;
+            continue;
+        }
+    };
+
+    let candidates = surge_intake::candidates::build_for_task(source, &task_details, 15)
+        .await
+        .unwrap_or_default();
+    let active_runs = storage.snapshot_active_runs().await.unwrap_or_default();
+    let input = TriageInput { task: task_details.clone(), candidates, active_runs };
+
+    let opts = TriageOptions {
+        claude_binary: surge_acp::discovery::AgentDiscovery::find_claude().ok(),
+        attempt_timeout: Duration::from_secs(300),
+        max_attempts: 3,
+        scratch_root: surge_runs_dir().join("intake").join("triage"),
+        keep_scratch_on_failure: true,
+    };
+
+    match surge_orchestrator::triage::dispatch_triage(bridge.clone(), input, opts).await {
+        Err(e) => {
+            warn!(error = %e, task_id = %event.task_id, "triage invariant failure; falling back");
+            deliver_fallback_inbox(&notifier, &event).await;
+        }
+        Ok(TriageDecision::Enqueued { priority, summary, .. }) => {
+            // Build InboxCardPayload using LLM-derived priority + summary
+            // (replaces existing Priority::Medium placeholder).
+        }
+        Ok(TriageDecision::Duplicate { of, reasoning }) => {
+            let body = format!("Surge: detected duplicate of {of}. {reasoning}");
+            if let Err(e) = source.post_comment(&event.task_id, &body).await {
+                warn!(error = %e, "duplicate comment post failed");
+            }
+            // No InboxCard.
+        }
+        Ok(TriageDecision::OutOfScope { reasoning }) => {
+            let body = format!("Surge: out of scope. {reasoning}");
+            if let Err(e) = source.post_comment(&event.task_id, &body).await {
+                warn!(error = %e, "out_of_scope comment post failed");
+            }
+            // No InboxCard.
+        }
+        Ok(TriageDecision::Unclear { question }) => {
+            let rendered = surge_notify::RenderedNotification {
+                severity: surge_core::notify_config::NotifySeverity::Warn,
+                title: format!("Triage unclear · {}", event.task_id.as_str()),
+                body: question,
+                artifact_paths: vec![],
+            };
+            // Deliver via Desktop channel (mirror existing InboxCard wiring).
+        }
+    }
+}
+```
+
+`deliver_fallback_inbox` extracts the existing placeholder logic
+(MVP `Priority::Medium` payload) into a helper so two error paths
+can call it without duplication.
+
+---
+
+## 4. Data flow
+
+```
+                                    ┌──────────────────┐
+                                    │ RouterOutput::    │
+                                    │  Triage { event } │
+                                    └─────────┬────────┘
+                                              │
+        ┌─────────────────────────────────────┴──────────────────────────────────┐
+        │                                                                         │
+        │ 1. Daemon: source.fetch_task(event.task_id) → TaskDetails              │
+        │ 2. Daemon: candidates::build_for_task(source, &task_details, 15)       │
+        │ 3. Daemon: storage.snapshot_active_runs() → Vec<ActiveRunSummary>      │
+        │ 4. Daemon: TriageInput { task, candidates, active_runs }                │
+        │                                                                         │
+        └─────────────────────────────────────┬──────────────────────────────────┘
+                                              │
+                                              ▼
+                              ┌─────────────────────────────┐
+                              │  dispatch_triage(...)       │
+                              │                             │
+                              │  per attempt (1..=3):       │
+                              │  ┌────────────────────────┐ │
+                              │  │ mkdir scratch_dir      │ │
+                              │  │ open ACP session       │ │
+                              │  │   working_dir=scratch  │ │
+                              │  │   sandbox=ReadOnly     │ │
+                              │  │ send_message(prompt    │ │
+                              │  │   + JSON(input))       │ │
+                              │  │ tokio::time::timeout(  │ │
+                              │  │   5min, event_loop)    │ │
+                              │  │   ↓                    │ │
+                              │  │ OutcomeReported →      │ │
+                              │  │   close_session →      │ │
+                              │  │   read decision.json → │ │
+                              │  │   read summary.md →    │ │
+                              │  │   into_decision()      │ │
+                              │  └────────────────────────┘ │
+                              │  retry on:                  │
+                              │   - timeout                 │
+                              │   - AgentCrashed            │
+                              │   - bad json                │
+                              │  exhaust → Unclear fallback │
+                              └────────────┬────────────────┘
+                                           │
+                                           ▼
+                       ┌──────────────────────────────────────┐
+                       │ TriageDecision (always Ok)            │
+                       └────────────┬──────────────────────────┘
+                                    │
+        ┌───────────────────────────┼──────────────────────────────┐
+        │                           │                              │
+        ▼                           ▼                              ▼
+  Enqueued                    Duplicate / OOS              Unclear
+  → InboxCardPayload          → source.post_comment()      → Warn-severity
+    with real priority,       → no InboxCard                 RenderedNotification
+    summary from              → ticket_index → Skipped       via Desktop
+    inbox_summary.md
+```
+
+### 4.1 Initial message contents
+
+The system prompt is the profile's `[prompt].system` section,
+followed by a `# Inputs` block containing the JSON-encoded
+`TriageInput`. The agent has read-only project access (sandbox
+mode) but the `working_dir` it sees is the scratch directory, not
+the project root, so practically it works from supplied data
+only — exactly what the spec intends.
+
+The full message body has the following shape (rendered via
+`format!`, no template engine):
+
+~~~text
+<system prompt from profile>
+
+# Inputs
+
+The triage input is encoded as JSON. The shape is:
+- task: TaskDetails  (the new ticket: title, description, labels, url, ...)
+- candidates: TaskSummary[]  (top-15 similar open tickets + recent specs)
+- active_runs: ActiveRunSummary[]  (currently active Surge runs)
+
+The literal JSON follows:
+
+<serialized JSON of TriageInput>
+
+# Task
+
+Decide whether this ticket is a duplicate, out-of-scope, unclear,
+or should be enqueued. Then, in your working directory:
+
+1. Write your structured decision to `triage_decision.json`
+   (schema below).
+2. Write a 3-5 line markdown blurb to `inbox_summary.md`
+   (used as the body of the inbox card on `enqueued`; safe to
+   omit otherwise).
+3. Call `report_stage_outcome` with the matching `outcome` and
+   `artifacts_produced = ["triage_decision.json", "inbox_summary.md"]`.
+
+triage_decision.json schema:
+- decision: "enqueued" | "duplicate" | "out_of_scope" | "unclear"
+- duplicate_of: string (task id, e.g. "github_issues:foo/bar#42")
+                or null
+- priority: "urgent" | "high" | "medium" | "low"
+- priority_reasoning: one sentence explaining priority
+- summary: one sentence high-level description of the task
+- question: string (only when decision = "unclear")
+~~~
+
+The schema is described in plain prose rather than as nested
+fenced code blocks for two reasons: (1) markdown rendering of
+nested triple-backticks is unreliable across viewers; (2)
+LLMs handle prose schemas as well as fenced JSON in this
+context, and we already have `serde_json::from_slice` enforcing
+the actual structure.
+
+### 4.2 SessionConfig
+
+When `opts.claude_binary` is `None` the dispatcher short-circuits
+before reaching this point (see §1.1 — returns `Unclear` with a
+configuration-hint message). The session is only built when a real
+agent binary is resolved:
+
+```rust
+SessionConfig {
+    agent_kind: AgentKind::ClaudeCode {
+        binary: opts.claude_binary.clone().expect("checked above"),
+        extra_args: vec![],
+    },
+    working_dir: scratch_dir.clone(),
+    system_prompt: prompt_text,
+    declared_outcomes: vec![
+        OutcomeKey::try_from("enqueued")?,
+        OutcomeKey::try_from("duplicate")?,
+        OutcomeKey::try_from("out_of_scope")?,
+        OutcomeKey::try_from("unclear")?,
+    ],
+    allows_escalation: false,
+    tools: vec![],                        // ACP-native fs tools are enough
+    sandbox: Box::new(DenyListSandbox::read_only()),
+    permission_policy: PermissionPolicy::default(),
+    bindings: BTreeMap::from([
+        ("intake.task_id".into(), task_id_str),
+        ("intake.attempt".into(), attempt.to_string()),
+    ]),
+}
+```
+
+For unit tests, the test harness constructs `SessionConfig` with
+`AgentKind::Mock { args: ... }` directly — Mock is a test
+mechanism, not a production fallback path.
+
+`bindings` carry the task id and attempt number for correlation in
+`BridgeEvent::SessionEstablished` — useful for the future tracing
+work that will surface intake telemetry.
+
+### 4.3 Event loop
+
+Mirrors `execute_agent_stage` but stripped to just outcome / crash
+/ timeout handling. No tool dispatch (the agent only uses ACP-native
+filesystem tools served by the bridge's built-in `Client` impl). No
+human-input handling (Triage profile sets `allows_escalation =
+false`).
+
+Event filter: only events for our `session_id`. Discarded:
+`AgentMessage`, `TokenUsage`, `ToolCall` with `meta.injected==true`,
+`ToolResult`, `Error` (logged at warn).
+
+Terminating events:
+- `OutcomeReported { outcome, .. }` → break and proceed to artifact
+  read.
+- `SessionEnded { reason: AgentCrashed { exit_code, stderr_tail } }`
+  → bail with retry-eligible error.
+
+---
+
+## 5. Error handling and retry
+
+### 5.1 Per-attempt failure modes
+
+| Failure | Retry decision | Feedback to next attempt |
+|---|---|---|
+| `tokio::time::timeout` exceeded (5 min) | retry up to `max_attempts` | none — fresh attempt |
+| `BridgeEvent::SessionEnded { reason: AgentCrashed }` | retry up to `max_attempts` | none — fresh attempt |
+| `triage_decision.json` missing after `OutcomeReported` | retry up to `max_attempts` | feedback message: "previous attempt did not produce triage_decision.json; you must write the file before calling report_stage_outcome" |
+| `triage_decision.json` exists but `serde_json::from_slice` fails | retry up to `max_attempts` | feedback message: "previous triage_decision.json was malformed: \<error\>" |
+| `TriageJson::into_decision` returns `Err` (e.g. unknown priority) | retry up to `max_attempts` | feedback message: "previous decision was rejected: \<error\>" |
+| `BridgeError::OpenSessionError` / `SendMessageError` | bail as `TriageError::Bridge` (no retry) | n/a |
+
+Retry feedback is delivered as a follow-up `MessageContent::Text` on
+the same session if the session is still alive, otherwise on a fresh
+session at the start of the next attempt.
+
+### 5.2 Final fallback
+
+After `max_attempts` exhaustion the dispatcher returns:
+
+```rust
+Ok(TriageDecision::Unclear {
+    question: format!(
+        "Triage failed after {} attempts: {}",
+        opts.max_attempts, last_error
+    ),
+})
+```
+
+Daemon surfaces this as a Warn-severity desktop notification. The
+`ticket_index` row stays in `Triaging` state — the ticket is not
+acted upon until a human resolves it (Layer 2 will introduce a
+proper inbox-cycle for Unclear).
+
+### 5.3 Scratch dir lifecycle
+
+- Created at the start of each attempt (top-level call): `mkdir -p
+  ~/.surge/intake/triage/{ulid}/`. Each retry within a single call
+  reuses the same directory (so prior decision.json drafts can be
+  overwritten by the agent).
+- On success (Enqueued / Duplicate / OutOfScope): scratch dir is
+  removed (`std::fs::remove_dir_all`). Best-effort — error is
+  warn-logged and not propagated.
+- On Unclear or `TriageError`: scratch dir is **kept** if
+  `keep_scratch_on_failure` is true (default). This preserves
+  artifacts for post-mortem.
+
+### 5.4 What does *not* fall under retry
+
+- Daemon-side errors before invoking the dispatcher
+  (`source.fetch_task`, `candidates::build_for_task`,
+  `storage.snapshot_active_runs`) — daemon delivers a fallback
+  Medium-priority InboxCard and logs at warn. This preserves
+  pre-existing Plan-C MVP behaviour for unrecoverable provider
+  errors.
+- `TriageError::Bridge` for facade-level dead bridge — propagates
+  as Err to the daemon, which logs and falls back to InboxCard
+  placeholder.
+
+---
+
+## 6. Testing strategy
+
+### 6.1 Unit tests (mock BridgeFacade)
+
+`crates/surge-orchestrator/tests/triage_dispatch.rs` — six
+scenarios using a mock `BridgeFacade`. Mock pattern: existing test
+double already used by `agent.rs` integration tests.
+
+| Test | Mock behaviour | Expected result |
+|---|---|---|
+| `enqueued_happy_path` | Mock writes `triage_decision.json` with `decision="enqueued", priority="high"`, fires `OutcomeReported` | `Ok(Enqueued { priority: High, .. })` |
+| `duplicate_happy_path` | Mock writes `decision="duplicate", duplicate_of="...#42"` | `Ok(Duplicate { of: "...#42", .. })` |
+| `out_of_scope_happy_path` | Mock writes `decision="out_of_scope", priority="low"` | `Ok(OutOfScope { .. })` |
+| `unclear_happy_path` | Mock writes `decision="unclear", question="..."` | `Ok(Unclear { question })` |
+| `bad_json_then_recovers` | Attempt 1: malformed JSON. Attempt 2: valid JSON. | `Ok(Enqueued { .. })` after retry |
+| `exhaust_retries_yields_unclear` | All three attempts produce malformed JSON | `Ok(Unclear { question: contains "Triage failed after 3 attempts" })` |
+
+### 6.2 Snapshot test of the rendered initial message
+
+`crates/surge-orchestrator/src/triage.rs` — `#[cfg(test)] mod
+prompt_render_tests`. Asserts the constructed prompt is byte-stable
+given a fixed `TriageInput` so prompt regressions are caught at PR
+review time. Using `insta` to match repo convention.
+
+### 6.3 Feature-gated end-to-end LLM test
+
+`crates/surge-orchestrator/tests/triage_llm.rs` — under feature
+flag `_bootstrap_llm_test`. Reuses the existing fixtures
+(`enqueue_001.toml`, `duplicate_001.toml`, `out_of_scope_001.toml`)
+to produce three real ACP calls against Claude Haiku at
+`temperature=0`. Asserts:
+
+- decision string matches exactly
+- priority is within ±1 step of the fixture's expectation
+- on `duplicate`, `duplicate_of` matches exactly
+
+Requires `ANTHROPIC_TEST_KEY` env. Default workspace test does not
+activate this feature, so CI cost stays unchanged.
+
+### 6.4 Daemon-side smoke
+
+`crates/surge-daemon/tests/triage_wiring.rs` — compile-and-init
+test. Constructs the daemon's task-source consumer (with a mock
+`BridgeFacade` that returns Enqueued), drives one `TaskEvent`
+through the pipeline, asserts that the resulting `InboxCardPayload`
+carries a non-`Medium` priority. Validates the wiring without an
+LLM round-trip.
+
+### 6.5 Coverage targets
+
+Per RFC-0010 §"Coverage targets" the Triage Author rendering and
+parser must hit ≥85%. The tests above plus the existing parser
+tests in `triage.rs` cover ≥90% of the new code paths.
+
+---
+
+## 7. Forward-compatibility (Layer 2)
+
+When Triage Author is promoted to a real graph node, the migration
+proceeds as follows. **No types in this design change.**
+
+### 7.1 RunState extension
+
+Add `RunState::IntakeTriage { task_id, scratch_dir, attempt }`
+ahead of `Bootstrapping`. The engine's main loop dispatches this
+state via a new `advance_intake_triage` method that wraps the same
+inner logic as `dispatch_triage`. Crash recovery checks for an
+existing `triage_decision.json` in `scratch_dir` and short-circuits
+to outcome routing if present — directly satisfying RFC-0010
+acceptance criterion #8.
+
+### 7.2 Event log
+
+New `EventPayload` variants (already drafted in the Plan-C plan
+under Task 10.1):
+
+- `TicketDetected { task_id, source_id, provider }` — emitted by
+  the daemon when `RouterOutput::Triage` arrives.
+- `Tier1DedupDecided { decision, duplicate_run_id }` — already
+  implicit in Tier-1; now externalised.
+- `TriageDecided { decision, priority, duplicate_of, reasoning }`
+  — emitted on `OutcomeReported`.
+
+### 7.3 dispatch_triage role in Layer 2
+
+Two options, picked at Layer-2 design time:
+
+- **Option α — keep as test wrapper.** Engine integration calls
+  the same logic via the standard agent stage path; `dispatch_triage`
+  is moved into `#[cfg(test)]` for unit-testing the input/output
+  shape without spinning up the engine.
+- **Option β — extract as library.** Engine's stage handler for
+  `_bootstrap/triage-author` profile delegates to `dispatch_triage`
+  internally; `dispatch_triage` continues to be public.
+
+Either way, the Layer 1 implementation does not need changes to
+support the migration. This is the test of "did we pick the right
+surface".
+
+### 7.4 Profile evolution
+
+The current `triage-author-1.0.toml` is minimal (id, version,
+declared_outcomes, prompt, sandbox). When Description Author's
+richer schema (`[role]`, `[runtime]`, `[approvals]`, `[hooks]`,
+`[bindings]`) is generalised across all bootstrap profiles, Triage
+Author's profile gets an upgrade in the same change. Layer 1 reads
+the minimal version; Layer 2 reads whatever the registry returns —
+both work with the same `BOOTSTRAP_TRIAGE_AUTHOR_TOML` constant
+because field defaults are permissive.
+
+---
+
+## 8. Implementation order
+
+Suggested TDD task breakdown (writing-plans skill will produce the
+final plan):
+
+1. **T1.** `surge-intake::candidates::build_for_task` — small helper
+   with three unit tests against `MockTaskSource`.
+2. **T2.** `Storage::snapshot_active_runs` — accessor + one unit
+   test (in-memory DB, two active runs and one terminal).
+3. **T3.** `triage::TriageOptions`, `triage::TriageError` types —
+   compilation only.
+4. **T4.** `dispatch_triage` happy path: Enqueued via mock bridge
+   + scratch dir read. One test.
+5. **T5.** `dispatch_triage` for Duplicate / OutOfScope / Unclear
+   variants. Three more tests.
+6. **T6.** Retry mechanics: bad JSON → retry → success; three
+   bad-JSON-attempts → Unclear fallback. Two tests.
+7. **T7.** Timeout and AgentCrashed retry handling. Two tests.
+8. **T8.** Initial-message snapshot test.
+9. **T9.** Daemon wiring replacement: extract `deliver_fallback_inbox`
+   helper, route four decision arms.
+10. **T10.** Daemon smoke test (`triage_wiring.rs`).
+11. **T11.** Feature-gated LLM E2E test (`triage_llm.rs` body
+    behind `_bootstrap_llm_test`).
+12. **T12.** Roadmap update — strike "Triage Author LLM dispatch via
+    ACP" from `docs/03-ROADMAP.md` Plan-C-polish remaining list.
+
+Estimated effort calibration: 1.5 sessions for T1–T11 (Plan-C-polish
+items #2–#5 took ~0.5 session each; this is 4× larger so 1.5–2× the
+unit). A second pass for clippy / fmt / final QA.
+
+---
+
+## 9. Open questions / explicit deferrals
+
+- **Q1.** Should the dispatcher emit any tracing events to be
+  surfaced via `surge engine watch` once Triage is event-sourced?
+  **Defer to Layer 2.** Layer 1 uses `tracing::info!` /
+  `tracing::warn!` only — fine for daemon log inspection.
+- **Q2.** Should Unclear notifications be deduped if the same
+  ticket triages-as-Unclear multiple times within a polling
+  window? **Defer.** Tier-1 dedup already prevents the LLM call
+  on a ticket already marked `Triaging`; Layer 2's FSM transition
+  rules will resolve any residual flapping.
+- **Q3.** What happens on `TriageDecision::Duplicate { of:
+  task_id }` when `of` does not exist in the source's active
+  set? Layer 1 still posts the comment using the agent's claim
+  (the agent has been told not to invent IDs in the system
+  prompt). Layer 2 will validate against `ticket_index` and
+  reject malformed `duplicate_of` claims at engine-event level.
+- **Q4.** Sandbox tier-3 (network) for triage in case the agent
+  needs to follow a link in the ticket. **Out of scope, defer.**
+  The profile stays read-only; agents that need web context will
+  ask via clarifying question in Layer 2.
+
+---
+
+## 10. Acceptance
+
+This spec is implemented when:
+
+1. `cargo build --workspace` clean.
+2. `cargo clippy --workspace --all-targets -- -D warnings` clean.
+3. All existing tests pass.
+4. New unit tests in §6.1 pass.
+5. New snapshot test in §6.2 passes (with committed snapshot).
+6. New daemon smoke test in §6.4 passes.
+7. `--features _bootstrap_llm_test` LLM E2E (§6.3) passes against
+   real Claude Haiku for all three fixtures (gated behind
+   `ANTHROPIC_TEST_KEY`; not enforced in CI).
+8. `crates/surge-daemon/src/main.rs` no longer constructs
+   `Priority::Medium` as a primary path on `RouterOutput::Triage`
+   (it remains as a fallback only on provider-side errors).
+9. RFC-0010 acceptance criterion #3 fully passes (priority is
+   LLM-derived).
+10. `docs/03-ROADMAP.md` Plan-C-polish list shows "Triage Author
+    LLM dispatch via ACP" as completed; remaining items =
+    explicitly Layer 2 / future RFC.

--- a/docs/superpowers/specs/2026-05-06-triage-author-llm-dispatch-design.md
+++ b/docs/superpowers/specs/2026-05-06-triage-author-llm-dispatch-design.md
@@ -510,11 +510,7 @@ SessionConfig {
     ],
     allows_escalation: false,
     tools: vec![],                        // ACP-native fs tools are enough
-    sandbox: Box::new(AlwaysAllowSandbox), // see note below — bridge-level
-                                           // sandbox is for tool filtering;
-                                           // profile's "read-only" mode is a
-                                           // semantic marker handled by Layer 2's
-                                           // profile loader.
+    sandbox: delegated_sandbox(),         // see note below
     permission_policy: PermissionPolicy::default(),
     bindings: BTreeMap::from([
         ("intake.task_id".into(), task_id_str),
@@ -526,6 +522,27 @@ SessionConfig {
 For unit tests, the test harness constructs `SessionConfig` with
 `AgentKind::Mock { args: ... }` directly — Mock is a test
 mechanism, not a production fallback path.
+
+**Sandbox-delegated convention.** `delegated_sandbox()` is a helper
+that returns `Box::new(AlwaysAllowSandbox)`. The bridge-level
+`Sandbox` trait field is required by `SessionConfig`'s shape but
+the no-op `AlwaysAllowSandbox` implementation means **the bridge
+applies no filtering**: tool-list and per-call decisions pass
+through to the agent. This matches `docs/revision/VISION-2026.md`
+§"Sandbox-delegated":
+
+> Each agent has its own native sandbox (Codex CLI sandbox modes,
+> Claude Code Skills isolation, etc.). Surge configures it via ACP,
+> the agent enforces it.
+
+The profile's `[sandbox] mode = "read-only"` field is a **semantic
+marker** read by the agent itself (or by a future Layer 2 profile
+loader that translates it to ACP-level capability flags). Surge's
+bridge does not enforce it — the agent does. Globalising this
+convention (e.g., a `delegate_sandbox_to_agent: bool` toggle in
+`SurgeConfig` and removing `DenyListSandbox` surface) is the
+subject of the RFC-0006 refactor (Tier 3+4 deprecation) called out
+in Vision-2026; it is out of scope here.
 
 `bindings` carry the task id and attempt number for correlation in
 `BridgeEvent::SessionEstablished` — useful for the future tracing

--- a/docs/superpowers/specs/2026-05-06-triage-author-llm-dispatch-design.md
+++ b/docs/superpowers/specs/2026-05-06-triage-author-llm-dispatch-design.md
@@ -510,7 +510,11 @@ SessionConfig {
     ],
     allows_escalation: false,
     tools: vec![],                        // ACP-native fs tools are enough
-    sandbox: Box::new(DenyListSandbox::read_only()),
+    sandbox: Box::new(AlwaysAllowSandbox), // see note below — bridge-level
+                                           // sandbox is for tool filtering;
+                                           // profile's "read-only" mode is a
+                                           // semantic marker handled by Layer 2's
+                                           // profile loader.
     permission_policy: PermissionPolicy::default(),
     bindings: BTreeMap::from([
         ("intake.task_id".into(), task_id_str),


### PR DESCRIPTION
## Summary

Closes the largest deferred RFC-0010 Plan-C-polish item: the `Priority::Medium` placeholder in `surge-daemon` is replaced with a real ACP-driven Triage Author call. When `RouterOutput::Triage { event }` arrives, the daemon assembles a typed `TriageInput`, opens an ACP session against the bundled `_bootstrap/triage-author@1.0` profile, awaits a `triage_decision.json` artifact, parses via `TriageJson::into_decision`, and routes the resulting `TriageDecision` to one of four destinations.

This is **Layer 1** of a two-layer plan. Layer 2 (separate RFC) promotes Triage Author to a first-class `NodeKind::Agent` inside the engine state machine.

## Architecture decision

After reviewing `docs/revision/architecture/03-engine.md`, `docs/revision/architecture/04-acp-integration.md`, `docs/revision/components/profiles.md`, and Vision-2026, the chosen approach uses **file artifacts via session scratch directory** — the agent writes `triage_decision.json` and `inbox_summary.md` to its working directory; the dispatcher reads them after `BridgeEvent::OutcomeReported`. This matches the established Description Author pattern and naturally satisfies RFC-0010 acceptance criterion #8 (SIGKILL recovery via persisted artifacts).

Rejected alternatives: JSON-in-`summary` (abuses the `report_stage_outcome` contract), custom tool `submit_triage_decision` (fragments the bootstrap-stage protocol).

Sandbox is **delegated to the agent** per Vision-2026 §"Sandbox-delegated" — the bridge applies no filtering (`AlwaysAllowSandbox`); each ACP-conformant agent enforces its own native sandbox.

## What landed

- **`surge-orchestrator/src/triage.rs`** — `dispatch_triage`, `TriageOptions`, `TriageError`, `find_claude_binary`, `delegated_sandbox`, `render_prompt`, `try_one_attempt` with retry/timeout/agent-crash handling. ~470 LOC.
- **`surge-intake/src/candidates.rs`** — `build_for_task` async helper bridging `TaskSource::list_open_tasks` to `Vec<TaskSummary>` filtered by Jaccard similarity.
- **`surge-persistence/src/runs/storage.rs`** — `Storage::snapshot_active_runs(limit)` returning `Vec<ActiveRunRow>` (Layer 1 leaves `task_id` as `None`; Layer 2 will populate from `ticket_index` JOIN).
- **`surge-daemon/src/main.rs`** — `RouterOutput::Triage` consumer rewritten with `handle_triage_event` + `dispatch_triage_decision` + `deliver_desktop` + `deliver_fallback_inbox` helpers. Four-way decision routing:
  - `Enqueued { priority, summary }` → `InboxCardPayload` with LLM-derived priority + summary
  - `Duplicate { of, reasoning }` → `source.post_comment("Surge: detected duplicate of ... ")`, no inbox
  - `OutOfScope { reasoning }` → `source.post_comment("Surge: out of scope. ...")`, no inbox
  - `Unclear { question }` → Warn-severity `RenderedNotification` via Desktop channel
  - `Err(_)` from dispatch / unknown source / `fetch_task` failure → `deliver_fallback_inbox` (Medium-priority placeholder preserved for unrecoverable provider errors)
- **Tests:** 9 unit tests in `tests/triage_dispatch.rs` (4 decision variants, retry recovery, retry exhaustion, timeout, agent crash, binary missing), 1 daemon smoke (`tests/triage_wiring.rs`), 1 prompt snapshot, 1 feature-gated real-Haiku E2E (`--features _bootstrap_llm_test`, `#[ignore]`d) covering the 3 fixtures.
- **Roadmap:** `docs/03-ROADMAP.md` updated — Plan-C-polish status `(5 of 6) → (6 of 6)`, item moved from "Remaining" to completed.

Spec: `docs/superpowers/specs/2026-05-06-triage-author-llm-dispatch-design.md`
Plan: `docs/superpowers/plans/2026-05-06-triage-author-llm-dispatch.md`

## Test plan

- [x] `cargo build --workspace` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test --workspace` — all green (0 failures)
- [x] `cargo build -p surge-orchestrator --tests --features _bootstrap_llm_test` — feature-gated path compiles
- [ ] Manual: `ANTHROPIC_TEST_KEY=sk-... cargo test -p surge-orchestrator --test triage_llm --features _bootstrap_llm_test -- --ignored` against real Claude Haiku for the 3 fixtures (decision exact match; priority ±1)
- [ ] Manual: smoke a real Linear/GitHub source with `surge:enabled` label, observe LLM-derived priority on the InboxCard (no longer `Medium` placeholder)

## Forward compatibility (Layer 2)

The public surface (`TriageInput` / `TriageJson` / `TriageDecision` / `dispatch_triage` signature) is stable across the two layers — see spec §7. Layer 2 either inlines `dispatch_triage`'s body into the engine's `_bootstrap/triage-author` profile handler or keeps it as a thin test wrapper.

`TriageOptions` is `#[non_exhaustive]` so future fields (e.g., a `profile_registry` handle) won't be a SemVer break for downstream callers.

## Acceptance criteria touched

- ✅ RFC-0010 #3 (priority becomes LLM-derived, not Medium placeholder)
- ✅ RFC-0010 #11 (workspace clippy clean across the LLM dispatch path)
- ⏳ RFC-0010 #8 (SIGKILL recovery via `triage_decision.json` artifact reuse) — deferred to Layer 2 with the engine-state-machine integration

🤖 Generated with [Claude Code](https://claude.com/claude-code)