### PR TITLE
[codex] Refresh Surge README and revision docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -486,7 +486,8 @@ surge spec ...          manage legacy specs
 surge run ...           execute the legacy spec pipeline
 surge engine ...        execute flow.toml graphs
 surge daemon ...        manage the long-running local engine host
-surge clean/worktrees   inspect and clean git worktrees
+surge clean             clean up orphaned worktrees and merged branches
+surge worktrees         list active worktrees
 surge analytics ...     view token/cost analytics
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,78 +1,580 @@
-# ⚡ Surge
+# Surge
 
 [![CI](https://github.com/vanyastaff/surge/workflows/CI/badge.svg)](https://github.com/vanyastaff/surge/actions)
 
-**Any Agent. One Protocol. Pure Rust.**
+**Local-first orchestration for AFK AI coding workflows.**
 
-Surge is an agent-agnostic autonomous coding orchestrator built entirely in Rust. It uses the [Agent Client Protocol (ACP)](https://agentclientprotocol.com) to connect to any compatible AI coding agent — Claude Code, GitHub Copilot, Zed Agent, or any future ACP agent — through a single unified interface.
+Surge is a Rust workspace for running long AI coding work as explicit,
+event-sourced workflow graphs. A run is not one giant prompt and not a swarm of
+agents negotiating with each other. A run is a `flow.toml`: typed nodes,
+declared outcomes, and edges. Agents do the work inside bounded stages; the
+graph decides where execution goes next.
 
-## Why Surge?
+The target experience is:
 
-Current autonomous coding tools (Aperant, Cursor Background Agents) are locked to a single AI provider, built on fragile multi-runtime stacks (Electron + Python + Node.js), and break constantly. Surge takes a different approach:
+```text
+initialize project -> describe work -> approve roadmap/flow -> walk away -> return to a PR
+```
 
-- **ACP-First** — One protocol, any agent. Use Claude for planning, Copilot for coding, or mix and match per subtask.
-- **Pure Rust** — Single ~15MB binary. No dependencies. Starts in <50ms. Uses ~30MB RAM.
-- **Spec-Driven** — Structured TOML specifications with dependency graphs, agent routing, and acceptance criteria.
-- **Zero Garbage** — Automatic cleanup of worktrees, branches, and temp files. Surge cleans up after itself.
+The current repository already contains the lower-level engine, ACP bridge,
+persistence, daemon, CLI, notification, MCP, and desktop UI pieces. The full
+polished AFK product loop is still pre-release and is documented in
+[`docs/revision`](docs/revision/README.md).
 
 ## Status
 
-🚧 **Early development** — Not ready for use yet.
+Surge is **pre-release software**. Treat it as an active development workspace,
+not a stable end-user product.
 
-## Testing & CI
+Current implementation:
 
-Surge uses GitHub Actions to ensure cross-platform reliability:
+- `surge-core` - graph, profile, event, sandbox, approval, and validation types.
+- `surge-acp` - ACP client/pool/bridge, agent registry, discovery, health,
+  mock ACP agent.
+- `surge-orchestrator` - legacy spec pipeline plus the newer graph engine.
+- `surge-persistence` - SQLite-backed run storage, event logs, views, memory,
+  and analytics.
+- `surge-daemon` - long-running local engine host over Unix sockets / Windows
+  named pipes.
+- `surge-cli` - agents, specs, git worktrees, graph engine, daemon, registry,
+  memory, insights, analytics.
+- `surge-notify` - desktop, webhook, Slack, email, and Telegram delivery
+  backends.
+- `surge-mcp` - stdio MCP server lifecycle and tool delegation, currently wired
+  at the library/engine level rather than through a user-facing config file.
+- `surge-ui` - GPUI desktop shell under development.
 
-- **Tests** run on Windows, macOS, and Linux for every push and pull request
-- **Linting** via `cargo clippy` on all platforms
-- **Formatting** checks via `cargo fmt`
-- **Release builds** for x86_64-pc-windows-msvc, x86_64-apple-darwin, aarch64-apple-darwin, and x86_64-unknown-linux-gnu
+Documentation convention in this README:
 
-This prevents platform-specific regressions and ensures Surge works reliably across all major operating systems. Unlike tools like Aperant that require hundreds of Windows-specific fixes per release, Surge's pure Rust implementation and comprehensive CI testing catch issues early.
+- **Current** means implemented enough to try from the repository.
+- **Target** means product direction from `docs/revision`; command names may
+  still change while the CLI is being aligned.
 
-## Architecture
+## Target AFK Workflow
 
+Surge is project-first. A user creates or opens a project folder, runs
+`surge init`, lets Surge detect available ACP clients, chooses default or
+interactive setup, then runs whole-project or task-level work. The daemon owns
+execution and Telegram/UI are monitoring and approval surfaces.
+
+```mermaid
+flowchart TD
+    Project[Project folder]
+    Init[surge init]
+    Detect[Detect installed ACP clients]
+    Setup{Setup mode}
+    Defaults[Safe defaults]
+    Wizard[Interactive wizard<br/>agents, sandbox, worktrees, approvals, Telegram]
+    Config[surge.toml and .surge/]
+
+    Describe[surge project describe]
+    ProjectContext[project.md<br/>repo scan, git state, stack, AGENTS.md]
+
+    Intake{New work}
+    ProjectRun[Whole-project run]
+    TaskRun[Task run]
+
+    Roadmap[Generate or update roadmap.md]
+    Flow[Generate and validate flow.toml]
+    Approval[Approve or edit flow]
+    Daemon[surge-daemon]
+    Execute[Execute workflow graph]
+    Phone[Telegram AFK mode<br/>progress + approval cards]
+    Result[PR, patch, artifact, or terminal report]
+
+    Project --> Init
+    Init --> Detect
+    Detect --> Setup
+    Setup -->|default| Defaults
+    Setup -->|interactive| Wizard
+    Defaults --> Config
+    Wizard --> Config
+
+    Config --> Describe
+    Describe --> ProjectContext
+    ProjectContext --> Intake
+
+    Intake -->|large goal| ProjectRun
+    Intake -->|feature, bug, issue| TaskRun
+    ProjectRun --> Roadmap
+    TaskRun --> Roadmap
+    Roadmap --> Flow
+    Flow --> Approval
+    Approval --> Daemon
+    Daemon --> Execute
+    Execute --> Phone
+    Phone --> Execute
+    Execute --> Result
 ```
+
+The AFK part is explicit: the local machine keeps executing while the user only
+handles strategic decisions, such as approving generated plans, granting a
+permission, answering a HumanGate, or reviewing the final PR.
+
+## Flow Model
+
+A `flow.toml` is a workflow graph. Each node is a bounded stage with its own:
+
+- role/profile
+- provider/client: Claude, Codex, Gemini, Copilot, or custom ACP
+- sandbox intent and tool access
+- input bindings from prior artifacts
+- retry and timeout policy
+- declared outcomes
+
+Each Agent node runs in a **SMART Zone**:
+
+- **Scope** - what this node owns.
+- **Model** - which ACP client/provider runs it.
+- **Access** - sandbox intent, MCP tools, filesystem/network policy.
+- **Runtime context** - project description, roadmap item, prior artifacts,
+  selected files, graph metadata.
+- **Termination contract** - the node must report a declared outcome.
+
+Agents understand the local flow context and choose an outcome, but routing is
+still graph data. If a step needs judgment, that judgment is modeled as outcome
+ports such as `pass`, `fixes_needed`, `architecture_issue`, `security_blocker`,
+or `escalate`.
+
+### Example Feature Flow
+
+```mermaid
+flowchart LR
+    Spec[Spec Author]
+    Adr[ADR Author]
+    Plan[Planner]
+    TaskLoop{Task loop}
+    Impl[Implementer]
+    Verify[Verifier]
+    Commit[Committer]
+    MoreTasks{More tasks?}
+    ReviewClaude[Reviewer - Claude]
+    ReviewCodex[Reviewer - Codex]
+    ReviewGate{Review outcome}
+    PR[PR Composer]
+    Success[Terminal Success]
+
+    Spec --> Adr
+    Adr --> Plan
+    Plan --> TaskLoop
+    TaskLoop --> Impl
+    Impl --> Verify
+    Verify --> Commit
+    Commit --> MoreTasks
+    MoreTasks -->|yes| TaskLoop
+    MoreTasks -->|no| ReviewClaude
+    ReviewClaude --> ReviewCodex
+    ReviewCodex --> ReviewGate
+    ReviewGate -->|pass| PR
+    ReviewGate -->|fixes needed| Plan
+    PR --> Success
+```
+
+This is one possible medium feature flow. The Flow Generator can add or remove
+nodes based on risk, scope, project type, and available profiles.
+
+### Roadmap Flow
+
+For a roadmap-driven run, the graph can contain nested loops: an outer loop over
+milestones and an inner loop over tasks inside the active milestone.
+
+```mermaid
+flowchart TD
+    Roadmap[Approved roadmap.md]
+    MilestoneLoop{Milestone loop}
+    MilestonePlan[Milestone planner]
+    TaskLoop{Task loop}
+    Implement[Implementer]
+    Verify[Verifier]
+    Commit[Committer]
+    MoreTasks{More tasks in milestone?}
+    MilestoneVerify[Milestone verifier]
+    MilestoneReview[Milestone reviewer]
+    MoreMilestones{More milestones?}
+    FinalReview[Final reviewers]
+    PR[PR Composer]
+    Done[Terminal Success]
+
+    Roadmap --> MilestoneLoop
+    MilestoneLoop --> MilestonePlan
+    MilestonePlan --> TaskLoop
+    TaskLoop --> Implement
+    Implement --> Verify
+    Verify --> Commit
+    Commit --> MoreTasks
+    MoreTasks -->|yes| TaskLoop
+    MoreTasks -->|no| MilestoneVerify
+    MilestoneVerify --> MilestoneReview
+    MilestoneReview --> MoreMilestones
+    MoreMilestones -->|yes| MilestoneLoop
+    MoreMilestones -->|no| FinalReview
+    FinalReview --> PR
+    PR --> Done
+```
+
+Each loop body is still made of normal nodes with normal outcomes. A verifier
+can route back to implementation for a local fix. A milestone reviewer can
+route back to planning if the milestone is structurally wrong. Final reviewers
+can route back before PR creation.
+
+## Intake Sources
+
+All incoming work should be normalized before bootstrap. A GitHub issue or
+Linear issue is not a special pipeline type; it is another source of task text
+and metadata.
+
+```mermaid
+flowchart TD
+    CliText[CLI task text]
+    CliFile[CLI --from-file task.md]
+    Telegram[Telegram /run]
+    UI[Desktop UI]
+    GitHub[GitHub issue URL or ID]
+    Linear[Linear issue URL or ID]
+    ExistingFlow[Existing flow.toml]
+    LegacySpec[Legacy spec.toml]
+
+    TrackerFetch[Fetch tracker payload]
+    Intake[Intake normalizer]
+    Description[Description Author<br/>description.md]
+    Roadmap[Roadmap Planner<br/>roadmap.md]
+    FlowGenerator[Flow Generator<br/>flow.toml]
+    Validate[Parse and validate graph]
+    Engine[surge-orchestrator engine]
+    Legacy[Legacy spec pipeline]
+
+    CliText --> Intake
+    CliFile --> Intake
+    Telegram --> Intake
+    UI --> Intake
+    GitHub --> TrackerFetch
+    Linear --> TrackerFetch
+    TrackerFetch --> Intake
+
+    Intake --> Description
+    Description --> Roadmap
+    Roadmap --> FlowGenerator
+    FlowGenerator --> Validate
+
+    ExistingFlow --> Validate
+    LegacySpec --> Legacy
+    Validate --> Engine
+    Legacy --> Engine
+```
+
+Current practical paths:
+
+- `surge engine run <flow.toml>` starts from an already-authored graph.
+- `surge run <spec_id>` uses the older spec pipeline.
+
+Target paths:
+
+- CLI/Telegram/UI natural-language work enters the bootstrap path.
+- GitHub Issues and Linear issues are fetched, normalized, and fed into the same
+  bootstrap path.
+
+## Roadmap Amendments
+
+Roadmaps are not frozen documents. After roadmap approval, the user can add a
+feature through a target `surge feature` flow. The feature planner proposes a
+patch: where to insert the feature and how to expand it into milestone/tasks.
+
+```mermaid
+flowchart TD
+    User[surge feature<br/>describe new feature]
+    Chat[Interactive chat<br/>clarify scope]
+    FeatureAgent[Feature planner agent]
+    Patch[Roadmap patch<br/>placement + task breakdown]
+    Decision{Approve patch?}
+    RoadmapUpdate[roadmap.md vNext]
+    FlowUpdate[Update flow<br/>new milestone/task nodes]
+    RunnerState{Roadmap runner active?}
+    ActiveRunner[Runner picks up<br/>new pending work]
+    FollowUp[Create follow-up run]
+    Daemon[surge-daemon queues or starts run]
+
+    User --> Chat
+    Chat --> FeatureAgent
+    FeatureAgent --> Patch
+    Patch --> Decision
+    Decision -->|edit| Chat
+    Decision -->|reject| User
+    Decision -->|approve| RoadmapUpdate
+    RoadmapUpdate --> FlowUpdate
+    FlowUpdate --> RunnerState
+    RunnerState -->|yes| ActiveRunner
+    RunnerState -->|no| FollowUp
+    FollowUp --> Daemon
+```
+
+If a roadmap runner is active, the daemon can emit a roadmap-updated event and
+the runner sees the new pending milestone/tasks. If the roadmap is already
+terminal, or roadmap-flow execution is disabled, Surge appends the feature and
+creates a follow-up run instead of mutating completed execution history.
+
+## Runtime Architecture
+
+```mermaid
+flowchart LR
+    User[User] --> CLI[surge CLI]
+    User --> UI[surge-ui]
+
+    CLI -->|local IPC| Daemon[surge-daemon]
+    UI -->|local IPC| Daemon
+    CLI -->|in-process mode| Engine[surge-orchestrator engine]
+    Daemon --> Engine
+
+    Engine --> Core[surge-core graph and event types]
+    Engine --> Store[surge-persistence]
+    Engine --> Git[surge-git worktrees]
+    Engine --> Notify[surge-notify]
+    Engine --> Acp[surge-acp bridge]
+    Engine --> Mcp[surge-mcp registry]
+
+    Store --> Runs[(~/.surge/runs)]
+    Acp --> Agents[Claude Code / Codex / Gemini / custom ACP agents]
+    Mcp --> Servers[MCP stdio servers]
+    Notify --> Channels[Desktop / Webhook / Slack / Email / Telegram]
+```
+
+The daemon is the local coordinator. It accepts work from CLI, Telegram, UI, and
+eventually external trackers, then starts or queues runs. Progress and approval
+state are derived from the event log, so Telegram messages and the desktop UI
+render the same underlying state.
+
+## Run Lifecycle
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant CLI as surge CLI
+    participant Daemon as surge-daemon
+    participant Engine
+    participant Store as Event Store
+    participant Agent as ACP Agent
+    participant Notify as Notifications
+
+    User->>CLI: surge engine run flow.toml --daemon --watch
+    CLI->>Daemon: StartRun(graph, worktree)
+    Daemon->>Engine: admit or queue run
+    Engine->>Store: append RunStarted
+
+    loop Until terminal node or unrecoverable failure
+        Engine->>Store: append StageEntered
+
+        alt Agent node
+            Engine->>Agent: open session and send prompt
+            Agent-->>Engine: report_stage_outcome(outcome)
+        else HumanGate node
+            Engine->>Notify: send approval request
+            Notify-->>Engine: decision
+        else Branch / Notify / Terminal node
+            Engine->>Engine: evaluate deterministic behavior
+        end
+
+        Engine->>Store: append StageCompleted or StageFailed
+        Engine->>Store: append EdgeTraversed
+        Engine-->>Daemon: broadcast event
+        Daemon-->>CLI: stream event
+    end
+
+    Engine->>Store: append RunCompleted / RunFailed / RunAborted
+    Engine-->>Daemon: broadcast terminal outcome
+```
+
+Every state transition is persisted first and rendered later. Replaying a run is
+a fold over the event stream.
+
+## Repository Layout
+
+```text
 surge/
-├── crates/
-│   ├── surge-core/          # Types, config, spec format, FSM
-│   ├── surge-acp/           # ACP Client implementation
-│   └── surge-cli/           # CLI application
-├── docs/                    # Project documentation & RFCs
-└── specs/                   # Spec templates
+|-- crates/
+|   |-- surge-core/          # Core graph, event, profile, config, validation types
+|   |-- surge-acp/           # ACP integration, agent pool, bridge, registry
+|   |-- surge-spec/          # Legacy TOML spec format and validation
+|   |-- surge-git/           # Git worktree and branch lifecycle
+|   |-- surge-persistence/   # SQLite/event-log storage, analytics, memory
+|   |-- surge-orchestrator/  # Legacy pipeline and new graph execution engine
+|   |-- surge-cli/           # `surge` CLI binary
+|   |-- surge-daemon/        # Long-running local engine process
+|   |-- surge-ui/            # GPUI desktop application
+|   |-- surge-notify/        # Notification delivery backends
+|   `-- surge-mcp/           # MCP stdio server lifecycle and tool calls
+|-- docs/
+|   |-- revision/            # Active product specification and roadmap
+|   |-- superpowers/         # Implementation specs/plans for recent milestones
+|   `-- *.md                 # Legacy/background docs
+|-- examples/
+|   |-- flow_terminal_only.toml
+|   `-- flow_minimal_agent.toml
+|-- surge.example.toml       # Example project config
+`-- Cargo.toml               # Rust workspace
 ```
 
-See [docs/02-ARCHITECTURE.md](docs/02-ARCHITECTURE.md) for the full architecture.
+## Quick Start
 
-## Roadmap
+Requirements:
 
-| Phase | Focus | Status |
-|-------|-------|--------|
-| 0 | Foundation + first ACP connection | 🔄 In Progress |
-| 1 | Spec system | ⬜ Planned |
-| 2 | Git worktrees | ⬜ Planned |
-| 3 | Orchestrator MVP | ⬜ Planned |
-| 4 | Parallel execution | ⬜ Planned |
-| 5 | Multi-agent | ⬜ Planned |
-| 6 | GUI (egui) | ⬜ Planned |
-| 7 | Advanced features | ⬜ Planned |
+- Rust `1.85+`
+- Git
+- An ACP-compatible agent on `PATH` for flows that contain `Agent` nodes
 
-See [docs/03-ROADMAP.md](docs/03-ROADMAP.md) for details.
+Build the core workspace:
+
+```bash
+cargo build --workspace --exclude surge-ui
+```
+
+The desktop UI is optional and has separate GPUI dependencies:
+
+```bash
+cargo build -p surge-ui
+```
+
+Run the smallest graph. This flow contains only a terminal node, so it does not
+need an agent:
+
+```bash
+cargo run -p surge-cli --bin surge -- engine run examples/flow_terminal_only.toml --watch
+```
+
+Run the same flow through the daemon:
+
+```bash
+cargo run -p surge-cli --bin surge -- daemon start --detached
+cargo run -p surge-cli --bin surge -- engine run examples/flow_terminal_only.toml --daemon --watch
+cargo run -p surge-cli --bin surge -- engine ls --daemon
+cargo run -p surge-cli --bin surge -- daemon stop
+```
+
+Configure agents in a project:
+
+```bash
+cargo run -p surge-cli --bin surge -- init
+cargo run -p surge-cli --bin surge -- registry list
+cargo run -p surge-cli --bin surge -- registry detect
+cargo run -p surge-cli --bin surge -- agent list
+```
+
+Then edit `surge.toml` or use registry commands to add an ACP agent. The sample
+config in [`surge.example.toml`](surge.example.toml) shows local, `npx`, custom,
+TCP, and MCP-flavored agent entries.
+
+Smoke-test an agent:
+
+```bash
+cargo run -p surge-cli --bin surge -- ping --agent claude
+cargo run -p surge-cli --bin surge -- prompt "Summarize this repository" --agent claude
+```
+
+Run the minimal agent graph once an ACP agent is available:
+
+```bash
+cargo run -p surge-cli --bin surge -- engine run examples/flow_minimal_agent.toml --watch
+```
+
+## CLI Surface
+
+Current command groups:
+
+```text
+surge init              create project-level surge.toml
+surge agent ...         manage configured agents
+surge registry ...      inspect built-in/remote ACP agent registry
+surge spec ...          manage legacy specs
+surge run ...           execute the legacy spec pipeline
+surge engine ...        execute flow.toml graphs
+surge daemon ...        manage the long-running local engine host
+surge clean/worktrees   inspect and clean git worktrees
+surge analytics ...     view token/cost analytics
+```
+
+There are two execution surfaces today:
+
+- `surge spec ...` + `surge run <spec_id>` is the older structured-spec
+  pipeline. It creates static task plans from templates and runs them through
+  planner/coder/reviewer-style stages.
+- `surge engine run <flow.toml>` is the newer graph engine path. It runs an
+  already-authored workflow graph with explicit nodes, outcomes, and edges.
+
+Current-to-target mapping:
+
+| Product intent | Current closest command | Gap |
+| --- | --- | --- |
+| Initialize a project | `surge init`, then `surge registry detect`, `surge registry add`, or `surge agent add` | `init` is not an interactive wizard yet; sandbox, worktree, approvals, and notification choices are separate/manual. |
+| Describe or refresh project context | `surge memory add` and `surge memory search` | No `surge project describe` command yet; repo scanning and stable project context generation are target behavior. |
+| Create a focused feature/task run | `surge spec create "..." --template feature`, then `surge plan <id>` or `surge run <id>` | Uses static legacy templates, not adaptive flow generation. |
+| Run a full roadmap/flow | Manually create `flow.toml`, then `surge engine run <flow.toml> --watch` | No command yet that generates roadmap, milestones, tasks, and flow from a project goal. |
+| Amend an existing roadmap with a new feature | Create another spec with `surge spec create ...` or edit roadmap/flow files manually | No `surge feature` command yet that inserts work into a roadmap and wakes the runner. |
+| Run AFK through a daemon | `surge daemon start` and `surge engine run <flow.toml> --daemon --watch` | Daemon exists; full Telegram approval bot and tracker intake loop are still target UX. |
+| Start from GitHub Issues or Linear | No direct CLI equivalent | GitHub/Linear issue intake should normalize tracker payloads into the same bootstrap path, but this is not a user-facing command yet. |
+
+Current `surge spec create` templates are `feature`, `bugfix`, `refactor`,
+`performance`, `security`, `docs`, and `migration`.
+
+Target command ideas from the product model:
+
+```text
+surge project describe  create or refresh stable project context
+surge task ...          create a focused task run
+surge feature ...       amend roadmap with a new feature
+```
 
 ## Documentation
 
-- [Vision](docs/01-VISION.md) — Mission, philosophy, key differentiators
-- [Architecture](docs/02-ARCHITECTURE.md) — Crate structure, types, data flows
-- [Roadmap](docs/03-ROADMAP.md) — Development phases and milestones
-- [RFC-001: ACP Integration](docs/04-RFC-001-ACP-INTEGRATION.md) — Core ACP design
-- [Competitive Analysis](docs/05-COMPETITIVE-ANALYSIS.md) — How Surge compares
-- [Features](docs/06-FEATURES.md) — Complete feature specification
-- [UX Solutions](docs/07-UX-PAIN-POINTS.md) — Pain points and how Surge solves them
-- [Community Pain Points](docs/08-COMMUNITY-PAIN-POINTS.md) — Issues from existing tools
+Start here:
+
+- [`docs/revision/README.md`](docs/revision/README.md) - active spec index
+- [`docs/revision/rfcs/0001-overview.md`](docs/revision/rfcs/0001-overview.md) -
+  vision, scope, non-goals, glossary
+- [`docs/revision/rfcs/0002-execution-model.md`](docs/revision/rfcs/0002-execution-model.md) -
+  event sourcing, run lifecycle, replay, crash recovery
+- [`docs/revision/rfcs/0003-graph-model.md`](docs/revision/rfcs/0003-graph-model.md) -
+  nodes, outcomes, edges, validation
+- [`docs/revision/rfcs/0004-bootstrap-and-flow-generation.md`](docs/revision/rfcs/0004-bootstrap-and-flow-generation.md) -
+  target bootstrap and adaptive flow generation
+- [`docs/revision/rfcs/0005-profiles-and-roles.md`](docs/revision/rfcs/0005-profiles-and-roles.md) -
+  reusable agent profiles
+- [`docs/revision/rfcs/0006-sandbox-and-approvals.md`](docs/revision/rfcs/0006-sandbox-and-approvals.md) -
+  agent-native sandbox intent and approval policy
+- [`docs/revision/rfcs/0007-telegram-bot.md`](docs/revision/rfcs/0007-telegram-bot.md) -
+  target mobile approval UX
+- [`docs/revision/rfcs/0008-ui-architecture.md`](docs/revision/rfcs/0008-ui-architecture.md) -
+  editor/runtime/replay UI direction
+- [`docs/revision/ROADMAP.md`](docs/revision/ROADMAP.md) - milestone roadmap
+
+Crate-level docs worth reading:
+
+- [`crates/surge-daemon/README.md`](crates/surge-daemon/README.md)
+- [`crates/surge-mcp/README.md`](crates/surge-mcp/README.md)
+- [`crates/surge-notify/README.md`](crates/surge-notify/README.md)
+
+## Development
+
+Common checks:
+
+```bash
+cargo fmt --check
+cargo test --workspace --exclude surge-ui
+cargo clippy -p surge-core --all-targets --all-features -- -D warnings
+cargo clippy -p surge-acp --all-targets -- -D warnings
+cargo clippy --workspace --all-targets --all-features
+```
+
+Long-running or external-agent engine tests are separated:
+
+```bash
+cargo build -p surge-acp --bin mock_acp_agent
+cargo test -p surge-orchestrator --tests -- --ignored
+```
+
+Local runtime state is stored under `~/.surge/`, including run databases and
+daemon metadata. Project-local state may appear under `.surge/`.
 
 ## License
 
-Licensed under either of
+Licensed under either of:
 
 - Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE))
 - MIT License ([LICENSE-MIT](LICENSE-MIT))

--- a/crates/surge-acp/src/bridge/mod.rs
+++ b/crates/surge-acp/src/bridge/mod.rs
@@ -1,5 +1,5 @@
 #![warn(missing_docs)]
-//! Vibe-flow ACP bridge.
+//! Surge ACP bridge.
 //!
 //! Pure-addition submodule introduced in M3. Coexists with the legacy
 //! `AgentPool` / `SurgeClient` stack at the crate root; consumers pick the

--- a/crates/surge-acp/src/lib.rs
+++ b/crates/surge-acp/src/lib.rs
@@ -59,7 +59,7 @@ pub mod secrets;
 pub mod terminal;
 pub mod transport;
 
-// New (M3) — vibe-flow ACP bridge. Pure addition, legacy modules untouched.
+// New (M3) — Surge ACP bridge. Pure addition, legacy modules untouched.
 pub mod bridge;
 pub mod shared;
 

--- a/crates/surge-core/src/id.rs
+++ b/crates/surge-core/src/id.rs
@@ -62,7 +62,7 @@ define_id!(SpecId, "spec");
 define_id!(TaskId, "task");
 define_id!(SubtaskId, "sub");
 
-// New runtime IDs added in M1 for vibe-flow data model.
+// New runtime IDs added in M1 for Surge data model.
 define_id!(RunId, "run");
 define_id!(SessionId, "session");
 

--- a/crates/surge-core/src/keys.rs
+++ b/crates/surge-core/src/keys.rs
@@ -1,4 +1,4 @@
-//! Stable string identifiers for vibe-flow graph entities.
+//! Stable string identifiers for Surge graph entities.
 //!
 //! These keys are *user-typed strings* in `flow.toml` (e.g., `"impl_2"`,
 //! `"done"`, `"implementer@1.0"`). For *runtime-generated* IDs (`RunId`,

--- a/crates/surge-core/src/lib.rs
+++ b/crates/surge-core/src/lib.rs
@@ -29,7 +29,7 @@ pub mod roadmap;
 pub mod spec;
 pub mod state;
 
-// New modules — vibe-flow data model.
+// New modules — Surge data model.
 pub mod agent_config;
 pub mod approvals;
 pub mod branch_config;
@@ -65,7 +65,7 @@ pub use roadmap::{Priority, RoadmapItem, RoadmapStatus, Timeline, TimelineBatch}
 pub use spec::{AcceptanceCriteria, Complexity, Spec, Subtask, SubtaskExecution, SubtaskState};
 pub use state::TaskState;
 
-// ── New re-exports (vibe-flow data model) ──
+// ── New re-exports (Surge data model) ──
 pub use content_hash::ContentHash;
 pub use edge::{Edge, EdgeKind, EdgePolicy, ExceededAction, PortRef};
 pub use graph::{Graph, GraphMetadata, SCHEMA_VERSION, Subgraph};

--- a/crates/surge-orchestrator/src/engine/stage/loop_stage.rs
+++ b/crates/surge-orchestrator/src/engine/stage/loop_stage.rs
@@ -120,7 +120,7 @@ async fn resolve_iterable(
             })?;
 
             // M6 supports TOML artifacts with a simple dotted path.
-            // (JSON support could be added later; current vibe-flow artifacts
+            // (JSON support could be added later; current Surge artifacts
             // are TOML by convention — see CLAUDE.md.)
             let content = std::str::from_utf8(&bytes).map_err(|e| {
                 StageError::Internal(format!(

--- a/crates/surge-persistence/src/lib.rs
+++ b/crates/surge-persistence/src/lib.rs
@@ -65,7 +65,7 @@ pub mod pricing;
 /// SQLite-based storage implementation
 pub mod store;
 
-/// New M2 vibe-flow storage layer (per-run event log, registry, worktree integration).
+/// New M2 Surge storage layer (per-run event log, registry, worktree integration).
 pub mod runs;
 
 /// Persistence error types

--- a/crates/surge-persistence/src/runs/mod.rs
+++ b/crates/surge-persistence/src/runs/mod.rs
@@ -1,4 +1,4 @@
-//! Per-run SQLite event store and registry for the vibe-flow architecture.
+//! Per-run SQLite event store and registry for the Surge architecture.
 //!
 //! This module is the M2 milestone of the surge-persistence layer. It lives
 //! alongside the existing legacy persistence (aggregator/budget/memory/

--- a/docs/revision/README.md
+++ b/docs/revision/README.md
@@ -1,10 +1,10 @@
-# vibe-flow · Project Specification
+# surge · Project Specification
 
-> Graph-based AI coding orchestrator with adaptive flow generation, sandbox-first autonomy, and Telegram-driven approvals.
+> Graph-based AI coding orchestrator with adaptive flow generation, agent-native sandbox autonomy, and Telegram-driven approvals.
 
 ## What is this
 
-`vibe-flow` is a local-first desktop tool for orchestrating long-running AI coding tasks through declarative graphs. The user describes a goal in natural language, the system generates a tailored execution flow (linear for trivial tasks, nested loops for large multi-milestone work), and agents execute autonomously with the user approving only at strategic checkpoints — typically via Telegram, so they don't need to sit at the computer.
+`surge` is a local-first desktop tool for orchestrating long-running AI coding tasks through declarative graphs. The user describes a goal in natural language, the system generates a tailored execution flow (linear for trivial tasks, nested loops for large multi-milestone work), and agents execute autonomously with the user approving only at strategic checkpoints — typically via Telegram, so they don't need to sit at the computer.
 
 It is **not** another kanban or task manager. It is **not** a multi-agent swarm. It is a deterministic engine driving typed graphs where each node is an isolated agent session with declared outcomes that route to specific next nodes.
 
@@ -16,9 +16,10 @@ Author has a full-time job. Existing AI coding tools require constant attention 
 
 1. **Engine is dumb, agents are smart.** Routing decisions are declarative (graph edges by outcome). LLM only writes code, never decides "what to do next" — that's the graph's job.
 2. **Adaptive complexity.** Trivial task → 3 nodes. Large project → nested milestone/task loops. The Flow Generator picks structure per-task, the user never selects a "tier" or "methodology".
-3. **Sandbox-first autonomy.** Default sandbox is restrictive enough that 90% of agent actions need no approval. User is pinged only on (a) declared HumanGate nodes, (b) sandbox elevation, (c) terminal events.
-4. **Event-sourced, replayable.** Every run is an append-only event log. Time-travel debugging and "fork from here" are free consequences.
-5. **Open source, MIT/Apache-2.0.** No paywalls, no telemetry without opt-in, no CLA. DCO sign-off only.
+3. **Compose-like configuration.** Agent routing is declared in a friendly `agents.yml` file with named agents and role routes, similar to `docker-compose.yml`. LLMs should be able to read and edit it safely.
+4. **Agent-native sandbox autonomy.** surge does not implement its own OS sandbox. It configures and observes the sandbox/permission system already provided by the selected agent runtime, then pings the user only on (a) declared HumanGate nodes, (b) agent permission/elevation requests, (c) terminal events.
+5. **Event-sourced, replayable.** Every run is an append-only event log. Time-travel debugging and "fork from here" are free consequences.
+6. **Open source, MIT/Apache-2.0.** No paywalls, no telemetry without opt-in, no CLA. DCO sign-off only.
 
 ## Document index
 
@@ -29,7 +30,7 @@ Author has a full-time job. Existing AI coding tools require constant attention 
 - [`rfcs/0003-graph-model.md`](rfcs/0003-graph-model.md) — Nodes, edges, outcomes, validation rules
 - [`rfcs/0004-bootstrap-and-flow-generation.md`](rfcs/0004-bootstrap-and-flow-generation.md) — Three-stage bootstrap, adaptive complexity
 - [`rfcs/0005-profiles-and-roles.md`](rfcs/0005-profiles-and-roles.md) — Profile registry, role-as-first-class-node
-- [`rfcs/0006-sandbox-and-approvals.md`](rfcs/0006-sandbox-and-approvals.md) — Sandbox modes, hooks, AGENTS.md, trust
+- [`rfcs/0006-sandbox-and-approvals.md`](rfcs/0006-sandbox-and-approvals.md) — Agent launch/sandbox settings, approvals, hooks, AGENTS.md, trust
 - [`rfcs/0007-telegram-bot.md`](rfcs/0007-telegram-bot.md) — Approval UX, inline keyboard, command interface
 - [`rfcs/0008-ui-architecture.md`](rfcs/0008-ui-architecture.md) — Editor canvas, runtime view, replay mode
 
@@ -43,7 +44,7 @@ Author has a full-time job. Existing AI coding tools require constant attention 
 
 ### Component specs (implementation level)
 
-- [`components/cli.md`](components/cli.md) — `vibe` CLI surface
+- [`components/cli.md`](components/cli.md) — `surge` CLI surface
 - [`components/editor.md`](components/editor.md) — egui canvas editor
 - [`components/runtime-ui.md`](components/runtime-ui.md) — gpui runtime/replay view
 - [`components/telegram-bot.md`](components/telegram-bot.md) — teloxide bot implementation

--- a/docs/revision/ROADMAP.md
+++ b/docs/revision/ROADMAP.md
@@ -2,9 +2,9 @@
 
 ## Overview
 
-This roadmap breaks the implementation into **milestones with concrete tasks**. Each milestone is independently shippable — at the end of each, you have a working slice of surge.
+This roadmap breaks the implementation into **milestones with concrete tasks**. Each milestone is independently shippable — at the end of each, you have a working slice of Surge.
 
-The roadmap is **realistic for solo evening/weekend work** — author has full-time job, builds Nebula and Surge in parallel. Estimates assume 8-12 hours/week of focused surge work.
+The roadmap is **realistic for solo evening/weekend work** — author has full-time job, builds Nebula and Surge in parallel. Estimates assume 8-12 hours/week of focused Surge work.
 
 ## Realistic timeline
 

--- a/docs/revision/ROADMAP.md
+++ b/docs/revision/ROADMAP.md
@@ -2,9 +2,9 @@
 
 ## Overview
 
-This roadmap breaks the implementation into **milestones with concrete tasks**. Each milestone is independently shippable — at the end of each, you have a working slice of vibe-flow.
+This roadmap breaks the implementation into **milestones with concrete tasks**. Each milestone is independently shippable — at the end of each, you have a working slice of surge.
 
-The roadmap is **realistic for solo evening/weekend work** — author has full-time job, builds Nebula and Surge in parallel. Estimates assume 8-12 hours/week of focused vibe-flow work.
+The roadmap is **realistic for solo evening/weekend work** — author has full-time job, builds Nebula and Surge in parallel. Estimates assume 8-12 hours/week of focused surge work.
 
 ## Realistic timeline
 
@@ -20,9 +20,9 @@ Total: 9-12 months from start to v1.0. Don't try to compress this.
 
 ## v0.1 MVP
 
-**Goal**: A user can run `vibe run "<description>"` from a Rust project, get bootstrapped through Telegram approvals, and end up with a merged PR — without ever opening a desktop UI.
+**Goal**: A user can run `surge run "<description>"` from a Rust project, get bootstrapped through Telegram approvals, and end up with a merged PR — without ever opening a desktop UI.
 
-**Includes**: CLI, engine, ACP integration, sandbox, Telegram bot, 7 standard profiles, 3 templates.
+**Includes**: CLI, engine, ACP integration, agent launch configuration, agent-native sandbox configuration, Telegram bot, 7 standard profiles, 3 templates.
 
 **Excludes**: Visual editor, runtime UI, replay/fork features.
 
@@ -92,30 +92,30 @@ Implement the ACP bridge from architecture/04-acp-integration.md.
 - T3.6 — Agent registry: detect Claude Code, Codex, Gemini in PATH.
 - T3.7 — Tool injection: `report_stage_outcome` with dynamic outcome enum.
 - T3.8 — Tool injection: `request_human_input`.
-- T3.9 — Sandbox-filtered MCP tool list per session.
+- T3.9 — Agent launch/profile/sandbox settings passed into each session; MCP tool exposure follows what the agent runtime supports.
 - T3.10 — Session crash detection (subprocess exit) → `SessionEnded` event.
 - T3.11 — Token usage tracking from agent messages.
 - T3.12 — Mock ACP agent for testing (in `crates/testing`).
 
 **Acceptance**: Can open a session with at least Claude Code (or mock), exchange messages, observe tool calls, close cleanly. Multiple concurrent sessions work.
 
-### M4: Sandbox (week 9)
+### M4: Agent sandbox integration and approvals (week 9)
 
-Implement sandbox enforcement from RFC-0006.
+Implement the launch, approval, and permission layer from RFC-0006. surge does **not** implement its own OS sandbox; it configures the selected agent runtime's launch mode, sandbox/permission mode, and records/approves escalation requests.
 
 **Tasks:**
-- T4.1 — Define `Sandbox` trait + 4 modes (`read-only`, `workspace-write`, `workspace+network`, `full-access`).
-- T4.2 — Tier 1 enforcement: MCP tool filtering.
-- T4.3 — Tier 2 enforcement: filesystem path checking.
-- T4.4 — Tier 3 Linux: Landlock integration via `landlock` crate.
-- T4.5 — Tier 3 macOS: `sandbox-exec` wrapper.
-- T4.6 — Tier 3 Windows: AppContainer + Job Objects (most limited).
-- T4.7 — Tier 4 network: domain allowlist for outbound HTTPS.
-- T4.8 — Sandbox elevation flow: detect, request, decide, persist if "remember".
-- T4.9 — Always-deny patterns (`.git`, `.vibe`, secrets).
-- T4.10 — `vibe doctor` reports sandbox capability per OS.
+- T4.1 — Define agent launch profile model (`provider-default`, `local`, `cloud`, `sandbox`) and sandbox profile model (`read-only`, `workspace-write`, `workspace+network`, `full-access`, `provider-default`) as configuration, not enforcement.
+- T4.2 — Implement compose-like `agents.yml` parser/validator with named agents, role routes, defaults, and project/global precedence.
+- T4.3 — Map named agent launch and sandbox settings to supported session flags for Claude Code, Codex, Gemini CLI, and Custom ACP agents.
+- T4.4 — Surface provider capability metadata: which launch modes, sandbox modes, approval policies, network flags, and tool permission flows are supported.
+- T4.5 — Implement permission/elevation event flow: detect provider permission request, write event, send Telegram card, resume with allow/deny result when the provider supports it.
+- T4.6 — Implement fallback behavior when provider cannot pause for permission: warn, fail closed for risky modes, or require explicit `full-access`.
+- T4.7 — Persist "Allow & remember" as profile/template policy, not as local OS rules.
+- T4.8 — Secrets filtering and protected-path warning rules for summaries sent to Telegram.
+- T4.9 — `surge doctor` reports agent launch/sandbox capability per installed provider and validates `agents.yml`.
+- T4.10 — Mock-agent tests for permission request/decision/retry flow and named-agent resolution.
 
-**Acceptance**: Attempted escapes (write outside worktree, access ~/.ssh, network to non-allowlisted) are blocked at appropriate tier on each OS.
+**Acceptance**: For each supported agent provider, surge passes the requested launch/sandbox/approval settings into the session when supported, reports unsupported modes clearly, and completes a permission request → Telegram decision → resumed session flow with the mock provider.
 
 ### M5: Engine executor (week 10-11)
 
@@ -153,14 +153,14 @@ Implement CLI commands from components/cli.md.
 - T6.9 — Daemon spawning logic (cross-platform).
 - T6.10 — Live attach: tail event log, format events for terminal.
 
-**Acceptance**: All commands work in text and JSON modes. `vibe doctor` correctly diagnoses common issues.
+**Acceptance**: All commands work in text and JSON modes. `surge doctor` correctly diagnoses common issues.
 
 ### M7: Telegram bot (week 13)
 
 Implement Telegram bot from components/telegram-bot.md.
 
 **Tasks:**
-- T7.1 — `teloxide` setup, bot binary `vibe-tg`.
+- T7.1 — `teloxide` setup, bot binary `surge-tg`.
 - T7.2 — Long-poll mode, dispatcher.
 - T7.3 — Setup flow: ephemeral binding token, /start handling.
 - T7.4 — Outgoing pipeline: poll for `pending_approvals`, build cards, send.
@@ -202,9 +202,9 @@ Implement the 10 v1 profiles + 3 templates.
 
 The v0.1 milestone is complete when:
 
-1. A new user can install vibe-flow on Linux/macOS/Windows (binary distribution or `cargo install`)
-2. They can run `vibe telegram setup` and bind their bot
-3. They can run `vibe run "<description>"` from a Rust project
+1. A new user can install surge on Linux/macOS/Windows (binary distribution or `cargo install`)
+2. They can run `surge telegram setup` and bind their bot
+3. They can run `surge run "<description>"` from a Rust project
 4. They receive Telegram bootstrap cards (Description → Roadmap → Flow)
 5. After approving, the run executes autonomously
 6. They receive a final card with PR link
@@ -257,7 +257,7 @@ The v0.1 milestone is complete when:
 - T10.11 — Multiple runs sidebar.
 - T10.12 — Cross-platform binaries.
 
-**Acceptance**: Can attach to a running run via `vibe-runtime --run <id>`, see live progress, follow events, view active stage details.
+**Acceptance**: Can attach to a running run via `surge-runtime --run <id>`, see live progress, follow events, view active stage details.
 
 ---
 
@@ -305,7 +305,7 @@ The v0.1 milestone is complete when:
 - T14.1 — Hook execution refinements: timeouts, env injection.
 - T14.2 — AGENTS.md JIT loading with token budget management.
 - T14.3 — Trust state management UI in editor.
-- T14.4 — Project-level `.vibe/` directory full support.
+- T14.4 — Project-level `.surge/` directory full support.
 
 ### M15: Specialized profiles (week 34-35)
 
@@ -326,8 +326,8 @@ The v0.1 milestone is complete when:
 ### M17: Quality of life (week 37-38)
 
 **Tasks:**
-- T17.1 — `vibe gc` polish.
-- T17.2 — Run export/import (`vibe export <id>`).
+- T17.1 — `surge gc` polish.
+- T17.2 — Run export/import (`surge export <id>`).
 - T17.3 — Better error messages across all commands.
 - T17.4 — Logging improvements with structured fields.
 - T17.5 — Performance audit on long runs (10K+ events).
@@ -352,7 +352,7 @@ The v0.1 milestone is complete when:
 **Tasks:**
 - T19.1 — Binary builds for major platforms (release artifacts).
 - T19.2 — Homebrew formula.
-- T19.3 — `cargo install vibe-flow` works.
+- T19.3 — `cargo install surge` works.
 - T19.4 — AUR package (Arch).
 - T19.5 — Debian/RPM packages.
 - T19.6 — Windows installer (msi or exe).
@@ -408,11 +408,11 @@ The 3 bootstrap prompts (Description, Roadmap, Flow Generator) are the make-or-b
 
 **Mitigation**: Spend disproportionate time iterating on these prompts during M8. Build a fixture-based testing system (M8.T14) that runs prompts against varied inputs and verifies output quality. Don't release v0.1 until 10+ test descriptions produce coherent flows.
 
-### Risk: Sandbox edge cases on Windows
+### Risk: Agent sandbox behavior differs by provider
 
-Windows sandboxing (AppContainer + Job Objects) is significantly more limited than Linux/macOS.
+Codex, Claude Code, Gemini CLI, and custom ACP agents may expose different local/cloud/sandbox launch modes, sandbox flags, approval prompts, or permission callback semantics.
 
-**Mitigation**: Windows in v0.1 ships with Tier 1 + Tier 2 only (MCP filtering + path checking). Tier 3 enforcement comes later. Document this clearly. Most users on Windows will probably run vibe-flow in WSL anyway.
+**Mitigation**: Treat launch and sandboxing as provider capability metadata. surge only promises to configure and observe what the selected runtime supports. Unsupported combinations fail with a clear diagnostic or require an explicit profile change.
 
 ### Risk: Author doesn't have time
 
@@ -428,7 +428,7 @@ Solo project, full-time job, two other side projects (Nebula, Surge).
 | M1 | Core types tested, 80%+ coverage |
 | M2 | All storage acceptance criteria pass |
 | M3 | Mock + real ACP integration works |
-| M4 | Sandbox tests pass on all 3 OSes |
+| M4 | Agent launch/sandbox settings and permission approvals work through provider capabilities |
 | M5 | End-to-end test (5-node graph) succeeds |
 | M6 | All CLI commands work in text + JSON |
 | M7 | Full bootstrap via Telegram works |

--- a/docs/revision/architecture/01-workspace.md
+++ b/docs/revision/architecture/01-workspace.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-vibe-flow is a Rust workspace with multiple crates. The split is driven by:
+surge is a Rust workspace with multiple crates. The split is driven by:
 - **Layered architecture**: dependencies flow only downward
 - **Different stacks**: editor (egui) and runtime (gpui) need separate UI crates
 - **Compilation time**: smaller crates rebuild faster
@@ -11,7 +11,7 @@ vibe-flow is a Rust workspace with multiple crates. The split is driven by:
 ## Crate structure
 
 ```
-vibe-flow/
+surge/
 ├── Cargo.toml                  (workspace)
 ├── README.md
 ├── ARCHITECTURE.md             (link to spec docs)
@@ -24,14 +24,13 @@ vibe-flow/
 │   ├── engine/                 (state machine, executor)
 │   ├── storage/                (SQLite + filesystem)
 │   ├── acp/                    (ACP integration)
-│   ├── sandbox/                (OS-level sandboxing)
 │   ├── telegram/               (bot service)
 │   ├── editor/                 (egui editor binary)
 │   ├── runtime-ui/             (gpui runtime binary)
 │   ├── cli/                    (CLI binary)
 │   └── testing/                (test utilities)
 │
-├── profiles/                   (bundled profiles, copied to ~/.vibe/profiles/)
+├── profiles/                   (bundled profiles, copied to ~/.surge/profiles/)
 │   ├── _bootstrap/
 │   │   ├── description-author-1.0.toml
 │   │   ├── roadmap-planner-1.0.toml
@@ -78,8 +77,9 @@ Lowest layer. No I/O, no async, no UI.
 - `Event`, `EventPayload` types (RFC-0002)
 - `RunState`, fold function (RFC-0002)
 - `Profile`, `Role` types (RFC-0005)
-- `SandboxMode`, `ApprovalPolicy` types (RFC-0006)
-- TOML serialization/deserialization
+- `AgentLaunchConfig`, `LaunchMode`, `SandboxMode`, `ApprovalPolicy` types (RFC-0006)
+- TOML serialization/deserialization for profiles/flows/templates
+- YAML serialization/deserialization for `agents.yml`
 - Validation logic
 
 **Dependencies:**
@@ -88,6 +88,7 @@ Lowest layer. No I/O, no async, no UI.
 serde = { version = "1", features = ["derive"] }
 toml = "0.8"
 toml_edit = "0.22"
+# YAML parser for compose-like agents.yml; exact crate chosen during implementation.
 chrono = { version = "0.4", features = ["serde"] }
 uuid = { version = "1", features = ["v7", "serde"] }
 domain-key = { workspace = true }   # author's existing crate
@@ -119,7 +120,6 @@ The state machine that drives runs.
 core = { path = "../core" }
 storage = { path = "../storage" }
 acp = { path = "../acp" }
-sandbox = { path = "../sandbox" }
 tokio = { version = "1", features = ["full"] }
 async-trait = "1"
 tracing = "0.1"
@@ -133,7 +133,7 @@ Wraps SQLite for event log + materialized views, plus filesystem for artifacts.
 - SQLite schema and migrations
 - Event log append + read
 - Materialized view maintenance
-- Artifact storage (filesystem under `~/.vibe/runs/<run_id>/artifacts/`)
+- Artifact storage (filesystem under `~/.surge/runs/<run_id>/artifacts/`)
 - Worktree management (creating, listing, cleaning git worktrees)
 - Run directory layout
 
@@ -153,8 +153,9 @@ Bridge to ACP (Agent Client Protocol). Handles agent invocation, session lifecyc
 **Contents:**
 - ACP bridge (dedicated thread + LocalSet pattern, similar to Surge)
 - Session pool
-- Tool injection (`report_stage_outcome`, sandbox-filtered MCP tools)
+- Tool injection (`report_stage_outcome`, provider-supported MCP tools)
 - Agent registry (Claude Code, Codex, Gemini executable lookup)
+- Agent launch and agent-native sandbox/session configuration mapping per provider
 - Streaming support for live tool calls
 
 **Dependencies:**
@@ -167,27 +168,11 @@ tokio = { version = "1" }
 
 This crate may be either built fresh or extracted from the author's `surge` project's `surge-acp` crate. The author has noted this could be either approach.
 
-### `sandbox` — OS-level enforcement
+### Sandbox boundary
 
-Per-OS sandboxing implementations.
+surge does **not** ship a dedicated sandbox crate in v0.1. Sandboxing is provided by the selected agent runtime (Claude Code, Codex, Gemini CLI, or a custom ACP agent). The core crate stores launch configuration (`provider-default`, `local`, `cloud`, `sandbox`) plus sandbox intent (`read-only`, `workspace-write`, `workspace+network`, `full-access`, provider-specific options), and the ACP crate maps those settings to provider-supported session flags or permission flows.
 
-**Contents:**
-- Trait `Sandbox` with `apply_to_command(...)`, `check_path(...)`, etc.
-- Linux impl: Landlock (via `landlock` crate), nsjail wrapper
-- macOS impl: sandbox-exec wrapper
-- Windows impl: AppContainer + Job Objects
-- Path checking (always-deny patterns)
-- Network allowlist enforcement
-
-**Dependencies:**
-```toml
-[dependencies]
-core = { path = "../core" }
-landlock = { version = "0.4", optional = true }    # Linux only
-
-[target.'cfg(target_os = "linux")'.dependencies]
-landlock = "0.4"
-```
+The engine records launch settings, sandbox settings, and approval/elevation events, but it does not implement Landlock, AppContainer, `sandbox-exec`, `nsjail`, DNS interception, or filesystem policy enforcement itself.
 
 ### `telegram` — bot service
 
@@ -318,20 +303,20 @@ strip = false
 ## Binary outputs
 
 Built binaries (debug or release):
-- `vibe` — CLI (the main binary users invoke)
-- `vibe-editor` — editor GUI
-- `vibe-runtime` — runtime GUI
-- `vibe-tg` — Telegram bot service (daemon)
+- `surge` — CLI (the main binary users invoke)
+- `surge-editor` — editor GUI
+- `surge-runtime` — runtime GUI
+- `surge-tg` — Telegram bot service (daemon)
 
-CLI can spawn the others when needed (e.g., `vibe replay` opens `vibe-runtime`).
+CLI can spawn the others when needed (e.g., `surge replay` opens `surge-runtime`).
 
 ## Dependency rules
 
 Strict layering enforced via Cargo.toml:
 
 - `core` depends on nothing (in our codebase)
-- `storage`, `acp`, `sandbox` depend on `core`
-- `engine` depends on `core`, `storage`, `acp`, `sandbox`
+- `storage`, `acp` depend on `core`
+- `engine` depends on `core`, `storage`, `acp`
 - `telegram` depends on `core`, `storage`
 - `editor` depends on `core`, `storage`
 - `runtime-ui` depends on `core`, `storage`, `engine`
@@ -356,9 +341,7 @@ strategy:
 All crates must build on all OS × stable. Nightly informational only.
 
 Skipped per OS:
-- Linux Landlock support: only ubuntu (others use no-op sandbox)
-- macOS sandbox-exec: only macOS
-- Windows Job Objects: only Windows
+- Provider availability differs by OS. CI uses mock ACP agents for sandbox/permission behavior and runs provider-specific smoke tests only where the provider binary is installed.
 
 ## Dependency philosophy
 
@@ -381,7 +364,6 @@ members = [
     "crates/engine",
     "crates/storage",
     "crates/acp",
-    "crates/sandbox",
     "crates/telegram",
     "crates/editor",
     "crates/runtime-ui",
@@ -395,7 +377,7 @@ edition = "2021"
 rust-version = "1.75"
 authors = ["..."]
 license = "MIT OR Apache-2.0"
-repository = "https://github.com/vanyastaff/vibe-flow"
+repository = "https://github.com/vanyastaff/surge"
 
 [workspace.dependencies]
 serde = { version = "1", features = ["derive"] }

--- a/docs/revision/architecture/02-data-model.md
+++ b/docs/revision/architecture/02-data-model.md
@@ -157,7 +157,9 @@ pub enum ExceededAction {
 ```rust
 pub struct AgentConfig {
     pub profile: ProfileRef,
+    pub agent: Option<String>, // named service from agents.yml
     pub prompt_overrides: Option<PromptOverride>,
+    pub launch_override: Option<AgentLaunchConfig>,
     pub tool_overrides: Option<ToolOverride>,
     pub sandbox_override: Option<SandboxConfig>,
     pub approvals_override: Option<ApprovalConfig>,
@@ -242,7 +244,13 @@ pub enum EventPayload {
     // Stage execution
     StageEntered { node: NodeId, attempt: u32 },
     StageInputsResolved { node: NodeId, bindings: HashMap<String, ArtifactId> },
-    SessionOpened { node: NodeId, session: SessionId, agent: String },
+    SessionOpened {
+        node: NodeId,
+        session: SessionId,
+        agent: String,
+        launch_mode: String,
+        sandbox_mode: String,
+    },
     ToolCalled { session: SessionId, tool: String, args_redacted: Value },
     ToolResultReceived { session: SessionId, success: bool, result_hash: String },
     ArtifactProduced { node: NodeId, artifact_id: ArtifactId, path: PathBuf },
@@ -288,6 +296,8 @@ pub enum BootstrapDecision {
     Reject,
 }
 ```
+
+`launch_override` is per-node by design. A graph can run different stages on different providers or execution targets while preserving deterministic routing through explicit graph edges.
 
 ## TOML schemas (user-facing files)
 
@@ -338,6 +348,15 @@ is_terminal = false
 
 # ... more nodes ...
 
+[[nodes]]
+id = "review_1"
+kind = "agent"
+position = { x = 700.0, y = 100.0 }
+
+[nodes.config]
+profile = "reviewer@1.0"
+agent = "codex-review"                # named agent from agents.yml
+
 # === Edges ===
 
 [[edges]]
@@ -360,7 +379,7 @@ kind = "escalate"
 
 ### Profile TOML
 
-See RFC-0005 for full schema. Stored at `~/.vibe/profiles/<id>-<version>.toml`.
+See RFC-0005 for full schema. Stored at `~/.surge/profiles/<id>-<version>.toml`.
 
 ### Template TOML (`template.toml`)
 
@@ -385,9 +404,66 @@ expected_complexity = "medium"
 # The actual flow.toml is in ./pipeline.toml in the same directory
 ```
 
+### Agent Compose (`agents.yml`)
+
+`agents.yml` is the friendly, LLM-readable configuration layer. It is intentionally shaped like a small `docker-compose.yml`: named agent services, shared defaults, and role routing. Humans and LLMs should edit this file; generated `flow.toml` can then reference stable agent names instead of repeating provider-specific flags.
+
+Locations, in precedence order:
+
+1. `<project>/.surge/agents.yml`
+2. `~/.surge/agents.yml`
+3. built-in defaults
+
+Example:
+
+```yaml
+version: 1
+
+agents:
+  claude-writer:
+    provider: claude-code
+    launch:
+      mode: local
+      profile: default
+    sandbox:
+      mode: workspace-write
+    approvals:
+      policy: on-request
+
+  codex-review:
+    provider: codex
+    launch:
+      mode: sandbox
+      profile: strict-review
+    sandbox:
+      mode: read-only
+
+  gemini-verify:
+    provider: gemini
+    launch:
+      mode: local
+    sandbox:
+      mode: workspace-write
+
+roles:
+  implementer: claude-writer
+  reviewer: codex-review
+  verifier: gemini-verify
+
+defaults:
+  agent: claude-writer
+```
+
+Resolution:
+
+- `nodes.config.agent = "codex-review"` selects a named agent from `agents.yml`.
+- `nodes.config.launch_override` can still override one node for power users.
+- Profile `[launch]` defaults are used when neither `agent` nor role routing selects a named agent.
+- `surge doctor` validates that every named agent maps to an installed provider and supported launch mode.
+
 ### Run config (per-run runtime config)
 
-Stored at `~/.vibe/runs/<run_id>/config.toml`:
+Stored at `~/.surge/runs/<run_id>/config.toml`:
 
 ```toml
 [run]
@@ -397,9 +473,14 @@ created_at = "2026-05-01T14:28:00Z"
 pipeline_template = "rust-crate-tdd@1.0"
 
 [policy]
+launch_default = "local"
 sandbox_default = "workspace+network"
 approval_default = "on-request"
 auto_pr = true
+
+[agents]
+compose_file = "/home/user/projects/json5-parser/.surge/agents.yml"
+default_agent = "claude-writer"
 
 [telegram]
 chat_id = 123456789
@@ -408,7 +489,7 @@ muted = false
 
 ## SQLite schema
 
-Database file: `~/.vibe/db/vibe.sqlite`. Per-run databases also in `~/.vibe/runs/<run_id>/events.sqlite`.
+Database file: `~/.surge/db/surge.sqlite`. Per-run databases also in `~/.surge/runs/<run_id>/events.sqlite`.
 
 ### Main database (registry)
 
@@ -468,7 +549,7 @@ CREATE TABLE user_config (
 
 ### Per-run database (event log)
 
-Each run has its own SQLite file: `~/.vibe/runs/<run_id>/events.sqlite`. This isolates large event logs and allows individual runs to be archived/exported atomically.
+Each run has its own SQLite file: `~/.surge/runs/<run_id>/events.sqlite`. This isolates large event logs and allows individual runs to be archived/exported atomically.
 
 ```sql
 -- Append-only event log
@@ -583,15 +664,16 @@ Each migration is a numbered SQL file in `crates/storage/migrations/`:
 ## Filesystem layout
 
 ```
-~/.vibe/
+~/.surge/
 ├── config.toml                        (user config)
+├── agents.yml                         (global compose-like agent routing)
 ├── secrets.toml                       (mode 0600: bot tokens, etc.)
 ├── trust.toml
 ├── ui-state.toml                      (last-opened file, window positions)
 ├── state.toml                         (runtime state: current project, etc.)
 │
 ├── db/
-│   └── vibe.sqlite                    (registry DB)
+│   └── surge.sqlite                    (registry DB)
 │
 ├── runs/
 │   └── <run_id>/
@@ -623,7 +705,7 @@ Each migration is a numbered SQL file in `crates/storage/migrations/`:
 │   └── generic-tdd/
 │
 ├── AGENTS.md                          (global rules)
-├── global-deny.toml                   (always-protected paths)
+├── global-deny.toml                   (protected-path warnings / provider deny hints)
 └── logs/
     ├── engine.log
     ├── telegram.log
@@ -637,14 +719,15 @@ Each migration is a numbered SQL file in `crates/storage/migrations/`:
 ├── ... (their code)
 ├── AGENTS.md                          (project rules, optional)
 ├── flow.toml                          (saved pipeline, optional, generated/edited)
-└── .vibe/
+└── .surge/
+    ├── agents.yml                     (project compose-like agent routing, optional)
     ├── hooks/                         (project-local hooks)
     │   ├── check_guard.sh
     │   └── ...
-    └── runs/                          (symlinks to ~/.vibe/runs/<id> for runs in this project)
+    └── runs/                          (symlinks to ~/.surge/runs/<id> for runs in this project)
 ```
 
-The `.vibe/` directory in the project is small — just hooks and convenience symlinks. Real run data is in `~/.vibe/runs/`.
+The `.surge/` directory in the project is small — agent routing, hooks, and convenience symlinks. Real run data is in `~/.surge/runs/`.
 
 ## Acceptance criteria
 
@@ -655,6 +738,6 @@ The data model is correctly implemented when:
 3. Round-trip: serialize all `EventPayload` variants to bincode → deserialize → equality.
 4. SQLite schema can be created from migration files on a fresh DB.
 5. Triggers correctly maintain materialized views: insert 100 events of various types, query views, verify they match expected aggregates.
-6. Filesystem layout: starting from empty `~/.vibe/`, completing a full run produces all expected directories and files.
+6. Filesystem layout: starting from empty `~/.surge/`, completing a full run produces all expected directories and files.
 7. Foreign-key-like consistency: every `node_id` in events references a node in the materialized graph (caught by validation).
 8. Schema versioning: an old-version event log can be upgraded to current via migration chain.

--- a/docs/revision/architecture/03-engine.md
+++ b/docs/revision/architecture/03-engine.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The engine is the heart of vibe-flow. It consumes events, advances run state, executes nodes, and produces new events. This document specifies the engine's internal structure, the executor's main loop, scheduling, and error recovery.
+The engine is the heart of surge. It consumes events, advances run state, executes nodes, and produces new events. This document specifies the engine's internal structure, the executor's main loop, scheduling, and error recovery.
 
 This is implementation-level detail building on RFC-0002 (execution model).
 
@@ -46,7 +46,6 @@ pub struct Executor {
     run_id: RunId,
     storage: Arc<Storage>,
     acp_bridge: Arc<AcpBridge>,
-    sandbox: Arc<dyn Sandbox>,
     state: RunState,
     config: RunConfig,
 }
@@ -110,12 +109,14 @@ async fn execute_agent_stage(&mut self, node: &Node) -> Result<()> {
     // 2. Build agent invocation context
     let profile = self.load_profile(&cfg.profile).await?;
     let prompt = self.render_prompt(&profile, &bindings, cfg.prompt_overrides.as_ref())?;
-    let sandbox_cfg = self.compute_sandbox(&profile, cfg.sandbox_override.as_ref())?;
+    let launch_cfg = self.compute_agent_launch_config(&profile, cfg.launch_override.as_ref())?;
+    let sandbox_cfg = self.compute_agent_sandbox_intent(&profile, cfg.sandbox_override.as_ref())?;
     let tools = self.compute_tools(&profile, cfg.tool_overrides.as_ref(), &sandbox_cfg)?;
     
     // 3. Open ACP session
     let session = self.acp_bridge.open_session(SessionConfig {
-        agent: profile.runtime.recommended_model.clone(),
+        launch: launch_cfg.clone(),
+        model: profile.runtime.recommended_model.clone(),
         system_prompt: prompt,
         tools: tools.clone(),
         sandbox: sandbox_cfg.clone(),
@@ -125,7 +126,9 @@ async fn execute_agent_stage(&mut self, node: &Node) -> Result<()> {
     self.write_event(EventPayload::SessionOpened {
         node: node.id.clone(),
         session: session.id.clone(),
-        agent: profile.runtime.recommended_model.clone(),
+        agent: launch_cfg.provider.clone(),
+        launch_mode: launch_cfg.mode.clone(),
+        sandbox_mode: sandbox_cfg.mode.clone(),
     }).await?;
     
     // 4. Run pre_tool_use hooks (none yet, will be triggered per-tool by ACP bridge)
@@ -518,7 +521,7 @@ pub async fn spawn_daemon(run_id: RunId, config: RunConfig) -> Result<u32> {
 
 ## Crash recovery
 
-On engine startup (called from `vibe doctor` or `vibe attach`):
+On engine startup (called from `surge doctor` or `surge attach`):
 
 ```rust
 pub async fn recover_runs(storage: &Storage) -> Result<Vec<RecoveryAction>> {
@@ -681,7 +684,9 @@ pub enum EngineError {
     StageTimeout { node: NodeId },
     HookExhaustion,
     SessionFailed(AcpError),
-    SandboxViolation { capability: String },
+    ProviderLaunchUnsupported { provider: String, requested: String },
+    ProviderSandboxUnsupported { provider: String, requested: String },
+    PermissionDenied { capability: String },
     MaxTraversalsExceeded,
     ReplanRequested,
     

--- a/docs/revision/architecture/04-acp-integration.md
+++ b/docs/revision/architecture/04-acp-integration.md
@@ -2,14 +2,14 @@
 
 ## Overview
 
-ACP (Agent Client Protocol) is the standard interface for invoking AI coding agents. vibe-flow uses ACP to remain agent-agnostic — the same engine can drive Claude Code, Codex CLI, Gemini CLI, or any future ACP-compatible agent.
+ACP (Agent Client Protocol) is the standard interface for invoking AI coding agents. surge uses ACP to remain agent-agnostic — the same engine can drive Claude Code, Codex CLI, Gemini CLI, or any future ACP-compatible agent.
 
 This document specifies the ACP bridge architecture, session lifecycle, tool injection mechanism, and the `report_stage_outcome` contract.
 
 ## Why agent-agnostic via ACP
 
 Alternatives:
-- **Direct Anthropic SDK calls**: locks vibe-flow to Anthropic. No way for users to use Codex or Gemini.
+- **Direct Anthropic SDK calls**: locks surge to Anthropic. No way for users to use Codex or Gemini.
 - **Custom protocol per agent**: explosion of integration code, brittle to upstream changes.
 - **ACP**: industry standard (zed, sourcegraph, etc. participate). One integration, many agents.
 
@@ -19,7 +19,7 @@ The cost is some indirection, but it's the right architectural decision long-ter
 
 The ACP SDK (Rust crate) has `!Send` futures in places. Combined with our preference for async/Tokio multi-threaded runtime, this requires the **bridge pattern**: a dedicated OS thread running a single-threaded Tokio runtime with `LocalSet`, communicating with the rest of the engine via channels.
 
-This pattern is what the author has used in `surge-acp` — we either reuse it or reimplement it in vibe-flow's `acp` crate.
+This pattern is what the author has used in `surge-acp` — we either reuse it or reimplement it in surge's `acp` crate.
 
 ```
 ┌─────────────────────────────────────────────────────┐
@@ -57,8 +57,32 @@ pub enum BridgeEvent {
     AgentMessage { session: SessionId, content: String },
     ToolCall { session: SessionId, tool: String, args: Value, call_id: String },
     ToolResult { session: SessionId, call_id: String, result: ToolResult },
+    PermissionRequest { session: SessionId, capability: String, reason: String },
     SessionEnded { session: SessionId, reason: SessionEndReason },
     Error { session: Option<SessionId>, error: String },
+}
+
+pub struct SessionConfig {
+    pub launch: AgentLaunchConfig,
+    pub model: String,
+    pub system_prompt: String,
+    pub tools: Vec<ToolDefinition>,
+    pub sandbox: SandboxConfig,
+    pub run_dir: PathBuf,
+}
+
+pub struct AgentLaunchConfig {
+    pub provider: AgentProvider,
+    pub mode: LaunchMode,
+    pub config_profile: Option<String>,
+    pub extra_args: Vec<String>,
+}
+
+pub enum LaunchMode {
+    ProviderDefault,
+    Local,
+    Cloud,
+    Sandbox,
 }
 
 impl AcpBridge {
@@ -130,9 +154,9 @@ async fn bridge_loop(
 
 1. Engine constructs `SessionConfig` for the agent stage.
 2. Engine calls `AcpBridge::open_session(config)`.
-3. Bridge spawns ACP-specific subprocess (e.g., `claude-code --acp` or `codex --acp`).
+3. Bridge starts the provider using `config.launch`: local process, provider cloud mode, provider sandbox mode, or provider default.
 4. Bridge negotiates ACP handshake (protocol version, capabilities).
-5. Bridge declares **injected tools** including `report_stage_outcome` and sandbox-filtered MCP servers.
+5. Bridge declares **injected tools** including `report_stage_outcome` and provider-supported MCP servers.
 6. Returns `SessionId` to engine.
 7. Engine writes `SessionOpened` event.
 
@@ -152,8 +176,9 @@ acp_bridge.send_message(session_id, initial_message).await?;
 The bridge emits `BridgeEvent`s as the agent works:
 
 - `AgentMessage` — text the agent produced (informational, logged but doesn't drive routing)
-- `ToolCall` — agent invoked a tool. Engine validates against sandbox + records as event
+- `ToolCall` — agent invoked a tool exposed through ACP/MCP. Engine records the event and may run hooks when the provider exposes the call before execution.
 - `ToolResult` — tool returned. Engine records as event
+- `PermissionRequest` — provider-native request for sandbox/permission elevation, when supported
 
 ### Tool call flow
 
@@ -177,26 +202,16 @@ match event {
             return Ok(());
         }
         
-        // 3. Validate against sandbox
-        let allowed = engine.sandbox.check_tool_call(&tool, &args)?;
-        if !allowed {
-            // Trigger sandbox elevation flow
-            let elevated = engine.request_sandbox_elevation(&tool, &args).await?;
-            if !elevated {
-                acp_bridge.send_tool_result(session, call_id, ToolResult::Error("Sandbox denied")).await?;
-                return Ok(());
-            }
-        }
-        
-        // 4. Special tool: report_stage_outcome
+        // 3. Special tool: report_stage_outcome
         if tool == "report_stage_outcome" {
             return engine.handle_outcome_report(args).await;
         }
         
-        // 5. Forward to actual tool implementation (MCP server)
+        // 4. Forward to actual tool implementation (MCP server) if surge owns it.
+        // Provider-native tools are executed by the provider runtime under its own sandbox.
         let result = engine.execute_tool(&tool, &args).await?;
         
-        // 6. Record ToolResultReceived
+        // 5. Record ToolResultReceived
         engine.write_event(EventPayload::ToolResultReceived {
             session: session.clone(),
             success: result.is_success(),
@@ -232,7 +247,7 @@ If the agent process dies unexpectedly:
 
 ## Tool injection
 
-vibe-flow injects two categories of tools into every ACP session:
+surge injects two categories of tools into every ACP session:
 
 ### 1. Engine-provided tools
 
@@ -290,9 +305,9 @@ Allows agent to escalate mid-stage if it hits genuine ambiguity.
 
 When invoked, engine triggers a HumanGate-like flow (Telegram card with the question), waits for response, returns it as tool result.
 
-### 2. Sandbox-filtered MCP tools
+### 2. Provider-aware MCP tools
 
-The engine determines which MCP servers and tools are accessible per the node's sandbox + tools config, and exposes only those:
+The engine determines which MCP servers and tools should be offered based on node/profile tool config and provider capability metadata. Sandboxing remains provider-native; surge does not promise OS-level enforcement for tools executed by the provider runtime.
 
 ```rust
 fn compute_available_tools(profile: &Profile, sandbox: &SandboxConfig) -> Vec<ToolDefinition> {
@@ -308,7 +323,7 @@ fn compute_available_tools(profile: &Profile, sandbox: &SandboxConfig) -> Vec<To
     for mcp_id in &profile.tools.default_mcp {
         let mcp_tools = mcp_registry.tools_for(mcp_id)?;
         for tool in mcp_tools {
-            if sandbox.allows_tool(&tool, mcp_id) {
+            if provider_capabilities.can_expose_tool_under_intent(&tool, mcp_id, sandbox) {
                 tools.push(tool);
             }
         }
@@ -317,53 +332,80 @@ fn compute_available_tools(profile: &Profile, sandbox: &SandboxConfig) -> Vec<To
     // Skill-based tools (if any)
     for skill_id in &profile.tools.default_skills {
         let skill = skills_registry.get(skill_id)?;
-        tools.extend(skill.tools_under_sandbox(sandbox));
+        tools.extend(skill.tools_for_provider_intent(sandbox));
     }
     
     tools
 }
 ```
 
-The agent literally doesn't see tools it can't use. This is the primary sandbox enforcement layer.
+The agent should not see tools that are outside the requested intent when the provider/tool surface allows filtering. This is a usability and policy layer, not a replacement for provider-native sandboxing.
 
-## ACP variants
+## ACP variants and launch modes
 
 Different agents have slightly different ACP implementations. The bridge handles per-agent quirks:
 
 ```rust
-pub enum AgentKind {
+pub enum AgentProvider {
     ClaudeCode,
     Codex,
     GeminiCli,
     Custom { binary: PathBuf, args: Vec<String> },
 }
 
-impl AgentKind {
-    fn invocation(&self) -> Command {
-        match self {
-            Self::ClaudeCode => Command::new("claude-code").arg("--acp"),
-            Self::Codex => Command::new("codex").arg("acp"),
-            Self::GeminiCli => Command::new("gemini").arg("--acp"),
+impl AgentProvider {
+    fn invocation(&self, launch: &AgentLaunchConfig) -> Command {
+        let mut cmd = match self {
+            Self::ClaudeCode => Command::new("claude-code"),
+            Self::Codex => Command::new("codex"),
+            Self::GeminiCli => Command::new("gemini"),
             Self::Custom { binary, args } => {
                 let mut cmd = Command::new(binary);
                 cmd.args(args);
-                cmd
+                return cmd;
             }
-        }
+        };
+        apply_provider_acp_args(&mut cmd, self);
+        apply_provider_launch_mode(&mut cmd, self, launch.mode);
+        cmd.args(&launch.extra_args);
+        cmd
     }
 }
 ```
 
-Discovery: engine checks `PATH` for known agent binaries, lists available ones at `vibe doctor`. User configures preferences in `~/.vibe/config.toml`:
+Discovery: engine checks `PATH` and provider config for known agent launch modes, lists available ones at `surge doctor`. User configures agent services and role routing in `agents.yml`:
 
-```toml
-[agents]
-default = "claude-code"
+```yaml
+version: 1
 
-[agents.preferred_per_role]
-implementer = "claude-code"
-reviewer = "codex"
+agents:
+  claude-writer:
+    provider: claude-code
+    launch: { mode: local, profile: default }
+    sandbox: { mode: workspace-write }
+
+  codex-review:
+    provider: codex
+    launch: { mode: sandbox, profile: strict-review }
+    sandbox: { mode: read-only }
+
+roles:
+  implementer: claude-writer
+  reviewer: codex-review
+
+defaults:
+  agent: claude-writer
 ```
+
+The selected provider is resolved independently for every Agent node:
+
+1. Node `agent = "name"` from `flow.toml`, resolved through project/global `agents.yml`.
+2. Node `launch_override`, if present.
+3. Role route in `agents.yml` based on the node profile's role ID.
+4. Profile `[launch]` defaults.
+5. Global default agent and launch mode.
+
+This allows a flow like `Spec Author → Implementer(Claude local) → Reviewer(Codex sandbox) → Verifier(Gemini local) → PR Composer` without special multi-agent coordination logic.
 
 ## Streaming
 
@@ -398,7 +440,8 @@ Resource limits: configurable max concurrent sessions (default: 4). Beyond this,
 
 ```rust
 pub enum AcpError {
-    AgentNotFound { kind: AgentKind },
+    AgentNotFound { provider: AgentProvider },
+    LaunchModeUnsupported { provider: AgentProvider, mode: LaunchMode },
     HandshakeFailed { reason: String },
     SessionTimeout { duration: Duration },
     AgentCrashed { exit_code: Option<i32>, stderr: String },
@@ -409,6 +452,7 @@ pub enum AcpError {
 
 Each maps to engine-level handling:
 - `AgentNotFound` — fail run start, instruct user to install agent
+- `LaunchModeUnsupported` — fail validation/start with a provider-specific message
 - `HandshakeFailed` — fail stage, check if agent is supported version
 - `SessionTimeout` — fail stage with timeout reason, allow retry
 - `AgentCrashed` — fail stage, retry available

--- a/docs/revision/architecture/05-storage.md
+++ b/docs/revision/architecture/05-storage.md
@@ -5,7 +5,7 @@
 Storage layer responsibilities:
 - Persist event logs (per-run SQLite databases)
 - Maintain registry database (cross-run queries, profiles, templates)
-- Manage artifacts on filesystem (under `~/.vibe/runs/<run_id>/artifacts/`)
+- Manage artifacts on filesystem (under `~/.surge/runs/<run_id>/artifacts/`)
 - Manage git worktrees (one per run)
 - Support concurrent reads (UI tailing live runs) with single writer (daemon)
 
@@ -15,10 +15,10 @@ This document specifies the storage crate's API, persistence patterns, and workt
 
 ```rust
 pub struct Storage {
-    registry_pool: SqlitePool,           // ~/.vibe/db/vibe.sqlite
-    runs_dir: PathBuf,                   // ~/.vibe/runs/
-    profiles_dir: PathBuf,               // ~/.vibe/profiles/
-    templates_dir: PathBuf,              // ~/.vibe/templates/
+    registry_pool: SqlitePool,           // ~/.surge/db/surge.sqlite
+    runs_dir: PathBuf,                   // ~/.surge/runs/
+    profiles_dir: PathBuf,               // ~/.surge/profiles/
+    templates_dir: PathBuf,              // ~/.surge/templates/
 }
 
 impl Storage {
@@ -119,7 +119,7 @@ Event payloads are stored as binary BLOB using `bincode`. Reasons:
 - Compact (smaller storage)
 - Type-safe via Rust types
 
-For human inspection (debugging, `vibe show event`), payloads are deserialized and pretty-printed as JSON.
+For human inspection (debugging, `surge show event`), payloads are deserialized and pretty-printed as JSON.
 
 ```rust
 pub fn payload_to_blob(payload: &EventPayload) -> Result<Vec<u8>> {
@@ -263,7 +263,7 @@ pub async fn rebuild_views(&self) -> Result<()> {
 }
 ```
 
-This is exposed via `vibe doctor --rebuild-views <run_id>`.
+This is exposed via `surge doctor --rebuild-views <run_id>`.
 
 ## Artifact storage
 
@@ -272,7 +272,7 @@ Artifacts (description.md, spec.md, source files modified, etc.) are stored on f
 ### Layout
 
 ```
-~/.vibe/runs/<run_id>/artifacts/
+~/.surge/runs/<run_id>/artifacts/
 ├── 01-bootstrap/
 │   ├── description.md
 │   ├── roadmap.md
@@ -333,16 +333,16 @@ Each run gets its own git worktree branch.
 ```rust
 pub struct Worktree {
     pub root: PathBuf,           // path to worktree dir
-    pub branch: String,          // branch name (e.g., "vibe/run-abc123")
+    pub branch: String,          // branch name (e.g., "surge/run-abc123")
     pub source_repo: PathBuf,    // original repo
 }
 
 impl Worktree {
     pub async fn create(source_repo: &Path, run_id: &RunId) -> Result<Self> {
         let short_id = run_id.short();
-        let branch = format!("vibe/run-{}", short_id);
+        let branch = format!("surge/run-{}", short_id);
         let target = source_repo.parent().unwrap()
-            .join(format!(".vibe-worktrees/{}", short_id));
+            .join(format!(".surge-worktrees/{}", short_id));
         
         // git worktree add <target> -b <branch> HEAD
         Command::new("git").args(&["-C", source_repo.to_str().unwrap(),
@@ -377,12 +377,12 @@ impl Worktree {
 
 ### Worktree placement
 
-By default: `<repo_parent>/.vibe-worktrees/<short_id>`. Reasons:
+By default: `<repo_parent>/.surge-worktrees/<short_id>`. Reasons:
 - Outside the source repo, so it's not visible to `git status` of source
 - Sibling to source, so file permissions are typically the same
 - Hidden directory
 
-User can override via `~/.vibe/config.toml`:
+User can override via `~/.surge/config.toml`:
 
 ```toml
 [worktrees]
@@ -396,14 +396,14 @@ After a run terminates:
 - Branch is preserved
 - After `prune_after_days = 30` (configurable), engine offers to clean up
 
-`vibe gc` command runs cleanup explicitly.
+`surge gc` command runs cleanup explicitly.
 
 ## Backups and exports
 
 ### Run export
 
 ```bash
-vibe export <run_id> [--output <file.tar.gz>]
+surge export <run_id> [--output <file.tar.gz>]
 ```
 
 Creates a tar.gz containing:
@@ -415,7 +415,7 @@ Creates a tar.gz containing:
 ### Run import
 
 ```bash
-vibe import <file.tar.gz>
+surge import <file.tar.gz>
 ```
 
 Imports a previously exported run. Useful for:
@@ -426,11 +426,11 @@ Imports a previously exported run. Useful for:
 ### Backup strategy
 
 For backup, recommended approach:
-- `~/.vibe/profiles/`, `~/.vibe/templates/` — user-edited content; back up
-- `~/.vibe/db/vibe.sqlite` — registry; back up
-- `~/.vibe/runs/` — selectively back up specific runs via `vibe export`
+- `~/.surge/profiles/`, `~/.surge/templates/` — user-edited content; back up
+- `~/.surge/db/surge.sqlite` — registry; back up
+- `~/.surge/runs/` — selectively back up specific runs via `surge export`
 
-A `vibe backup` command (future) automates this into a single tarball.
+A `surge backup` command (future) automates this into a single tarball.
 
 ## Performance budgets
 

--- a/docs/revision/components/cli.md
+++ b/docs/revision/components/cli.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The `vibe` CLI is the primary entry point for users. It must be:
+The `surge` CLI is the primary entry point for users. It must be:
 - **Fast** to start (<100ms cold start)
 - **Scriptable** (JSON output, exit codes)
 - **Self-documenting** (`--help` everywhere, examples)
@@ -13,11 +13,11 @@ This document specifies the full CLI surface, command behavior, and output forma
 ## Command structure
 
 ```
-vibe [GLOBAL OPTIONS] <COMMAND> [SUBCOMMAND] [OPTIONS] [ARGS]
+surge [GLOBAL OPTIONS] <COMMAND> [SUBCOMMAND] [OPTIONS] [ARGS]
 ```
 
 Global options (any command):
-- `--config <path>` — alternate config file (default: `~/.vibe/config.toml`)
+- `--config <path>` — alternate config file (default: `~/.surge/config.toml`)
 - `--verbose, -v` — increase logging (repeat for more)
 - `--quiet, -q` — suppress non-essential output
 - `--json` — JSON output format
@@ -26,24 +26,26 @@ Global options (any command):
 
 ## Commands
 
-### `vibe init`
+### `surge init`
 
-Initialize vibe-flow for a project (creates `.vibe/` dir, optionally selects template).
+Initialize surge for a project (creates `.surge/` dir, optionally selects template).
 
 ```
-vibe init [--template <name>] [--dry-run]
+surge init [--template <name>] [--agents-preset <name>] [--dry-run]
 ```
 
 Options:
 - `--template <name>` — use specific template (e.g., `rust-crate-tdd`)
+- `--agents-preset <name>` — create `.surge/agents.yml` from a preset (e.g., `claude-write-codex-review`)
 - `--dry-run` — show what would be created without writing
 
 Behavior:
 1. Detect project type (language, structure)
 2. If `--template` not specified, prompt user (or auto-select if confidence high)
-3. Create `.vibe/` directory in project
-4. Symlink to bundled template's pipeline.toml or copy as starting point
-5. Print success message with next steps
+3. Create `.surge/` directory in project
+4. Create `.surge/agents.yml` with friendly compose-like agent routing
+5. Symlink to bundled template's pipeline.toml or copy as starting point
+6. Print success message with next steps
 
 Exit codes:
 - 0: success
@@ -51,12 +53,12 @@ Exit codes:
 - 2: project not detected
 - 3: template not found
 
-### `vibe run`
+### `surge run`
 
 Start a new run.
 
 ```
-vibe run [OPTIONS] [DESCRIPTION]
+surge run [OPTIONS] [DESCRIPTION]
 ```
 
 Arguments:
@@ -74,20 +76,20 @@ Options:
 
 Examples:
 ```
-vibe run "add CLI flag for verbose mode"
-vibe run --template rust-crate-tdd "build JSON5 parser"
-vibe run --auto "fix typo in README"
-vibe run --from-file task.md
+surge run "add CLI flag for verbose mode"
+surge run --template rust-crate-tdd "build JSON5 parser"
+surge run --auto "fix typo in README"
+surge run --from-file task.md
 ```
 
 Output (default):
 ```
 ✓ Run #0083 started (id: 0190a4b2-...)
   Pipeline: rust-crate-tdd@1.0
-  Worktree: /path/to/.vibe-worktrees/abc123
+  Worktree: /path/to/.surge-worktrees/abc123
   
 Run is now executing. To follow progress:
-  vibe attach 0083
+  surge attach 0083
   
 You'll be pinged on Telegram when approval is needed.
 ```
@@ -99,17 +101,17 @@ Output (--json):
   "short_id": "0083",
   "status": "started",
   "pipeline": "rust-crate-tdd@1.0",
-  "worktree": "/path/to/.vibe-worktrees/abc123",
+  "worktree": "/path/to/.surge-worktrees/abc123",
   "daemon_pid": 12345
 }
 ```
 
-### `vibe list`
+### `surge list`
 
 List runs (active and recent).
 
 ```
-vibe list [OPTIONS]
+surge list [OPTIONS]
 ```
 
 Options:
@@ -127,12 +129,12 @@ ID    STATUS    PROJECT             DESCRIPTION                ELAPSED   COST
 0080  ✓ done   myproject           Update deps                3m 11s    $0.42
 ```
 
-### `vibe status`
+### `surge status`
 
 Show current state of a run.
 
 ```
-vibe status <RUN_ID>
+surge status <RUN_ID>
 ```
 
 Run ID can be:
@@ -147,7 +149,7 @@ Run #0083 · sample-app
 Status:     ⚡ running
 Started:    14:28:42 (24m ago)
 Pipeline:   rust-crate-tdd@1.0
-Worktree:   .vibe-worktrees/abc123 (branch: vibe/run-abc123)
+Worktree:   .surge-worktrees/abc123 (branch: surge/run-abc123)
 
 Progress: ████████████████░░░░░░░ 4 / 7 stages
 
@@ -159,12 +161,12 @@ Pending approvals: 0
 Total cost: $3.18
 ```
 
-### `vibe attach`
+### `surge attach`
 
 Tail the live output of a running run.
 
 ```
-vibe attach <RUN_ID> [OPTIONS]
+surge attach <RUN_ID> [OPTIONS]
 ```
 
 Options:
@@ -173,12 +175,12 @@ Options:
 
 Output is streaming; Ctrl+C detaches without affecting the run.
 
-### `vibe cancel`
+### `surge cancel`
 
 Abort a running run.
 
 ```
-vibe cancel <RUN_ID> [--force]
+surge cancel <RUN_ID> [--force]
 ```
 
 Behavior:
@@ -186,26 +188,26 @@ Behavior:
 - With `--force`: immediate cancel
 - Sends SIGTERM to daemon, daemon writes `RunAborted` event, exits
 
-### `vibe replay`
+### `surge replay`
 
 Open replay UI for a finished run.
 
 ```
-vibe replay <RUN_ID> [OPTIONS]
+surge replay <RUN_ID> [OPTIONS]
 ```
 
 Options:
 - `--at <seq>` — open at specific event seq
 - `--no-ui` — print event log to stdout instead
 
-Default: spawns `vibe-runtime` GUI in replay mode.
+Default: spawns `surge-runtime` GUI in replay mode.
 
-### `vibe fork`
+### `surge fork`
 
 Create a new run forked from an existing run at a specific point.
 
 ```
-vibe fork <RUN_ID> --at <SEQ> [OPTIONS]
+surge fork <RUN_ID> --at <SEQ> [OPTIONS]
 ```
 
 Options:
@@ -219,14 +221,14 @@ Behavior:
 - Optional edits applied to nodes that haven't yet executed
 - New run starts execution from fork point
 
-### `vibe profile`
+### `surge profile`
 
 Manage profile registry.
 
-#### `vibe profile list`
+#### `surge profile list`
 
 ```
-vibe profile list [--category <cat>]
+surge profile list [--category <cat>]
 ```
 
 Output:
@@ -238,52 +240,52 @@ spec-author              1.0      agents    Writes specs from descriptions
 ...
 ```
 
-#### `vibe profile show <ID>`
+#### `surge profile show <ID>`
 
 ```
-vibe profile show implementer@1.0
+surge profile show implementer@1.0
 ```
 
 Output: full profile contents (TOML), validated.
 
-#### `vibe profile install <SOURCE>`
+#### `surge profile install <SOURCE>`
 
 ```
-vibe profile install ./my-profile.toml
-vibe profile install https://example.com/profile.toml
-vibe profile install gh:user/repo/path/profile.toml
+surge profile install ./my-profile.toml
+surge profile install https://example.com/profile.toml
+surge profile install gh:user/repo/path/profile.toml
 ```
 
 Behavior:
 - Validates the profile
 - Asks user to confirm trust (untrusted sources)
-- Installs to `~/.vibe/profiles/`
+- Installs to `~/.surge/profiles/`
 
-#### `vibe profile uninstall <ID>[@VERSION]`
+#### `surge profile uninstall <ID>[@VERSION]`
 
 ```
-vibe profile uninstall implementer@1.0
+surge profile uninstall implementer@1.0
 ```
 
-#### `vibe profile validate <PATH>`
+#### `surge profile validate <PATH>`
 
 Validates a profile file without installing.
 
-#### `vibe profile diff <ID1> <ID2>`
+#### `surge profile diff <ID1> <ID2>`
 
 Shows differences between two profile versions.
 
-### `vibe template`
+### `surge template`
 
 Manage template registry.
 
-Same subcommands as `vibe profile`: `list`, `show`, `install`, `uninstall`, `validate`.
+Same subcommands as `surge profile`: `list`, `show`, `install`, `uninstall`, `validate`.
 
-### `vibe telegram`
+### `surge telegram`
 
 Telegram bot management.
 
-#### `vibe telegram setup`
+#### `surge telegram setup`
 
 Interactive setup wizard:
 1. Asks for bot token (or reads from env)
@@ -292,25 +294,26 @@ Interactive setup wizard:
 4. Polls for user to tap "Start"
 5. Stores chat_id, exits
 
-#### `vibe telegram test`
+#### `surge telegram test`
 
 Sends a test message to the configured chat.
 
-#### `vibe telegram unbind`
+#### `surge telegram unbind`
 
 Removes the chat_id binding (next setup re-registers).
 
-### `vibe doctor`
+### `surge doctor`
 
 Diagnose common issues.
 
 ```
-vibe doctor [--fix]
+surge doctor [--fix]
 ```
 
 Checks:
 - Git installed and accessible
 - ACP-compatible agents available (claude-code, codex, gemini)
+- `agents.yml` parses, all named agents resolve, role routes are valid
 - Telegram bot configured
 - Storage permissions OK
 - No orphaned daemon processes
@@ -318,14 +321,16 @@ Checks:
 
 Output:
 ```
-Checking vibe-flow setup...
+Checking surge setup...
 
-✓ Storage:        ~/.vibe/ (7 runs, 2.4GB)
+✓ Storage:        ~/.surge/ (7 runs, 2.4GB)
 ✓ Agents:         claude-code (1.5.2), codex (0.8.1)
+✓ Agent config:   .surge/agents.yml (3 agents, 4 role routes)
+✓ Launch modes:   codex local/cloud/sandbox, claude-code local
 ✓ Telegram bot:   bound to chat 123456789
-✓ Sandbox:        Landlock available
+✓ Sandbox:        provider-native (codex: workspace-write + approvals)
 ⚠ Worktrees:     2 orphaned worktrees from completed runs (8 days old)
-                  Run `vibe gc` to clean up.
+                  Run `surge gc` to clean up.
 
 Found 1 warning. Use --fix to attempt automatic fixes.
 ```
@@ -335,12 +340,12 @@ With `--fix`:
 - Rebuilds materialized views if corrupted
 - Restarts telegram service if not running
 
-### `vibe gc`
+### `surge gc`
 
 Garbage collect old runs and worktrees.
 
 ```
-vibe gc [--older-than <duration>] [--dry-run]
+surge gc [--older-than <duration>] [--dry-run]
 ```
 
 Options:
@@ -354,7 +359,7 @@ Behavior:
 
 ## Daemon mode
 
-When `vibe run` is invoked, it spawns a detached daemon and returns. The CLI's role is:
+When `surge run` is invoked, it spawns a detached daemon and returns. The CLI's role is:
 
 1. Parse arguments
 2. Validate config
@@ -362,9 +367,9 @@ When `vibe run` is invoked, it spawns a detached daemon and returns. The CLI's r
 4. Spawn daemon subprocess (detached)
 5. Return run ID to user
 
-The daemon is a separate process running `vibe-engine` (the engine binary or `vibe --daemon` mode). It owns the run from start to terminal.
+The daemon is a separate process running `surge-engine` (the engine binary or `surge --daemon` mode). It owns the run from start to terminal.
 
-CLI commands like `vibe attach`, `vibe status`, `vibe cancel` communicate with the daemon via the event log (read pending state, append cancel events).
+CLI commands like `surge attach`, `surge status`, `surge cancel` communicate with the daemon via the event log (read pending state, append cancel events).
 
 ## Output formatting
 
@@ -391,9 +396,13 @@ For long-running operations (file uploads, etc.), `indicatif` progress bars. Sup
 
 CLI reads config in this priority order (later overrides earlier):
 1. Built-in defaults
-2. `~/.vibe/config.toml`
-3. Environment variables (prefixed `VIBE_*`)
-4. Command-line flags
+2. `~/.surge/config.toml`
+3. `~/.surge/agents.yml`
+4. `<project>/.surge/agents.yml`
+5. Environment variables (prefixed `SURGE_*`)
+6. Command-line flags
+
+`config.toml` stores global app settings. `agents.yml` stores agent launch/routing settings.
 
 Example `config.toml`:
 
@@ -407,25 +416,57 @@ chat_id = 123456789
 mode = "long-poll"
 
 [agents]
-default = "claude-code"
+compose_file = "~/.surge/agents.yml"
 
 [runs]
 max_concurrent = 4
-auto_attach = false             # whether `vibe run` auto-attaches
+auto_attach = false             # whether `surge run` auto-attaches
 
 [storage]
-home = "~/.vibe"
+home = "~/.surge"
 worktrees_location = "auto"     # or absolute path
 
 [gc]
 auto_gc_after_days = 30
 ```
 
+Example `agents.yml`:
+
+```yaml
+version: 1
+
+agents:
+  claude-writer:
+    provider: claude-code
+    launch:
+      mode: local
+      profile: default
+    sandbox:
+      mode: workspace-write
+
+  codex-review:
+    provider: codex
+    launch:
+      mode: sandbox
+      profile: strict-review
+    sandbox:
+      mode: read-only
+
+roles:
+  implementer: claude-writer
+  reviewer: codex-review
+  verifier: codex-review
+
+defaults:
+  agent: claude-writer
+```
+
 Environment variables:
-- `VIBE_HOME` — alternate vibe-flow home (default `~/.vibe`)
-- `VIBE_TELEGRAM_BOT_TOKEN` — bot token (overrides config)
-- `VIBE_DEFAULT_AGENT` — default agent
-- `VIBE_LOG` — log level (e.g., `vibe=debug`)
+- `SURGE_HOME` — alternate surge home (default `~/.surge`)
+- `SURGE_TELEGRAM_BOT_TOKEN` — bot token (overrides config)
+- `SURGE_DEFAULT_AGENT` — default named agent from `agents.yml`
+- `SURGE_AGENTS_FILE` — alternate `agents.yml`
+- `SURGE_LOG` — log level (e.g., `surge=debug`)
 
 ## Exit codes
 
@@ -454,16 +495,16 @@ Every command supports `--help`. Help text includes:
 - Options (with defaults and types)
 - Examples (at least 2)
 
-`vibe --help` shows top-level commands. `vibe run --help` shows run-specific.
+`surge --help` shows top-level commands. `surge run --help` shows run-specific.
 
 ## Shell completion
 
 Generated via `clap`'s built-in completion support:
 
 ```
-vibe completion bash > /etc/bash_completion.d/vibe
-vibe completion zsh > ~/.zfunc/_vibe
-vibe completion fish > ~/.config/fish/completions/vibe.fish
+surge completion bash > /etc/bash_completion.d/surge
+surge completion zsh > ~/.zfunc/_surge
+surge completion fish > ~/.config/fish/completions/surge.fish
 ```
 
 ## Implementation notes
@@ -481,12 +522,12 @@ The CLI binary should be small and start fast — defer most loading to when com
 The CLI is correctly implemented when:
 
 1. All commands listed work with proper output formatting in text and JSON modes.
-2. `vibe --help` shows all commands; each command's `--help` is informative.
-3. Cold-start time of `vibe --help` is < 100ms on a 2024 laptop.
-4. Daemon mode: `vibe run` returns within 2 seconds, daemon continues independently.
-5. `vibe attach` correctly tails events from a running daemon in real-time.
+2. `surge --help` shows all commands; each command's `--help` is informative.
+3. Cold-start time of `surge --help` is < 100ms on a 2024 laptop.
+4. Daemon mode: `surge run` returns within 2 seconds, daemon continues independently.
+5. `surge attach` correctly tails events from a running daemon in real-time.
 6. Shell completion works for all commands and major options.
 7. Exit codes follow the documented schema.
 8. End-to-end: scripted (no TTY) invocation works correctly with `--quiet --json`.
 9. Cross-platform: identical behavior on Linux, macOS, Windows for all commands.
-10. `vibe doctor --fix` resolves at least 80% of common issues automatically.
+10. `surge doctor --fix` resolves at least 80% of common issues automatically.

--- a/docs/revision/components/editor.md
+++ b/docs/revision/components/editor.md
@@ -31,10 +31,10 @@ fn main() -> eframe::Result<()> {
     let options = eframe::NativeOptions {
         viewport: egui::ViewportBuilder::default()
             .with_inner_size([1280.0, 800.0])
-            .with_title("vibe·flow editor"),
+            .with_title("surge editor"),
         ..Default::default()
     };
-    eframe::run_native("vibe-editor", options, Box::new(|cc| Box::new(App::new(cc))))
+    eframe::run_native("surge-editor", options, Box::new(|cc| Box::new(App::new(cc))))
 }
 
 struct App {
@@ -68,7 +68,7 @@ impl eframe::App for App {
 
 ```
 ┌──────────────────────────────────────────────────────────────────────────┐
-│ TOP BAR · vibe·flow · ~/projects/myapp/flow.toml · [💾] · validation   │
+│ TOP BAR · surge · ~/projects/myapp/flow.toml · [💾] · validation   │
 ├──────────┬─────────────────────────────────────────────────┬───────────────┤
 │ SIDEBAR  │                                                 │ INSPECTOR     │
 │          │                                                 │               │
@@ -161,7 +161,7 @@ Primary work surface. Built on egui-snarl which provides:
 Each node is rendered with:
 
 ```rust
-impl SnarlViewer<NodeData> for VibeFlowViewer {
+impl SnarlViewer<NodeData> for SurgeViewer {
     fn show_header(&mut self, node: NodeId, ...) {
         ui.horizontal(|ui| {
             ui.label(node.icon());
@@ -395,7 +395,7 @@ If a flow.toml is currently running (active run uses this graph), the editor can
 
 - Top bar: "📡 Connected to run #0083"
 - Canvas: nodes show real-time status (running with pulse, completed teal, failed red)
-- Click "Open in runtime" → spawns vibe-runtime in a new window for that run
+- Click "Open in runtime" → spawns surge-runtime in a new window for that run
 
 Editor doesn't allow saving changes to a flow that's actively running (changes would create inconsistency). User must either save as different file or wait for run to finish.
 
@@ -434,7 +434,7 @@ History stored in memory (not persisted). Limit: 100 operations.
 
 ## Persistence
 
-UI state stored in `~/.vibe/ui-state.toml`:
+UI state stored in `~/.surge/ui-state.toml`:
 
 ```toml
 [editor]

--- a/docs/revision/components/profiles.md
+++ b/docs/revision/components/profiles.md
@@ -2,16 +2,16 @@
 
 ## Overview
 
-This document specifies the **bundled profiles** shipped with vibe-flow v1.0. Each profile includes the full system prompt, tool configuration, sandbox defaults, and outcomes.
+This document specifies the **bundled profiles** shipped with surge v1.0. Each profile includes the full system prompt, tool configuration, agent-native sandbox defaults, and outcomes.
 
-**This is the most important document in the spec.** The quality of every vibe-flow run depends on these prompts. They have been written to be:
+**This is the most important document in the spec.** The quality of every surge run depends on these prompts. They have been written to be:
 - **Specific** — clear instructions, no fluff
 - **Anti-fragile** — explicit anti-patterns to avoid
 - **Tool-aware** — instruct correct tool usage
 - **Outcome-disciplined** — agents must use `report_stage_outcome` correctly
 - **Conservative** — agents prefer to escalate rather than guess
 
-Profiles ship in `vibe-flow/profiles/` (relative to repo root) and are copied to `~/.vibe/profiles/` on first run.
+Profiles ship in `surge/profiles/` (relative to repo root) and are copied to `~/.surge/profiles/` on first run.
 
 ## Bootstrap profiles (`_bootstrap/`)
 
@@ -42,7 +42,7 @@ default_max_tokens = 50000
 default_mode = "read-only"
 default_writable_roots = []
 default_network_allowlist = []        # web search added per-run if user opts in
-default_protected_paths = [".git", ".vibe", ".env", "**/secrets*"]
+default_protected_paths = [".git", ".surge", ".env", "**/secrets*"]
 
 [tools]
 default_mcp = ["filesystem"]
@@ -75,12 +75,12 @@ expected = []
 [[hooks.entries]]
 trigger = "on_outcome"
 matcher = 'outcome == "done"'
-command = "test -f $WORKTREE/.vibe/runs/$RUN_ID/artifacts/description.md"
+command = "test -f $WORKTREE/.surge/runs/$RUN_ID/artifacts/description.md"
 on_failure = "reject_outcome"
 
 [prompt]
 system = """
-You are the Description Author for vibe-flow. Your job is to convert a user's natural language task description into a structured, technical specification document.
+You are the Description Author for surge. Your job is to convert a user's natural language task description into a structured, technical specification document.
 
 # What you receive
 
@@ -215,12 +215,12 @@ expected = [
 [[hooks.entries]]
 trigger = "on_outcome"
 matcher = 'outcome == "done"'
-command = "test -f $WORKTREE/.vibe/runs/$RUN_ID/artifacts/roadmap.md"
+command = "test -f $WORKTREE/.surge/runs/$RUN_ID/artifacts/roadmap.md"
 on_failure = "reject_outcome"
 
 [prompt]
 system = """
-You are the Roadmap Planner for vibe-flow. Your job is to decompose a task description into milestones and tasks suitable for autonomous execution by AI coding agents.
+You are the Roadmap Planner for surge. Your job is to decompose a task description into milestones and tasks suitable for autonomous execution by AI coding agents.
 
 # What you receive
 
@@ -367,12 +367,12 @@ expected = [
 [[hooks.entries]]
 trigger = "on_outcome"
 matcher = 'outcome == "done"'
-command = "vibe internal validate-flow $WORKTREE/.vibe/runs/$RUN_ID/artifacts/flow.toml"
+command = "surge internal validate-flow $WORKTREE/.surge/runs/$RUN_ID/artifacts/flow.toml"
 on_failure = "reject_outcome"
 
 [prompt]
 system = """
-You are the Flow Generator for vibe-flow. Your job is to convert a roadmap into an executable graph (`flow.toml`) using existing profiles.
+You are the Flow Generator for surge. Your job is to convert a roadmap into an executable graph (`flow.toml`) using existing profiles.
 
 # What you receive
 
@@ -445,6 +445,8 @@ For each Agent node, select a profile from the registry. Match:
 
 CRITICAL: You can ONLY use profiles that are in the registry. Do not invent new profile names.
 
+Provider choice is per Agent node. Prefer named agents from `agents.yml` and role routes. Use raw node launch overrides only when the user, project config, or roadmap explicitly requests a one-off provider/mode change. Example: implementation may run on `claude-writer`, review may run on `codex-review`, and verification may run on `gemini-verify`. This is expressed as `agent = "..."` or node launch overrides, not as new profiles.
+
 ## Step 6: Wire bindings
 
 For each Agent node, declare bindings to the artifacts it needs:
@@ -482,11 +484,26 @@ when_to_use = "Standard implementation work where plan and spec exist"
 inputs_expected = ["spec.md", "plan.md", "adrs"]
 outputs_produced = ["modified source files", "git commits"]
 declared_outcomes = ["done", "blocked", "escalate"]
+default_launch = { provider = "claude-code", mode = "local" }
 
 # ... more profiles
+
+[[available_agents]]
+name = "claude-writer"
+provider = "claude-code"
+launch_mode = "local"
+sandbox_mode = "workspace-write"
+intended_roles = ["implementer", "architect"]
+
+[[available_agents]]
+name = "codex-review"
+provider = "codex"
+launch_mode = "sandbox"
+sandbox_mode = "read-only"
+intended_roles = ["reviewer", "verifier"]
 ```
 
-Use the `when_to_use` field to choose between similar profiles.
+Use the `when_to_use` field to choose between similar profiles. Use `available_agents` and role routes to choose the execution provider for each node.
 
 # Critical anti-patterns
 
@@ -900,10 +917,10 @@ These are non-negotiable:
 
 # Constraints
 
-- Modify only files in the run's worktree (sandbox enforces this).
-- Don't add dependencies not listed in the plan. If you genuinely need one, request sandbox elevation with rationale.
+- Modify only files in the run's worktree. The selected agent runtime is expected to enforce or request approval for this according to its sandbox model.
+- Don't add dependencies not listed in the plan. If you genuinely need one, request permission/elevation with rationale.
 - Don't change public API beyond what the spec authorizes.
-- Don't modify `.git/`, `.vibe/`, secrets, or protected paths.
+- Don't modify `.git/`, `.surge/`, secrets, or protected paths.
 
 # Outcome reporting
 
@@ -1216,7 +1233,7 @@ You are the PR Composer. Compose a PR description from the run's history and ope
 - Run ID: #N
 - Duration: Xm Ys
 - Cost: $Z
-- Generated by: vibe-flow
+- Generated by: surge
 ```
 
 5. Push the branch to origin (if remote exists).

--- a/docs/revision/components/runtime-ui.md
+++ b/docs/revision/components/runtime-ui.md
@@ -221,7 +221,7 @@ Modal dialog when "Fork from here" clicked:
 │ □ Change profile of next node                                     │
 │ □ Skip next node entirely                                         │
 │                                                                   │
-│ Branch name: [vibe/run-fork-abc123____________]                   │
+│ Branch name: [surge/run-fork-abc123____________]                   │
 │                                                                   │
 │                              [Cancel]  [Create fork]              │
 └──────────────────────────────────────────────────────────────────┘
@@ -311,7 +311,7 @@ Same color palette as editor (control-room dark theme). Color tokens defined in 
 
 ## Persistence
 
-UI state in `~/.vibe/ui-state.toml`:
+UI state in `~/.surge/ui-state.toml`:
 
 ```toml
 [runtime]

--- a/docs/revision/components/telegram-bot.md
+++ b/docs/revision/components/telegram-bot.md
@@ -8,9 +8,9 @@ This document specifies the bot's process structure, message handlers, callback 
 
 ## Process model
 
-The bot runs as a **singleton daemon process** (`vibe-tg`), independent from per-run engine daemons. Started:
-- Automatically on first `vibe run` invocation
-- Manually via `vibe telegram start`
+The bot runs as a **singleton daemon process** (`surge-tg`), independent from per-run engine daemons. Started:
+- Automatically on first `surge run` invocation
+- Manually via `surge telegram start`
 - Auto-restart on crash (via systemd-style supervisor or simple loop)
 
 Process lifecycle:
@@ -416,7 +416,7 @@ pub async fn setup(home: &Path) -> Result<()> {
     
     println!("\n✓ Bound to chat {}", chat_id);
     println!("  Sending test message...");
-    bot.send_message(ChatId(chat_id), "vibe·flow connected. You'll receive approval cards here.").await?;
+    bot.send_message(ChatId(chat_id), "surge connected. You'll receive approval cards here.").await?;
     
     dispatcher_task.abort();
     Ok(())
@@ -433,7 +433,7 @@ async fn start_polling(bot: Bot, handler: ...) {
 }
 ```
 
-Webhook (configured via `~/.vibe/config.toml`):
+Webhook (configured via `~/.surge/config.toml`):
 
 ```rust
 async fn start_webhook(bot: Bot, handler: ..., webhook_url: &str, secret_token: &str) {
@@ -518,9 +518,9 @@ Bot logs:
 - All received callbacks (with action, run ID)
 - Errors and rate-limit hits
 
-Logs go to `~/.vibe/logs/telegram.log` with rotation.
+Logs go to `~/.surge/logs/telegram.log` with rotation.
 
-`vibe telegram status` shows:
+`surge telegram status` shows:
 - Service uptime
 - Messages sent/received
 - Pending approvals queue size

--- a/docs/revision/rfcs/0001-overview.md
+++ b/docs/revision/rfcs/0001-overview.md
@@ -4,7 +4,7 @@
 
 A solo developer with a full-time job describes a coding task in natural language. Several minutes later, after approving a brief description and proposed plan via Telegram, walks away. Hours later receives a Telegram notification that a Pull Request is ready. Total time spent: 60–120 seconds across the run.
 
-This is what `vibe-flow` enables: **truly autonomous AI coding pipelines** where the human is the architect-of-architecture (defines templates, sets policies) but not the operator-of-each-decision.
+This is what `surge` enables: **truly autonomous AI coding pipelines** where the human is the architect-of-architecture (defines templates, sets policies) but not the operator-of-each-decision.
 
 ## Why graphs
 
@@ -14,7 +14,7 @@ Existing AI coding tools fall into two camps:
 
 2. **Multi-agent swarms** (BridgeSwarm, AutoGPT) — agents talk to each other through LLM calls to coordinate. Expensive in tokens, non-deterministic, hard to debug. When something fails, you don't know why.
 
-`vibe-flow` takes a third path: **explicit directed graphs with typed handoffs**. The graph is the workflow. Each node is an isolated agent session with declared outcome ports (e.g., `done`, `blocked`, `escalate`). Edges route outcomes to next nodes. The engine is a deterministic state machine — agents only do work, the graph decides routing.
+`surge` takes a third path: **explicit directed graphs with typed handoffs**. The graph is the workflow. Each node is an isolated agent session with declared outcome ports (e.g., `done`, `blocked`, `escalate`). Edges route outcomes to next nodes. The engine is a deterministic state machine — agents only do work, the graph decides routing.
 
 This gives:
 
@@ -53,7 +53,7 @@ For richer interactions (full diff review, prompt editing) — deeplink to deskt
 - 7 built-in roles (Spec Author, Architect, Implementer, Test Author, Verifier, Reviewer, PR Composer)
 - Event-sourced engine with SQLite persistence
 - ACP bridge for agent-agnostic execution (Claude Code / Codex / Gemini CLI)
-- Sandbox modes with per-node configuration
+- Agent-native sandbox modes with per-node configuration
 - Worktree-per-run isolation
 - Visual graph editor (egui) for viewing/editing pipelines
 - Runtime view (gpui) with live progress, logs, artifacts
@@ -73,7 +73,7 @@ For richer interactions (full diff review, prompt editing) — deeplink to deskt
 - Cross-machine sync of runs
 - Manager/coordinator agents that do LLM-based routing
 - Auto-fixing failed runs without human input
-- Auto-detection of project type for `vibe init` (per-run flow generation only)
+- Auto-detection of project type for `surge init` (per-run flow generation only)
 
 ## Glossary
 
@@ -81,10 +81,11 @@ For richer interactions (full diff review, prompt editing) — deeplink to deskt
 |------|------------|
 | **Run** | One execution of a pipeline from start to terminal node. Has unique ID, immutable event log, lives in single git worktree. |
 | **Pipeline** | A graph definition (`flow.toml`). May be ephemeral (per-run generated) or saved as template. |
-| **Template** | A reusable pipeline blueprint. Lives in `~/.vibe/templates/` or shipped in-box. Used as few-shot example by Flow Generator. |
+| **Template** | A reusable pipeline blueprint. Lives in `~/.surge/templates/` or shipped in-box. Used as few-shot example by Flow Generator. |
 | **Node** | A vertex in the graph. Has `id`, `NodeKind`, configuration. Cannot be reused across runs (each run gets fresh node instances). |
 | **NodeKind** | Closed enum: `Agent`, `HumanGate`, `Branch`, `Terminal`, `Notify`, `Loop`, `Subgraph`. |
-| **Profile** / **Role** | A reusable Agent configuration (system prompt, tools, sandbox, outcomes). Lives in `~/.vibe/profiles/`. Examples: `implementer`, `reviewer`, `spec-author`. |
+| **Profile** / **Role** | A reusable Agent configuration (system prompt, launch settings, tools, sandbox, outcomes). Lives in `~/.surge/profiles/`. Examples: `implementer`, `reviewer`, `spec-author`. |
+| **Launch config** | Provider-native session startup settings: agent provider plus execution target such as `local`, `cloud`, `sandbox`, or provider default. This is passed through to Codex, Claude Code, Gemini CLI, or a custom ACP agent. |
 | **Outcome** | A typed result an Agent reports via `report_stage_outcome` tool. Each declared outcome on a node is an output port that maps to an edge. |
 | **Edge** | A connection from a node's outcome port to another node's input. Has `EdgeKind`: `Forward`, `Backtrack`, `Escalate`. |
 | **HumanGate** | A node type that pauses execution waiting for human decision via Telegram or UI. |
@@ -92,7 +93,7 @@ For richer interactions (full diff review, prompt editing) — deeplink to deskt
 | **Flow Generator** | The bootstrap agent that produces the run-specific graph based on user description and roadmap. |
 | **Worktree** | Git worktree branch dedicated to a single run. Created at run start, optionally merged at run end. |
 | **Event** | Immutable record in the run's event log. Examples: `RunStarted`, `StageEntered`, `OutcomeReported`, `ApprovalRequested`. |
-| **Sandbox** | Per-node policy controlling filesystem/network/shell access. Modes: `read-only`, `workspace-write`, `workspace+network`, `full-access`. See RFC-0006 for full semantics. |
+| **Sandbox** | Per-node policy passed to the selected agent runtime. surge does not implement OS sandboxing itself; it maps modes like `read-only`, `workspace-write`, `workspace+network`, and `full-access` to the capabilities supported by Codex, Claude Code, Gemini CLI, or a custom ACP agent. See RFC-0006 for full semantics. |
 | **AGENTS.md** | Markdown rules file format (Linux Foundation standard). Loaded into agent context based on scope (global/profile/project/subdir). |
 | **ACP** | Agent Client Protocol. Standard interface for invoking AI coding agents (Claude Code, Codex, Gemini). |
 
@@ -100,9 +101,9 @@ For richer interactions (full diff review, prompt editing) — deeplink to deskt
 
 The product is "done enough" when:
 
-1. A user can run `vibe init` in an empty Rust project and get a working `pipeline.toml` after answering 0 questions (auto-detection)
-2. A user can run `vibe run "build a JSON5 parser library"` and receive a merged PR within 30 minutes with no terminal interaction beyond 3 Telegram taps
+1. A user can run `surge init` in an empty Rust project and get a working `pipeline.toml` after answering 0 questions (auto-detection)
+2. A user can run `surge run "build a JSON5 parser library"` and receive a merged PR within 30 minutes with no terminal interaction beyond 3 Telegram taps
 3. A failed run can be replayed and forked from the failure point without redoing successful stages
-4. A new role can be contributed by creating a single TOML file in `~/.vibe/profiles/` without code changes
+4. A new role can be contributed by creating a single TOML file in `~/.surge/profiles/` without code changes
 5. The graph editor opens an existing `flow.toml` and renders it correctly with live edit/save
 6. End-to-end test suite covering all 7 default roles runs in CI on Linux/macOS/Windows

--- a/docs/revision/rfcs/0002-execution-model.md
+++ b/docs/revision/rfcs/0002-execution-model.md
@@ -15,7 +15,7 @@ This document specifies:
 
 Alternatives considered and rejected:
 
-**Plain CRUD** (current_status column, updated in place). Cannot replay. Cannot fork. Cannot debug "why did the run go this way at 14:32" — that information is gone the moment status updates. Common choice in similar tools (Vibe Kanban, Conductor) — and they all suffer from this limitation.
+**Plain CRUD** (current_status column, updated in place). Cannot replay. Cannot fork. Cannot debug "why did the run go this way at 14:32" — that information is gone the moment status updates. Common choice in similar tools (surge Kanban, Conductor) — and they all suffer from this limitation.
 
 **Snapshots + diffs**. Periodically dump full state to disk, store diffs between snapshots. Less storage than full event log but loses fine-grained history. Time-travel only works to snapshot boundaries.
 
@@ -48,7 +48,7 @@ struct Event {
 
 #### Run lifecycle
 
-- **`RunStarted`** — first event of any run. Carries pipeline ID, initial inputs, project context, run policy (sandbox tier, retry limits).
+- **`RunStarted`** — first event of any run. Carries pipeline ID, initial inputs, project context, run policy (agent sandbox intent, retry limits).
 - **`RunCompleted`** — terminal event. Carries final state and which Terminal node was reached.
 - **`RunFailed`** — terminal event for unrecoverable failures. Carries error chain.
 - **`RunAborted`** — terminal event for user-initiated cancellation.
@@ -68,7 +68,7 @@ struct Event {
 
 - **`StageEntered`** — pipeline reached a node. Carries node ID and attempt number (≥1).
 - **`StageInputsResolved`** — all bindings (artifact references, prompt variables) have been computed and the agent is about to be invoked.
-- **`SessionOpened`** — ACP session created for this stage attempt. Carries session ID.
+- **`SessionOpened`** — ACP session created for this stage attempt. Carries session ID, provider, launch mode, and applied sandbox mode.
 - **`ToolCalled`** — agent invoked a tool. Carries tool name, arguments (redacted if sensitive), session ID.
 - **`ToolResultReceived`** — tool returned. Carries success/failure and result hash.
 - **`ArtifactProduced`** — stage created or modified an artifact (file, document). Carries path and content hash.
@@ -91,7 +91,7 @@ struct Event {
 
 #### Sandbox
 
-- **`SandboxElevationRequested`** — agent attempted action outside current sandbox. Carries requested capability.
+- **`SandboxElevationRequested`** — provider or agent requested capability outside current sandbox intent. Carries requested capability.
 - **`SandboxElevationDecided`** — user approved/denied (or remembered for template).
 
 #### Hooks
@@ -175,11 +175,11 @@ The full match is exhaustive. Invalid transitions (e.g., `OutcomeReported` while
 
 ### Phase 1: Initialization
 
-User invokes `vibe run "<description>"` from a project directory.
+User invokes `surge run "<description>"` from a project directory.
 
 1. Engine generates `RunId` (UUIDv7).
-2. Engine creates worktree branch `vibe/run-<short_id>` from current `HEAD`.
-3. Engine creates run directory `~/.vibe/runs/<run_id>/`.
+2. Engine creates worktree branch `surge/run-<short_id>` from current `HEAD`.
+3. Engine creates run directory `~/.surge/runs/<run_id>/`.
 4. Engine writes initial event `RunStarted` to event log.
 5. Engine forks subprocess to handle this run; main process returns control.
 6. Daemon mode: engine continues even after CLI exits (run persists across terminal closures).
@@ -241,7 +241,7 @@ The engine must survive:
 
 ### Recovery procedure
 
-On engine startup, scan `~/.vibe/runs/` for runs in non-terminal state. For each:
+On engine startup, scan `~/.surge/runs/` for runs in non-terminal state. For each:
 
 1. Load event log into memory.
 2. Fold events to compute current state.
@@ -273,7 +273,7 @@ Multiple runs can execute concurrently. Each run is isolated:
 - Own ACP session pool
 - Own subprocess (daemon)
 
-The CLI tracks runs by ID. `vibe list` queries all runs, `vibe attach <run_id>` connects stdout to a running run for live tailing.
+The CLI tracks runs by ID. `surge list` queries all runs, `surge attach <run_id>` connects stdout to a running run for live tailing.
 
 ### Locking
 

--- a/docs/revision/rfcs/0003-graph-model.md
+++ b/docs/revision/rfcs/0003-graph-model.md
@@ -113,7 +113,9 @@ The most common node. Runs an ACP session to do agent work.
 ```rust
 struct AgentConfig {
     profile: ProfileRef,               // mandatory — references registry
+    agent: Option<String>,             // named agent from agents.yml
     prompt_overrides: Option<PromptOverride>,
+    launch_override: Option<AgentLaunchConfig>,
     tool_overrides: Option<ToolOverride>,
     sandbox_override: Option<SandboxConfig>,
     bindings: Vec<Binding>,            // input artifacts
@@ -141,6 +143,10 @@ struct NodeLimits {
     max_tokens: u32,                   // default 200_000
 }
 ```
+
+Each Agent node is an independent session. A single flow may mix providers and launch modes by using named agents from `agents.yml`, profile defaults, or per-node `launch_override`: for example, an Implementer node can run Claude Code locally, a Reviewer node can run Codex in sandbox mode, and a Verifier node can run Gemini. This is still a deterministic graph, not a swarm: agents do not coordinate with each other directly; artifacts and outcomes move through edges.
+
+Recommended generated `flow.toml` should prefer `agent = "name-from-agents-yml"` over raw provider flags because named agents are easier for humans and LLMs to read and edit.
 
 **Outcomes** — declared per-node, common patterns:
 - `done` (success, forward) + `blocked` (backtrack to plan) + `escalate` (HumanGate)

--- a/docs/revision/rfcs/0004-bootstrap-and-flow-generation.md
+++ b/docs/revision/rfcs/0004-bootstrap-and-flow-generation.md
@@ -25,7 +25,7 @@ Cost is three LLM calls instead of one (~$0.50–$1.50 extra per run). Acceptabl
 
 ## Bootstrap stages as graph nodes
 
-Bootstrap stages are not hidden pre-stages. They are first-class Agent nodes in the run's graph, just shipped in `~/.vibe/profiles/_bootstrap/`. This means:
+Bootstrap stages are not hidden pre-stages. They are first-class Agent nodes in the run's graph, just shipped in `~/.surge/profiles/_bootstrap/`. This means:
 
 - Same execution mechanics (event log, replay, fork-from-here) apply
 - Bootstrap nodes can be customized by power users (override the profile)
@@ -97,7 +97,7 @@ The agent:
 
 ### System prompt outline
 
-The Description Author profile lives in `~/.vibe/profiles/_bootstrap/description-author.toml`. Key elements:
+The Description Author profile lives in `~/.surge/profiles/_bootstrap/description-author.toml`. Key elements:
 
 - Role: "You convert vague human task descriptions into structured technical specifications."
 - Constraints: "Do not propose implementation. Do not suggest tools or libraries unless user mentioned them."
@@ -242,9 +242,9 @@ Step 5: Validate output.
 
 **Flow Generator must select from existing profiles only.** It cannot invent new roles. This is the determinism boundary — agents do work, but they don't define new types of agents at runtime. This is encoded heavily in the system prompt.
 
-## Profile registry as Flow Generator's input
+## Profile registry and agent compose as Flow Generator input
 
-For Flow Generator to make good choices, it needs to know what profiles exist and what they do. The profile registry is exposed to the Flow Generator in its prompt context:
+For Flow Generator to make good choices, it needs to know what profiles exist and which named agents are available. The profile registry and `agents.yml` are exposed to the Flow Generator in its prompt context:
 
 ```toml
 # This is what gets injected into Flow Generator's system prompt as context
@@ -263,9 +263,30 @@ id = "reviewer"
 display_name = "Reviewer"
 description = "Reads diff, reviews for logic errors and architecture issues."
 # ... etc
+
+[[available_agents]]
+name = "claude-writer"
+provider = "claude-code"
+launch_mode = "local"
+sandbox_mode = "workspace-write"
+intended_roles = ["implementer", "architect"]
+
+[[available_agents]]
+name = "codex-review"
+provider = "codex"
+launch_mode = "sandbox"
+sandbox_mode = "read-only"
+intended_roles = ["reviewer", "verifier"]
+
+[role_routes]
+implementer = "claude-writer"
+reviewer = "codex-review"
+verifier = "codex-review"
 ```
 
-This is generated dynamically from the profile registry on each Flow Generator invocation. Add a new profile → it's automatically available for Flow Generator to consider.
+This is generated dynamically from the profile registry plus project/global `agents.yml` on each Flow Generator invocation. Add a new profile or named agent → it's automatically available for Flow Generator to consider.
+
+Flow Generator should prefer role routes and named agents over raw launch overrides. Raw launch overrides are reserved for cases where the user explicitly asked for a one-off provider/mode change.
 
 ## Edit feedback loop
 
@@ -292,7 +313,7 @@ This makes correction conversational, not menu-driven. Most edits are 1–2 sent
 For experienced users with a stable template that works well for them:
 
 ```bash
-vibe run "<description>" --template=rust-crate-tdd
+surge run "<description>" --template=rust-crate-tdd
 ```
 
 This skips Description and Roadmap stages, directly uses the named template's pre-baked flow, and starts execution. Description equivalent is auto-generated from `<description>` argument as a single paragraph; no human approval.
@@ -369,15 +390,15 @@ If user keeps editing and re-running same stage indefinitely, that's their choic
 
 Default: no timeout on approval gates. User may walk away for hours. Run sits as daemon. On return, taps approve.
 
-Configurable per-user policy: `~/.vibe/config.toml` can set `bootstrap_approval_timeout_hours = 24` to auto-fail after 24h. Default `None`.
+Configurable per-user policy: `~/.surge/config.toml` can set `bootstrap_approval_timeout_hours = 24` to auto-fail after 24h. Default `None`.
 
 ## Acceptance criteria
 
 The bootstrap and flow generation are correctly implemented when:
 
-1. Running `vibe run "fix typo in README"` produces a 3–4 node linear flow after bootstrap.
-2. Running `vibe run "build a JSON5 parser library with serde support"` produces a multi-milestone nested-loop flow.
-3. Running `vibe run "fix the panic in parse_object"` produces a bug-fix archetype flow with reproduce + regression test stages.
+1. Running `surge run "fix typo in README"` produces a 3–4 node linear flow after bootstrap.
+2. Running `surge run "build a JSON5 parser library with serde support"` produces a multi-milestone nested-loop flow.
+3. Running `surge run "fix the panic in parse_object"` produces a bug-fix archetype flow with reproduce + regression test stages.
 4. Description, Roadmap, and Flow stages are visible as nodes in canvas, can be inspected, and their outputs are stored as artifacts.
 5. Editing each stage with free-text feedback produces a revised artifact and second approval card.
 6. Flow Generator's output passes graph validation (RFC-0003) for 100% of test cases (unit tests with 50+ scenarios).

--- a/docs/revision/rfcs/0005-profiles-and-roles.md
+++ b/docs/revision/rfcs/0005-profiles-and-roles.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-A **profile** is a reusable configuration for an Agent node. It encapsulates everything that defines an agent's role: system prompt, allowed tools, sandbox policy, default outcomes, recommended model. Profiles are TOML files in `~/.vibe/profiles/` (and shipped defaults).
+A **profile** is a reusable configuration for an Agent node. It encapsulates everything that defines an agent's role: system prompt, allowed tools, agent launch configuration, agent-native sandbox intent, default outcomes, recommended model. Profiles are TOML files in `~/.surge/profiles/` (and shipped defaults).
 
 A **role** is the user-facing concept: "Implementer", "Reviewer", "Spec Author". Each role corresponds to one (or more, versioned) profile.
 
@@ -15,7 +15,7 @@ This document specifies:
 
 ## Why profiles are first-class
 
-Without profiles, every Agent node would carry its full configuration inline (system prompt, tools, sandbox, etc.) — duplicated across runs and projects. Updating the "Implementer" prompt would require touching every pipeline. Profiles solve this:
+Without profiles, every Agent node would carry its full configuration inline (system prompt, tools, launch settings, sandbox intent, etc.) — duplicated across runs and projects. Updating the "Implementer" prompt would require touching every pipeline. Profiles solve this:
 
 - **DRY**: One profile, many nodes referencing it
 - **Versioning**: Profile updates propagate to nodes via semver
@@ -41,11 +41,17 @@ recommended_model = "claude-opus-4-7"
 default_temperature = 0.2
 default_max_tokens = 200000
 
+[launch]
+provider = "claude-code"              # claude-code | codex | gemini | custom
+mode = "local"                        # provider-default | local | cloud | sandbox
+config_profile = "default"            # provider-specific launch/config profile
+extra_args = []                       # provider-specific CLI/ACP args
+
 [sandbox]
-default_mode = "workspace-write"      # read-only | workspace-write | workspace+network | full-access
-default_writable_roots = []           # additional paths beyond worktree
+default_mode = "workspace-write"      # provider-default | read-only | workspace-write | workspace+network | full-access
+default_writable_roots = []           # advisory unless provider supports path policy
 default_network_allowlist = ["crates.io", "github.com", "*.githubusercontent.com"]
-default_protected_paths = [".git", ".vibe", "~/.ssh", "~/.config"]
+default_protected_paths = [".git", ".surge", "~/.ssh", "~/.config"]
 
 [tools]
 default_mcp = ["filesystem", "shell", "git"]
@@ -154,11 +160,17 @@ default = true
 
 ### `[runtime]`
 
-Sets defaults for the agent invocation. Per-node overrides exist.
+Sets model and generation defaults for the agent invocation. Per-node overrides exist.
+
+### `[launch]`
+
+Defines how the agent is started when no named agent is selected from `agents.yml`. `provider` selects the agent family, `mode` selects the provider-supported execution target (`local`, `cloud`, `sandbox`, or provider default), and `config_profile`/`extra_args` pass through provider-specific launch configuration. This is separate from `[sandbox]`: launch mode says where/how the agent runs, sandbox says what permissions it should request inside that run.
+
+Launch config is resolved per node. Profile defaults are only defaults: a flow can select a named agent from `agents.yml` or override the provider/launch mode on a specific Agent node when the user wants different agents for different stages, such as Claude for implementation and Codex or Gemini for review.
 
 ### `[sandbox]`
 
-Default sandbox configuration. Maps to RFC-0006 sandbox modes. Per-node overrides allowed for power users.
+Default sandbox intent. Maps to RFC-0006 agent-native sandbox modes and is passed to the selected provider when supported. Per-node overrides are allowed for power users.
 
 ### `[tools]`
 
@@ -197,8 +209,8 @@ Definitions of custom fields shown in the node Inspector when a node uses this p
 
 When a node references `profile = "implementer@1.0"`:
 
-1. Engine looks up `~/.vibe/profiles/implementer-1.0.toml` (most specific path)
-2. Falls back to `~/.vibe/profiles/implementer.toml` (latest version) with semver compatibility check
+1. Engine looks up `~/.surge/profiles/implementer-1.0.toml` (most specific path)
+2. Falls back to `~/.surge/profiles/implementer.toml` (latest version) with semver compatibility check
 3. Falls back to bundled profile in app distribution
 4. Errors out if not found
 
@@ -239,7 +251,7 @@ Inheritance is **shallow merge**: child overrides parent for each key, except fo
 
 ## Bundled v1 profiles
 
-Shipped in `vibe-flow/profiles/` directory of the repo, installed to `~/.vibe/profiles/` on first run.
+Shipped in `surge/profiles/` directory of the repo, installed to `~/.surge/profiles/` on first run.
 
 ### Bootstrap profiles (under `_bootstrap/`)
 
@@ -269,12 +281,12 @@ These are special — `category = "_bootstrap"`, hidden from user node library b
 ## Profile registry CLI
 
 ```
-vibe profile list                     # list all installed profiles
-vibe profile show <id>                # show profile details
-vibe profile install <path-or-url>    # install a profile from file or URL
-vibe profile uninstall <id>           # remove a profile
-vibe profile validate <path>          # check profile is valid
-vibe profile diff <id> <id>           # compare two versions
+surge profile list                     # list all installed profiles
+surge profile show <id>                # show profile details
+surge profile install <path-or-url>    # install a profile from file or URL
+surge profile uninstall <id>           # remove a profile
+surge profile validate <path>          # check profile is valid
+surge profile diff <id> <id>           # compare two versions
 ```
 
 ## Profile authoring guidelines
@@ -350,9 +362,9 @@ Pipelines should reference profiles with caret semver (`^1.0`) for auto-updates 
 The profile system is correctly implemented when:
 
 1. All 7 v1 profiles validate, load, and produce coherent agent behavior on test inputs.
-2. A new profile (e.g., `linter@1.0`) can be added by dropping a TOML file in `~/.vibe/profiles/` with no code changes; it appears in the editor's Node Library and is selectable by Flow Generator.
+2. A new profile (e.g., `linter@1.0`) can be added by dropping a TOML file in `~/.surge/profiles/` with no code changes; it appears in the editor's Node Library and is selectable by Flow Generator.
 3. Profile inheritance works correctly: a child profile gets parent's defaults plus its own overrides.
-4. Per-node overrides (e.g., overriding `default_temperature`) take precedence over profile defaults.
-5. `vibe profile diff implementer@1.0 implementer@1.1` shows a clear comparison of changed fields.
+4. Per-node overrides (e.g., overriding `default_temperature`, launch provider, or launch mode) take precedence over profile defaults.
+5. `surge profile diff implementer@1.0 implementer@1.1` shows a clear comparison of changed fields.
 6. Flow Generator's prompt receives the profile registry as structured context and selects appropriate profiles for each milestone/task.
 7. Inspector UI custom fields render correctly in the node config dialog when a node uses a profile that defines them.

--- a/docs/revision/rfcs/0006-sandbox-and-approvals.md
+++ b/docs/revision/rfcs/0006-sandbox-and-approvals.md
@@ -1,89 +1,230 @@
-# RFC-0006 · Sandbox and Approvals
+# RFC-0006 · Agent Sandbox and Approvals
 
 ## Overview
 
-The sandbox-and-approvals system is the **autonomy enabler**: it lets agents execute long-running work without per-action human approval, while preserving safety. Without effective sandboxing, the user's "describe and walk away" model collapses into per-tool-call confirmation dialogs.
+The sandbox-and-approvals system is the **autonomy enabler**: it lets agents execute long-running work without per-action human approval, while preserving enough control that the user can safely walk away.
 
-This document specifies:
-- Sandbox modes and what each allows/denies
-- Per-OS sandbox enforcement mechanisms
-- Approval policy and granular flags
-- Hooks system
-- AGENTS.md rules loading
-- Trust state for projects and templates
+surge does **not** implement its own OS sandbox in v0.1. There is no Landlock layer, no AppContainer layer, no `sandbox-exec`, no custom DNS interception, and no filesystem policy engine owned by surge.
 
-## Core principle
+Instead, surge treats sandboxing as **agent-native capability**:
 
-> The agent should be able to do everything the **graph allows** without asking a human, and nothing else.
+- Codex, Claude Code, Gemini CLI, and custom ACP agents already have their own permission/sandbox models.
+- surge stores the desired agent launch configuration and sandbox intent in profiles and nodes.
+- The ACP integration maps launch configuration and sandbox intent to the selected provider's supported session settings.
+- If the provider requests permission/elevation, surge turns that request into a Telegram/UI approval event and resumes the agent with the user's decision when the provider supports that flow.
+
+This keeps v0.1 focused on orchestration and remote control instead of rebuilding security primitives each agent runtime already ships.
+
+## Core Principle
+
+> The agent should be able to do everything its configured runtime sandbox allows without asking a human, and surge should ask the human only when the agent runtime requests a decision or the graph reaches a declared HumanGate.
 
 This means:
-- Sandbox enforces **technical** boundaries (filesystem, network, processes)
-- Profile/node config defines **policy** boundaries (allowed tools, max retries)
-- HumanGate nodes are explicit pause points — the only place humans interact during a run
-- Sandbox elevations are **rare exceptions** that ping the user, not normal flow
 
-## Sandbox modes
+- Agent runtime enforces **technical** boundaries.
+- Profile/node config defines **orchestration policy**: launch mode, requested sandbox intent, approval policy, allowed MCP/tool exposure, max retries.
+- HumanGate nodes are explicit pause points.
+- Permission/elevation requests are rare exceptions that ping the user, not normal flow.
 
-Four built-in modes plus custom configurations:
+## What surge Owns
+
+surge owns:
+
+- Agent launch configuration model in graph/profile TOML.
+- Sandbox intent model in graph/profile TOML.
+- Provider capability detection and diagnostics.
+- Mapping launch mode and sandbox intent to provider launch/session settings.
+- Approval events, Telegram cards, UI/CLI resolution, audit log.
+- "Allow once" / "Allow & remember" policy persistence.
+- Secrets filtering before remote notifications.
+- AGENTS.md trust and prompt-loading policy.
+- Hooks triggered by engine lifecycle events.
+
+surge does **not** own:
+
+- OS-level filesystem enforcement.
+- OS-level network enforcement.
+- Kernel sandboxing.
+- Shell subprocess containment.
+- Provider-specific internals that are not exposed through ACP/CLI settings.
+
+If a provider cannot enforce a requested mode, surge must say so clearly and either fail closed or require explicit user opt-in.
+
+## Agent Launch Configuration
+
+Launch configuration is the first layer of provider setup. It answers: **where and how is this agent session started?**
+
+Most users should not write raw launch fields in every flow. They define named agents in `agents.yml`, then `flow.toml` nodes reference those names. This mirrors `docker-compose.yml`: the friendly file declares reusable services, and the generated graph references them.
+
+```toml
+[launch]
+provider = "codex"                    # claude-code | codex | gemini | custom
+mode = "local"                        # provider-default | local | cloud | sandbox
+config_profile = "default"
+extra_args = []
+```
+
+Launch modes are provider-native:
+
+- **`provider-default`** — use the provider's default launch behavior.
+- **`local`** — run the agent on the user's machine as a local process.
+- **`cloud`** — use the provider's cloud/hosted execution mode when available.
+- **`sandbox`** — use the provider's isolated/sandboxed execution target when available.
+
+surge does not emulate a missing launch mode. If Codex supports a sandbox launch and Claude Code does not, the provider capability metadata says that clearly and validation handles it.
+
+## Sandbox Intent Modes
+
+These modes are portable intent labels. They are not a guarantee that every provider implements identical semantics.
+
+### `provider-default`
+
+Use the selected agent's default sandbox/permission behavior. This is useful during early integration or when the provider's defaults are already trusted by the user.
 
 ### `read-only`
 
-- Filesystem: read-only access to project worktree
-- No network
-- No subprocess execution
-- No git operations
+Intent:
 
-Use case: planning agents, analyzers, security auditors.
+- Agent may inspect project files.
+- Agent should not modify files.
+- Agent should not run mutating commands.
+- Network is disabled unless the provider default allows read-only network metadata.
+
+Use case: planning agents, analyzers, reviewers.
 
 ### `workspace-write`
 
-- Filesystem: read everywhere allowed, write only within run worktree
-- No network
-- Subprocess execution allowed for declared shell allowlist (e.g., `cargo`, `git`)
-- Git: read + commit allowed (within run branch), no push, no force operations
+Intent:
 
-Use case: implementers, test authors. **Default for most coding agents.**
+- Agent may read the project.
+- Agent may write within the run worktree.
+- Agent may run normal build/test commands.
+- Agent should not access user secrets or write outside the worktree.
+
+Use case: implementers, test authors. This is the default intent for most coding nodes.
 
 ### `workspace+network`
 
-- Same as `workspace-write` plus
-- Network: outbound HTTPS to declared domain allowlist
-- DNS: only allowed domains resolvable
+Intent:
 
-Use case: agents that need to download dependencies (`cargo add` resolves crates.io), agents that fetch API specs.
+- Same as `workspace-write`.
+- Agent may use network for declared development domains such as package registries, API docs, or GitHub.
+
+Use case: dependency updates, codegen from public specs, package resolution.
 
 ### `full-access`
 
-- Filesystem: full read/write (subject to `protected_paths` exclusions)
-- Network: unrestricted
-- Subprocess: unrestricted
-- Git: full access including push
+Intent:
 
-Use case: PR Composer (needs github push), CI integrations. **Always requires explicit elevation, never default.**
+- Agent runtime runs with broad access according to its own model.
+- Used only for trusted stages such as PR composition or explicit user-approved operations.
 
-### Custom
+`full-access` must never be silently selected by generated flows. It requires explicit profile/template configuration or a human approval.
 
-A node can define its own sandbox profile:
+### `custom`
+
+Provider-specific options for users who know the selected runtime:
 
 ```toml
-[sandbox_override]
+[sandbox]
 mode = "custom"
-read = ["~/projects/**"]
-write = ["~/.vibe/runs/<run_id>/**", "/tmp/vibe-*"]
-network_allowlist = ["api.openai.com", "internal.company.com"]
-shell_allowlist = ["docker", "kubectl"]
+provider = "codex"
+
+[sandbox.provider_options]
+approval_policy = "on-request"
+network = "enabled"
+extra_args = ["--some-provider-flag"]
 ```
 
-## Protected paths (always denied)
+Custom options are passed only to the matching provider. Unknown options are rejected during profile validation.
 
-Regardless of sandbox mode, these are **always read-only or denied**:
+## Provider Capability Metadata
 
-- `.git/` — never write directly (use git commands)
-- `.vibe/` — engine's own state
-- `~/.ssh/`, `~/.config/`, `~/.aws/` — user secrets
-- Files matched by `~/.vibe/global-deny.toml`
+Each provider reports or is configured with capabilities:
 
-The default global deny list is shipped with the app and includes:
+```toml
+[[providers]]
+id = "codex"
+supports_launch_modes = ["local", "cloud", "sandbox"]
+supports_modes = ["read-only", "workspace-write", "workspace+network", "full-access"]
+supports_permission_callbacks = true
+supports_mcp_filtering = true
+supports_network_policy = "provider-native"
+notes = "Exact enforcement is owned by Codex."
+```
+
+Capability metadata is used by:
+
+- `surge doctor`
+- profile validation
+- flow validation
+- engine startup diagnostics
+- Telegram warning cards when the requested policy is weaker/stronger than what the provider can express
+
+## Profile Configuration
+
+Profiles declare launch configuration and sandbox intent:
+
+```toml
+[launch]
+provider = "codex"
+mode = "local"
+config_profile = "default"
+
+[sandbox]
+mode = "workspace-write"              # provider-default | read-only | workspace-write | workspace+network | full-access | custom
+network_allowlist = ["crates.io", "github.com"]
+require_provider_support = true
+
+[approvals]
+policy = "on-request"                 # untrusted | on-request | never
+sandbox_approval = true
+mcp_elicitations = false
+request_permissions = true
+skill_approval = false
+elevation = true
+```
+
+`network_allowlist` is advisory unless the selected provider supports native network policy. If unsupported and `require_provider_support = true`, validation fails. If `false`, surge logs a warning and records the limitation in the run event log.
+
+## Approval Policy
+
+### Policy levels
+
+- **`untrusted`** — conservative mode. Human approval is requested for generated flow approval, sensitive permission requests, and risky provider warnings.
+- **`on-request`** — default. Agent runs autonomously inside its provider sandbox; user is pinged only for HumanGate nodes and provider permission/elevation requests.
+- **`never`** — no approvals during this stage. Used for automated re-runs or trusted CI-like stages. If a provider asks for permission, the request is denied or the stage fails.
+
+### Granular flags
+
+| Flag | Effect when `true` |
+|------|-------------------|
+| `sandbox_approval` | Ask before accepting provider sandbox/elevation requests |
+| `mcp_elicitations` | Forward MCP server elicitations to the user |
+| `request_permissions` | Forward agent permission requests to the user |
+| `skill_approval` | Ask before loading optional skills |
+| `elevation` | Always ask before moving to `full-access` |
+
+Combination: `policy = on-request, elevation = true` means the agent works autonomously until its runtime asks for more authority.
+
+## Permission and Elevation Flow
+
+When a provider exposes a permission/elevation request:
+
+1. **Detection**: ACP bridge or provider adapter receives a permission request, tool approval request, or sandbox escalation signal.
+2. **Event**: Engine writes `SandboxElevationRequested` or a more specific provider-permission event.
+3. **Delivery**: Telegram bot sends a card with action, reason, stage, command/tool summary, and risk notes.
+4. **Decision**:
+   - `Allow once`: return approval to the provider for this request.
+   - `Allow & remember`: approve and persist a broader profile/template policy when safe.
+   - `Deny`: return denial to the provider.
+5. **Resume**: Engine writes `SandboxElevationDecided` and resumes or fails the stage based on provider result.
+
+If the provider cannot pause and wait for a decision, surge fails closed for risky requests unless the profile explicitly selected `full-access` or `provider-default`.
+
+## Protected Paths and Secret Handling
+
+Because surge does not own OS enforcement, protected-path handling is advisory unless supported by the provider. The engine still keeps a default deny/warning list:
 
 ```toml
 deny = [
@@ -97,239 +238,67 @@ deny = [
 ]
 ```
 
-User can extend but not weaken this list.
+Uses:
 
-## OS-level enforcement
+- Pass to providers that support path deny lists.
+- Warn during flow/profile validation.
+- Redact sensitive-looking data before Telegram notifications.
+- Instruct bundled profiles to avoid copying secrets into summaries.
 
-The sandbox is enforced by the engine at multiple layers:
-
-### Tier 1: MCP tool filtering (always active)
-
-The engine controls which MCP tools the agent can call. Tools that would violate sandbox are not exposed at all. The agent literally doesn't see them in its tool list.
-
-This is the primary enforcement layer.
-
-### Tier 2: Filesystem path checking (always active)
-
-For tools that take paths (`read_file`, `write_file`, `edit_file`):
-- Engine intercepts the tool call before forwarding to MCP server
-- Checks the path against allow/deny lists
-- Rejects with informative error if violated
-
-This catches cases where the agent tries to escape via path manipulation (e.g., `../../etc/passwd`).
-
-### Tier 3: OS sandboxing (best effort, OS-dependent)
-
-When available, the engine wraps shell subprocesses in OS-level sandboxes:
-
-- **Linux**: Landlock (kernel 5.13+) for filesystem; seccomp-bpf for syscalls; or `nsjail` if installed.
-- **macOS**: Seatbelt (`sandbox-exec`) with custom `.sb` profile
-- **Windows**: Job Objects + AppContainer (more limited)
-
-This prevents agents from escaping through subprocess spawn (e.g., `cargo build` → `build.rs` → arbitrary code).
-
-If OS sandbox is unavailable, engine logs a warning and proceeds with Tier 1+2 only. User is notified at run start.
-
-### Tier 4: Network isolation (best effort)
-
-For `workspace+network` and `full-access`:
-- DNS resolution restricted to allowlist (via `/etc/hosts` patching in nsjail, or DNS server override)
-- Outbound connections monitored; deny attempts to reach non-allowlisted IPs
-
-Like Tier 3, this is best-effort. On systems without nsjail, agents could theoretically bypass via direct IP calls, but this is impractical for typical agent workflows.
-
-## Approval policy
-
-Per-node approval policy:
-
-```toml
-[approvals]
-policy = "on-request"                 # untrusted | on-request | never
-
-# Granular flags
-sandbox_approval = true               # ask before sandbox elevation
-mcp_elicitations = false              # auto-confirm MCP server prompts
-request_permissions = true            # ask if agent requests new perms
-skill_approval = false                # auto-load safe skills
-elevation = true                      # always ask before full-access
-```
-
-### Policy levels
-
-- **`untrusted`** — every meaningful action requires approval. Used when running untrusted templates or third-party flows.
-- **`on-request`** — agent runs autonomously within sandbox, approvals requested only for elevation events. **Default for normal use.**
-- **`never`** — no approvals during this stage. Used for automated re-runs, CI integrations.
-
-### Granular flags
-
-Override the policy for specific event types:
-
-| Flag | Effect when `true` |
-|------|-------------------|
-| `sandbox_approval` | Ask before commands escape sandbox |
-| `mcp_elicitations` | MCP server can ask agent for input → forwarded to user |
-| `request_permissions` | Agent can request new tool/scope, ask user |
-| `skill_approval` | New skills require approval before use |
-| `elevation` | Always ask before sandbox raised to higher tier |
-
-Combination: `policy = on-request, elevation = true` (default) means: agent works autonomously, only pings for sandbox tier upgrades.
-
-## Sandbox elevation flow
-
-When an agent attempts an action outside its sandbox:
-
-1. **Detection**: Tool filter / path checker / OS sandbox catches the attempt.
-2. **Decision**: Engine checks node's `approvals.elevation`:
-   - `false` (auto-deny): write `SandboxElevationDecided { decision: deny }`, agent receives error.
-   - `true` (ask): write `SandboxElevationRequested`, send Telegram card, pause.
-3. **User response**: 
-   - `Allow once`: action proceeds, no template change.
-   - `Allow & remember`: action proceeds, template's allowlist is permanently extended.
-   - `Deny`: action fails with informative error to agent.
-4. **Resolution**: write `SandboxElevationDecided`, resume execution.
-
-The "remember" option makes the system **learn from user choices**. Each future run from the same template starts with broader allowlist, fewer pings.
+Telegram must never receive full source files, secret values, or raw environment dumps. It receives summaries, command snippets, metadata, and links to local views.
 
 ## Hooks
 
-Hooks are user-defined shell commands executed at lifecycle points. They cannot be invoked by the agent directly — they're triggered by the engine.
+Hooks are user-defined shell commands executed at lifecycle points. They cannot be invoked by the agent directly; they are triggered by the engine.
 
 ### Hook triggers
 
-- **`pre_tool_use`** — before agent calls a tool
-- **`post_tool_use`** — after tool returns successfully
-- **`on_outcome`** — after agent reports outcome (before engine routes)
-- **`on_error`** — when stage fails or retry attempted
+- **`pre_tool_use`** — before a provider-visible tool call is accepted by the engine/adapter, when available.
+- **`post_tool_use`** — after a tool returns successfully.
+- **`on_outcome`** — after agent reports outcome, before routing.
+- **`on_error`** — when stage fails or retry is attempted.
 
 ### Hook configuration
 
 ```toml
 [[hooks.entries]]
 trigger = "pre_tool_use"
-matcher = 'tool == "edit_file"'       # JS-like predicate
-command = "./.vibe/hooks/check_guard.sh ${TOOL_ARG_PATH}"
+matcher = 'tool == "edit_file"'
+command = "./.surge/hooks/check_guard.sh ${TOOL_ARG_PATH}"
 on_failure = "reject"                 # reject | warn | ignore
 timeout_seconds = 10
 inherit = "extend"                    # extend | replace | disable
 ```
 
-### Available context variables in hook commands
+Hook coverage depends on what the provider exposes. If a provider does not expose a tool event before execution, `pre_tool_use` cannot be guaranteed for that provider.
 
-- `${RUN_ID}` — current run ID
-- `${NODE_ID}` — current node
-- `${TOOL_NAME}` — for tool hooks
-- `${TOOL_ARG_*}` — tool argument values (e.g., `${TOOL_ARG_PATH}`)
-- `${OUTCOME_ID}` — for `on_outcome` hooks
-- `${WORKTREE}` — path to run's worktree
+## AGENTS.md Rules Files
 
-### Hook on_failure semantics
+`AGENTS.md` is used for context injection and project rules. Loading scope hierarchy:
 
-- **`reject`**: stage fails as if hook is part of the contract
-- **`warn`**: log a warning, continue
-- **`ignore`**: silent, continue
-
-For `on_outcome` hooks, `reject` causes outcome rejection (covered in RFC-0003): retry counter increments, agent gets another chance.
-
-### Hook inheritance
-
-Hooks combine across scopes (global → profile → project → node):
-
-- **`extend`** (default): node-level hooks add to inherited hooks
-- **`replace`**: node-level hooks replace inherited hooks at this trigger
-- **`disable`**: explicitly disable specific inherited hooks by ID
-
-This lets profiles ship reasonable defaults while allowing per-node opt-out.
-
-## AGENTS.md rules files
-
-`AGENTS.md` is the de facto standard for AI coding agent rules (Linux Foundation initiative). vibe-flow uses this format for context injection.
-
-### Loading scope hierarchy
-
-```
-1. ~/.vibe/AGENTS.md                          (global, user-level)
-2. <profile>/<role>.md or .toml [prompt.system] (profile-level)
-3. <project_root>/AGENTS.md                   (project-level)
-4. <subdir>/AGENTS.md                         (subdir-level, JIT)
+```text
+1. ~/.surge/AGENTS.md
+2. <profile>/<role>.md or .toml [prompt.system]
+3. <project_root>/AGENTS.md
+4. <subdir>/AGENTS.md
 ```
 
-Loaded in order, later overrides earlier. JIT (just-in-time) loading: subdir AGENTS.md is loaded only when an agent touches a file in that subdir, saving tokens.
-
-### Rule file format
-
-Standard markdown. Front matter optional for metadata:
-
-```markdown
----
-applies_to: ["**/*.rs"]
-priority: high
----
-
-# Project rules
-
-- All public functions must have rustdoc comments
-- No `unwrap()` outside `#[cfg(test)]`
-- Use `tracing` not `log` for logging
-```
-
-The `applies_to` pattern (if specified) restricts the rule to matching files. The agent sees rules only when they apply.
+Rules are loaded in order, later scopes override earlier scopes. Subdirectory rules can be loaded just-in-time when the agent touches relevant paths, if the provider supports mid-session context injection. Otherwise they are loaded at stage start.
 
 ### Trust state
 
-A rules file can be marked untrusted:
+Rules files imported from external sources start untrusted. Untrusted files are not loaded into agent context until the user trusts them.
 
-- Files imported from external sources start untrusted
-- User must explicitly trust them in the editor
-- Untrusted files are NOT loaded into agent context, regardless of scope
-
-Trust is per-file, persisted in `~/.vibe/trust.toml`:
+Trust is persisted globally:
 
 ```toml
 [[trusted]]
 path = "/home/user/projects/myapp/AGENTS.md"
 hash = "sha256:..."
 trusted_at = "2026-05-01T..."
-
-[[untrusted]]
-path = "/home/user/projects/myapp/imported/external-rules.md"
-reason = "Imported from external source, awaiting review"
 ```
 
-### Project trust
-
-A project (working directory) is also trusted/untrusted:
-
-- New project (first time `vibe run` is invoked): prompts for trust decision
-- Trusted: project's `AGENTS.md` and `.vibe/` configs are loaded
-- Untrusted: project hooks, rules, custom node types are skipped (Codex-style)
-
-Trust is project-path-based, persisted globally.
-
-## JIT context loading
-
-For large projects with many AGENTS.md files in subdirs:
-
-### Strategy
-
-Engine maintains a watch list of subdir AGENTS.md files (just paths, not content). When the agent reads or writes a file in a subdir, engine:
-
-1. Checks if there's an unloaded AGENTS.md in that subdir or its parents up to the loaded root.
-2. If yes, reads it, validates trust, prepends to next agent turn's context.
-3. Tracks "loaded" status to avoid re-reading.
-
-### Token budget
-
-Each profile has a `max_context_tokens` that JIT loading respects. If loading the new AGENTS.md would exceed budget, the engine either:
-- Skips loading (and logs warning)
-- Truncates oldest non-essential context to make room
-
-User-configurable via `auto_trim_oldest = true` (default).
-
-### Disabling JIT
-
-Set `[runtime].load_rules_lazily = false` in profile to load all AGENTS.md upfront. Useful for short runs where the up-front cost is acceptable and avoiding mid-run context shifts.
-
-## Notification channels (recap from RFC-0001 + sandbox angle)
+## Notification Channels
 
 Approvals can route through different channels in priority order:
 
@@ -338,60 +307,47 @@ Approvals can route through different channels in priority order:
 channels = [
   { type = "telegram", chat_id_ref = "$DEFAULT" },
   { type = "desktop", duration = "persistent" },
-  { type = "email", to_ref = "$USER_EMAIL" },     # fallback
+  { type = "email", to_ref = "$USER_EMAIL" },
 ]
-fallback_timeout_seconds = 1800                    # try next channel after 30 min
+fallback_timeout_seconds = 1800
 ```
 
-Critical for "user is away" scenarios: if Telegram delivery fails or user doesn't respond in 30 min, engine escalates to email or desktop notification.
+For the "user is away" scenario, Telegram is the primary channel. Desktop UI is a convenience, not a v0.1 dependency.
 
-## Audit log
+## Audit Log
 
-Every approval event is in the run's event log permanently. This is the audit trail:
+Every approval event is in the run event log permanently:
 
-- Who approved what (channel + decision)
-- When (seq + timestamp)
-- What was the context (the artifact being approved)
-- What changed in trust state ("Allow & remember" → which template extended)
+- Who approved what, by channel.
+- When it was approved.
+- What context was shown.
+- Whether policy changed because of "Allow & remember".
+- Which provider launch and sandbox settings were requested and which were actually applied.
 
-For compliance-conscious users, this gives a complete record. Future enterprise feature could export this to SIEM, but for v1 it's just the SQLite event log.
+This is the source of truth for replay, debugging, and trust decisions.
 
-## Open questions
+## Security Model
 
-### Network egress monitoring
+surge's v0.1 security model is honest and limited:
 
-Even with allowlist, an agent could exfiltrate data via DNS queries to allowed domains (e.g., encoding data in subdomain queries to a domain that has wildcard support). This is theoretical — in practice, mitigation:
+- It is an orchestrator, not a sandbox kernel.
+- It relies on the selected agent runtime for technical isolation.
+- It records what it requested from the provider.
+- It warns when the provider cannot honor the requested mode.
+- It keeps code and secrets local; Telegram receives summaries only.
 
-- Log all DNS queries
-- Pattern-match for suspicious patterns (high entropy, unusual subdomain structure)
-- Per-template "data egress concerns" flag that tightens monitoring
+For high-risk repositories, users should run surge inside a VM, container, WSL distro, or dedicated machine and choose an agent provider with the sandbox guarantees they need.
 
-For v1: log + pattern-match + warn. Active blocking is v2.
+## Acceptance Criteria
 
-### Sandbox escape via OS bugs
+The agent sandbox and approval system is correctly implemented when:
 
-The agent could find a kernel bug (in Landlock, seccomp) and escape. Mitigation: defense in depth — multiple tiers, with Tier 1 (MCP filtering) being the strongest. Even if Tier 3 is bypassed, the agent has limited tool access.
-
-For high-stakes work (production systems), users should run vibe-flow in a VM or container. Document this in security best practices.
-
-### Approval forgery
-
-A malicious actor with access to user's Telegram could approve runs. Mitigations:
-- Two-factor approval for elevation events (Telegram + desktop confirmation)
-- Approval signing (require user to type a confirmation phrase for sensitive operations)
-
-For v1: Telegram-only. Two-factor is opt-in v2.
-
-## Acceptance criteria
-
-The sandbox and approval system is correctly implemented when:
-
-1. An Implementer node with default `workspace-write` sandbox cannot write outside the worktree (verified via attempted escapes in test).
-2. Trying to access `~/.ssh/` from any sandbox mode is denied at Tier 1 + Tier 2 + Tier 3.
-3. Sandbox elevation request reaches Telegram within 5 seconds of the agent's blocked attempt.
-4. "Allow & remember" persists the new allowlist entry in the template, verified by inspecting template TOML after run.
-5. AGENTS.md JIT loading saves measurable tokens vs. eager loading on a 100-file project (test fixture).
-6. Untrusted AGENTS.md files are NOT included in agent context, verified by token-level inspection.
-7. Hooks fire reliably and reject failed outcomes per `on_failure` policy.
-8. OS sandbox enforcement works on Linux (Landlock available), macOS (sandbox-exec), and Windows (Job Objects).
-9. End-to-end: a 30-minute autonomous run with default `workspace-write` produces zero approval requests beyond the 3 declared HumanGates.
+1. Profiles can declare launch configuration and sandbox intent, and validation checks both against provider capability metadata.
+2. Starting a session records requested and applied launch/sandbox settings in the event log.
+3. Unsupported launch or sandbox modes fail with a clear diagnostic unless `provider-default` or explicit opt-in is selected.
+4. A mock provider permission request reaches Telegram within 5 seconds.
+5. Telegram `Allow once`, `Allow & remember`, and `Deny` decisions are written to the event log and returned to the mock provider.
+6. "Allow & remember" persists a profile/template policy change and is visible in later validation.
+7. Secret filtering catches common API key patterns before Telegram delivery.
+8. `surge doctor` reports provider sandbox capabilities and warns about unsupported or unknown behavior.
+9. End-to-end: a 30-minute autonomous run with default `workspace-write` produces zero approval requests beyond declared HumanGates and provider-native permission requests.

--- a/docs/revision/rfcs/0007-telegram-bot.md
+++ b/docs/revision/rfcs/0007-telegram-bot.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The Telegram bot is the primary approval channel for vibe-flow runs. It implements the "describe and walk away" experience by delivering inline-keyboard approval cards on the user's phone, allowing them to make decisions in seconds without a computer.
+The Telegram bot is the primary approval channel for surge runs. It implements the "describe and walk away" experience by delivering inline-keyboard approval cards on the user's phone, allowing them to make decisions in seconds without a computer.
 
 This document specifies:
 - Bot architecture and lifecycle
@@ -18,16 +18,16 @@ This document specifies:
 
 ```
 ┌─────────────────────────────────────────────────┐
-│ vibe-flow daemon (per-run subprocess)           │
+│ surge daemon (per-run subprocess)           │
 │  ↓ "approval needed" event                       │
 │                                                  │
-│ vibe-flow telegram service (singleton)           │
+│ surge telegram service (singleton)           │
 │  ├─ Outgoing: format card, send via Bot API      │
 │  └─ Incoming: webhook or long-poll for replies   │
 │       ↓ user tapped button                       │
 │  ↓ "approval decided" event                      │
 │                                                  │
-│ vibe-flow daemon                                 │
+│ surge daemon                                 │
 └─────────────────────────────────────────────────┘
 ```
 
@@ -54,25 +54,25 @@ This avoids needing a network connection between bot service and daemon — they
 
 First-time bot connection (one-time per user):
 
-1. User runs `vibe telegram setup`
+1. User runs `surge telegram setup`
 2. CLI shows a URL: `https://t.me/<your-bot-name>?start=<ephemeral-token>`
 3. User opens URL on phone, taps "Start"
 4. Bot receives `/start <token>` and binds the user's chat_id to the token
-5. CLI polls for binding completion, stores `chat_id` in `~/.vibe/config.toml`
+5. CLI polls for binding completion, stores `chat_id` in `~/.surge/config.toml`
 6. CLI displays "Connected — chat ID 12345" and exits
 
 After this, all approvals route to that chat_id by default.
 
 ### Token rotation
 
-The bot's API token is read from environment variable `VIBE_TELEGRAM_BOT_TOKEN` or from `~/.vibe/secrets.toml` (mode 0600). Rotation: update the secret, restart bot service.
+The bot's API token is read from environment variable `SURGE_TELEGRAM_BOT_TOKEN` or from `~/.surge/secrets.toml` (mode 0600). Rotation: update the secret, restart bot service.
 
 ### Multiple users
 
 For a single user, single chat_id — sufficient for v1. For shared projects (future), configurable per-project chat IDs:
 
 ```toml
-# ~/.vibe/config.toml
+# ~/.surge/config.toml
 default_chat_id = 123456789
 
 [[chat_overrides]]
@@ -296,7 +296,7 @@ Initiates a run from Telegram chat:
 3. Engine starts daemon, run begins
 4. Description Author proceeds, bot will send approval cards as usual
 
-The "current project" is the project most recently used (tracked in `~/.vibe/state.toml`). To run in a different project, user can specify:
+The "current project" is the project most recently used (tracked in `~/.surge/state.toml`). To run in a different project, user can specify:
 
 ```
 /run --project /path/to/other "fix bug in parser"
@@ -336,11 +336,11 @@ For local-first single-user setup, **long-poll** is recommended:
 
 For users running on a server with public IP:
 - Webhook recommended (more efficient)
-- Configurable in `~/.vibe/config.toml`:
+- Configurable in `~/.surge/config.toml`:
   ```toml
   [telegram]
   mode = "webhook"
-  webhook_url = "https://my-domain.com/vibe/tg-webhook"
+  webhook_url = "https://my-domain.com/surge/tg-webhook"
   webhook_secret_token = "..."  # for request validation
   ```
 
@@ -414,7 +414,7 @@ Filtering is best-effort. Users should not embed secrets in approval-relevant ar
 
 ## Bot identity
 
-The bot displays as `vibe·flow` with profile image (custom avatar shipped with project). Bot username is unique per user (e.g., `vibe_flow_<user_initials>_bot`) to avoid conflicts.
+The bot displays as `surge` with profile image (custom avatar shipped with project). Bot username is unique per user (e.g., `surge_<user_initials>_bot`) to avoid conflicts.
 
 For multi-user installations on shared servers: each user creates their own bot via @BotFather, gets unique token.
 
@@ -422,7 +422,7 @@ For multi-user installations on shared servers: each user creates their own bot 
 
 The Telegram bot is correctly implemented when:
 
-1. `vibe telegram setup` completes binding within 30 seconds.
+1. `surge telegram setup` completes binding within 30 seconds.
 2. Bootstrap approval cards arrive within 5 seconds of stage completion.
 3. Inline button taps result in `ApprovalDecided` event within 2 seconds.
 4. Slash commands `/run`, `/list`, `/status`, `/cancel`, `/replay`, `/help` all work as specified.

--- a/docs/revision/rfcs/0008-ui-architecture.md
+++ b/docs/revision/rfcs/0008-ui-architecture.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-vibe-flow has two desktop UIs:
+surge has two desktop UIs:
 
 1. **Editor** — for building and editing pipeline graphs (canvas-based, egui)
 2. **Runtime / Replay** — for monitoring active runs and reviewing finished ones (gpui)
@@ -42,7 +42,7 @@ Build and edit pipeline graphs visually. Open existing `flow.toml`, modify, save
 
 ```
 ┌─────────────────────────────────────────────────────────────┐
-│ TOP BAR · vibe·flow editor · ~/projects/myapp/flow.toml [💾]│
+│ TOP BAR · surge editor · ~/projects/myapp/flow.toml [💾]│
 ├──────────┬──────────────────────────────────┬───────────────┤
 │ SIDEBAR  │                                  │ INSPECTOR     │
 │          │                                  │               │
@@ -266,20 +266,20 @@ Sidebar shows list of active and recent runs. Switching between them swaps the e
 ### Commands
 
 ```
-vibe init                         # initialize project (creates pipeline.toml or selects template)
-vibe run <description>            # start a new run
-vibe run --template <name> <desc> # use specific template, skip bootstrap
-vibe list                         # list runs (active + recent)
-vibe status <run_id>              # show current state of a run
-vibe attach <run_id>              # tail logs of a running run
-vibe cancel <run_id>              # abort a run
-vibe replay <run_id>              # open replay mode in runtime UI
-vibe fork <run_id> --at <seq>     # fork from event seq
-vibe profile <subcmd>             # profile management
-vibe template <subcmd>            # template management
-vibe telegram setup               # set up Telegram bot
-vibe telegram test                # send test message
-vibe doctor                       # diagnose common issues
+surge init                         # initialize project (creates pipeline.toml or selects template)
+surge run <description>            # start a new run
+surge run --template <name> <desc> # use specific template, skip bootstrap
+surge list                         # list runs (active + recent)
+surge status <run_id>              # show current state of a run
+surge attach <run_id>              # tail logs of a running run
+surge cancel <run_id>              # abort a run
+surge replay <run_id>              # open replay mode in runtime UI
+surge fork <run_id> --at <seq>     # fork from event seq
+surge profile <subcmd>             # profile management
+surge template <subcmd>            # template management
+surge telegram setup               # set up Telegram bot
+surge telegram test                # send test message
+surge doctor                       # diagnose common issues
 ```
 
 ### Output formats
@@ -290,13 +290,13 @@ vibe doctor                       # diagnose common issues
 
 ### Daemon mode
 
-`vibe run` starts a daemon subprocess for the run that persists across CLI invocations. CLI returns control immediately after run starts. Subsequent `vibe attach` reconnects to view live progress.
+`surge run` starts a daemon subprocess for the run that persists across CLI invocations. CLI returns control immediately after run starts. Subsequent `surge attach` reconnects to view live progress.
 
 Daemon lifecycle:
 - Linux/macOS: daemon detaches via `setsid`, parent process can exit
 - Windows: spawned as detached process
 
-Daemon writes PID + status to `~/.vibe/runs/<run_id>/.daemon`. CLI uses this to communicate.
+Daemon writes PID + status to `~/.surge/runs/<run_id>/.daemon`. CLI uses this to communicate.
 
 ## Cross-cutting concerns
 
@@ -347,7 +347,7 @@ Runtime remembers:
 - Per-run scrubber position
 - Selected bottom panel tab
 
-State stored in `~/.vibe/ui-state.toml`.
+State stored in `~/.surge/ui-state.toml`.
 
 ## Implementation phasing
 
@@ -399,7 +399,7 @@ The UI architecture is correctly implemented when:
 
 1. Editor binary opens any valid `flow.toml` and renders it correctly with all node types, edges, and positions.
 2. Editing on canvas (add/move/delete nodes, connect ports) saves valid `flow.toml`.
-3. Runtime binary connects to a live run within 2 seconds of `vibe attach`.
+3. Runtime binary connects to a live run within 2 seconds of `surge attach`.
 4. Live updates render at 60fps for runs producing up to 10 events/second.
 5. Replay scrubber smoothly transitions between events with state correctly snapshotted at any cursor position.
 6. Fork-from-here creates a new run with state matching the cursor position, verified by event log comparison.

--- a/docs/superpowers/plans/2026-05-02-surge-core-m1-adaptation.md
+++ b/docs/superpowers/plans/2026-05-02-surge-core-m1-adaptation.md
@@ -2,7 +2,7 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Add the vibe-flow data model (graph, events, profiles, state machine) to `surge-core` via pure addition, without breaking any existing consumer.
+**Goal:** Add the Surge data model (graph, events, profiles, state machine) to `surge-core` via pure addition, without breaking any existing consumer.
 
 **Architecture:** Flat module layout — 19 new files at `surge-core/src/` next to legacy modules. Domain-key for stable string keys (`NodeKey`, `EdgeKey`, `OutcomeKey`, `SubgraphKey`, `ProfileKey`, `TemplateKey`); existing ULID `define_id!` macro for runtime IDs (`RunId`, `SessionId`); dedicated `ContentHash` newtype. `RunState::Pipeline` holds `Arc<Graph>` from the start. Subgraphs flat-stored at root level via `SubgraphKey` references (no `Box<Graph>` recursion).
 
@@ -93,7 +93,7 @@ Expected: compiles cleanly (no missing-dep errors). If `domain-key` API doesn't 
 
 ```bash
 git add Cargo.toml crates/surge-core/Cargo.toml
-git commit -m "chore(surge-core): add deps for vibe-flow data model
+git commit -m "chore(surge-core): add deps for Surge data model
 
 domain-key for stable string keys, chrono for timestamps, toml_edit for
 edit-aware writes, sha2+hex for ContentHash, bincode for event log,
@@ -133,7 +133,7 @@ Edit `crates/surge-core/src/lib.rs`. Add `pub mod keys;` between `pub mod id;` a
 Create `crates/surge-core/src/keys.rs` with this content:
 
 ```rust
-//! Domain-keyed identifiers for vibe-flow graph entities.
+//! Domain-keyed identifiers for Surge graph entities.
 //!
 //! These keys are *user-typed strings* in `flow.toml` (e.g., `"impl_2"`,
 //! `"done"`). For *runtime-generated* IDs (`RunId`, `SessionId`) see [`crate::id`].
@@ -427,7 +427,7 @@ Run `cat crates/surge-core/src/id.rs` to see the existing `define_id!` macro and
 Edit `crates/surge-core/src/id.rs`. After `define_id!(SubtaskId, "sub");` add:
 
 ```rust
-// New runtime IDs added in M1 for vibe-flow data model.
+// New runtime IDs added in M1 for Surge data model.
 define_id!(RunId, "run");
 define_id!(SessionId, "session");
 ```
@@ -486,7 +486,7 @@ Expected: existing id tests pass + 4 new tests pass.
 git add crates/surge-core/src/id.rs crates/surge-core/src/lib.rs
 git commit -m "feat(surge-core): add RunId and SessionId via define_id!
 
-ULID-based runtime IDs for the vibe-flow event log. Same macro as legacy
+ULID-based runtime IDs for the Surge event log. Same macro as legacy
 SpecId/TaskId/SubtaskId — consistent prefix-display, FromStr semantics.
 
 Part of M1."
@@ -4474,7 +4474,7 @@ Run: `cargo test -p surge-core --lib error`. Expected: existing tests + 2 new = 
 
 Commit:
 ```
-feat(surge-core): extend SurgeError with new variants for vibe-flow
+feat(surge-core): extend SurgeError with new variants for Surge
 
 GraphValidation (carries Vec<ValidationError>), EventFold (#[from]
 FoldError), ProfileParse, ContentHashMismatch. Existing variants
@@ -4507,7 +4507,7 @@ pub mod roadmap;
 pub mod spec;
 pub mod state;
 
-// New modules — vibe-flow data model.
+// New modules — Surge data model.
 pub mod agent_config;
 pub mod approvals;
 pub mod branch_config;
@@ -4540,7 +4540,7 @@ pub use roadmap::{Priority, RoadmapItem, RoadmapStatus, Timeline, TimelineBatch}
 pub use spec::{AcceptanceCriteria, Complexity, Spec, Subtask, SubtaskExecution, SubtaskState};
 pub use state::TaskState;
 
-// ── New re-exports (vibe-flow data model) ──
+// ── New re-exports (Surge data model) ──
 pub use content_hash::ContentHash;
 pub use edge::{Edge, EdgeKind, EdgePolicy, ExceededAction, PortRef};
 pub use graph::{Graph, GraphMetadata, Subgraph, SCHEMA_VERSION};
@@ -4570,7 +4570,7 @@ Expected: all green. Any clippy warnings — fix them in their respective files 
 - [ ] **Step 3: Commit**
 
 ```
-chore(surge-core): finalize lib.rs re-exports for vibe-flow data model
+chore(surge-core): finalize lib.rs re-exports for Surge data model
 
 All new types reachable from crate root: ContentHash, Edge*, Graph*,
 *Key (5 domain-keys), Node*, Profile*, RunEvent*, RunState*, validate.
@@ -4998,7 +4998,7 @@ Part of M1."
 
 - [ ] **Step 1: Pick a real project's roadmap**
 
-Pick the author's `domain-key` crate (or another real project the author maintains). Read its existing roadmap or task plan; mentally translate the milestones into a vibe-flow graph: a Milestone Loop over the listed milestones with an inner Task Loop per milestone's tasks. Write it as `flow.toml` based on the structure from `nested-3-levels.toml`.
+Pick the author's `domain-key` crate (or another real project the author maintains). Read its existing roadmap or task plan; mentally translate the milestones into a Surge graph: a Milestone Loop over the listed milestones with an inner Task Loop per milestone's tasks. Write it as `flow.toml` based on the structure from `nested-3-levels.toml`.
 
 If no real roadmap exists, use Surge's own roadmap (see `docs/03-ROADMAP.md`) — describe its milestones as graph nodes.
 

--- a/docs/superpowers/plans/2026-05-02-surge-persistence-m2.md
+++ b/docs/superpowers/plans/2026-05-02-surge-persistence-m2.md
@@ -246,7 +246,7 @@ In `crates/surge-core/src/lib.rs`, after the `pub mod run_state;` line, add:
 pub mod run_status;
 ```
 
-In the "New re-exports (vibe-flow data model)" block near the bottom of `lib.rs`, add:
+In the "New re-exports (Surge data model)" block near the bottom of `lib.rs`, add:
 
 ```rust
 pub use run_status::{ParseRunStatusError, RunStatus};
@@ -389,7 +389,7 @@ Also add `workspace = true` for `surge-core` if not already, and update `[packag
 `crates/surge-persistence/src/runs/mod.rs`:
 
 ```rust
-//! Per-run SQLite event store and registry for the vibe-flow architecture.
+//! Per-run SQLite event store and registry for the Surge architecture.
 //!
 //! This module is the M2 milestone of the surge-persistence layer. It lives
 //! alongside the existing legacy persistence (aggregator/budget/memory/
@@ -657,7 +657,7 @@ mod tests {
 In `crates/surge-persistence/src/lib.rs`, after the existing `pub mod store;` line, add:
 
 ```rust
-/// New M2 vibe-flow storage layer (per-run event log, registry, worktree integration).
+/// New M2 Surge storage layer (per-run event log, registry, worktree integration).
 pub mod runs;
 ```
 
@@ -684,7 +684,7 @@ Expected: both clean.
 git add crates/surge-persistence/Cargo.toml crates/surge-persistence/src/lib.rs crates/surge-persistence/src/runs/
 git commit -m "M2(persistence): scaffold runs/ module with errors, EventSeq, Clock
 
-Empty skeleton for the new vibe-flow storage layer. Adds error enums
+Empty skeleton for the new Surge storage layer. Adds error enums
 (OpenError, StorageError, WriterError, CloseError), EventSeq newtype,
 and a small Clock trait (SystemClock + MockClock) for deterministic
 test timestamps. Legacy modules untouched."
@@ -5348,7 +5348,7 @@ cargo clippy -p surge-core --all-targets -- -D warnings ✓
 cargo doc with -D warnings on persistence/git/core ✓
 rustfmt --check on new files ✓
 
-Closes M2 milestone of vibe-flow roadmap."
+Closes M2 milestone of Surge roadmap."
 ```
 
 ---

--- a/docs/superpowers/plans/2026-05-03-surge-acp-bridge-m3.md
+++ b/docs/superpowers/plans/2026-05-03-surge-acp-bridge-m3.md
@@ -2,7 +2,7 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Add `surge-acp::bridge` submodule (AcpBridge, BridgeClient, BridgeEvent broadcast, sandbox stub, mock ACP agent) to enable vibe-flow ACP integration without disturbing the legacy ACP stack.
+**Goal:** Add `surge-acp::bridge` submodule (AcpBridge, BridgeClient, BridgeEvent broadcast, sandbox stub, mock ACP agent) to enable Surge ACP integration without disturbing the legacy ACP stack.
 
 **Architecture:** Pure-addition strategy following the M1/M2 precedent. New `bridge/` submodule lives inside `surge-acp` next to legacy modules; private `shared/` helpers are extracted from legacy `client.rs` so both legacy and bridge can reuse them. Bridge runs its own dedicated OS thread with current-thread tokio runtime + `LocalSet` for the `!Send` ACP futures, isolated from the legacy `AgentPool`. Two-method `Sandbox` trait surface (`visibility` + `allows_tool`) ships with `AlwaysAllowSandbox` and `DenyListSandbox`; tier-3 OS enforcement deferred to M4. Engine integration (translating `BridgeEvent` → `EventPayload` and appending via `RunWriter`) lives in M5; M3 ships only the bridge layer plus a mock ACP agent that drives every code path end-to-end.
 
@@ -96,7 +96,7 @@ The binary file lands in Phase 9. Cargo will refuse to compile right now because
 Create `crates/surge-acp/src/bridge/mod.rs`:
 
 ```rust
-//! Vibe-flow ACP bridge.
+//! Surge ACP bridge.
 //!
 //! Pure-addition submodule introduced in M3. Coexists with the legacy
 //! `AgentPool` / `SurgeClient` stack at the crate root; consumers pick the
@@ -127,7 +127,7 @@ Create `crates/surge-acp/src/bridge/mod.rs`:
 Open `crates/surge-acp/src/lib.rs`. After the existing `pub mod transport;` line (currently the last `pub mod`), add:
 
 ```rust
-// New (M3) — vibe-flow ACP bridge. Pure addition, legacy modules untouched.
+// New (M3) — Surge ACP bridge. Pure addition, legacy modules untouched.
 pub mod bridge;
 mod shared;
 ```

--- a/docs/superpowers/plans/2026-05-03-surge-orchestrator-engine-m5.md
+++ b/docs/superpowers/plans/2026-05-03-surge-orchestrator-engine-m5.md
@@ -6877,7 +6877,7 @@ Expected: every step succeeds. M5 complete.
 
 ```bash
 git push -u origin claude/m5-engine
-gh pr create --title "M5: surge-orchestrator engine — closes vibe-flow loop" --body "$(cat <<'EOF'
+gh pr create --title "M5: surge-orchestrator engine — closes Surge loop" --body "$(cat <<'EOF'
 ## Summary
 - Engine drives a `Graph` through `AcpBridge` sessions and persists to `surge-persistence`
 - Sequential pipeline; parallel/loops/subgraphs deferred to M6

--- a/docs/superpowers/plans/2026-05-04-surge-orchestrator-engine-m6.md
+++ b/docs/superpowers/plans/2026-05-04-surge-orchestrator-engine-m6.md
@@ -2435,7 +2435,7 @@ async fn resolve_iterable(src: &IterableSource, memory: &RunMemory) -> Result<Ve
                 .map_err(|e| StageError::Internal(format!("read artifact {}: {e}", artifact.path.display())))?;
 
             // M6 supports TOML artifacts with a simple dotted path.
-            // (JSON support could be added later; current vibe-flow artifacts
+            // (JSON support could be added later; current Surge artifacts
             // are TOML by convention — see CLAUDE.md.)
             let content = std::str::from_utf8(&bytes)
                 .map_err(|e| StageError::Internal(format!("artifact {} not utf8: {e}", artifact.path.display())))?;

--- a/docs/superpowers/specs/2026-05-02-surge-core-m1-adaptation-design.md
+++ b/docs/superpowers/specs/2026-05-02-surge-core-m1-adaptation-design.md
@@ -1,4 +1,4 @@
-# M1 — `surge-core` adaptation toward vibe-flow data model
+# M1 — `surge-core` adaptation toward Surge data model
 
 > Status: design (approved 2026-05-02)
 > Scope: milestone M1 from [docs/revision/ROADMAP.md](../../revision/ROADMAP.md) — adapted for in-place evolution of Surge.
@@ -6,7 +6,7 @@
 
 ## 1. Goal
 
-Add the foundational data model for the new vibe-flow architecture (graph-based pipelines, event-sourced runs, profile registry) into `surge-core` **without breaking any existing consumer**. After this milestone:
+Add the foundational data model for the new Surge architecture (graph-based pipelines, event-sourced runs, profile registry) into `surge-core` **without breaking any existing consumer**. After this milestone:
 
 - New types `Graph`, `Node`, `Edge`, `Profile`, `RunEvent`, `RunState` are public API of `surge-core`.
 - TOML round-trip for `Graph` and `Profile` works.
@@ -15,7 +15,7 @@ Add the foundational data model for the new vibe-flow architecture (graph-based 
 - The fold function `apply(state, &event) -> RunState` is pure and deterministic.
 - All existing types (`SurgeConfig`, `TaskState`, `Spec`, `SurgeEvent`, etc.) remain unchanged and untouched.
 
-The vibe-flow name is an internal codename for the new architecture; the project, crate names, and public branding stay **Surge**.
+The old internal codename has been retired; the project, crate names, and public branding stay **Surge**.
 
 ## 2. Strategy
 
@@ -24,7 +24,7 @@ The vibe-flow name is an internal codename for the new architecture; the project
 Decisions locked in during brainstorming:
 
 - **Pure addition.** No `#[deprecated]` attributes, no module renames. Both old and new types coexist in `surge-core`. Migration of consumers (orchestrator, CLI, persistence) happens in later milestones, file by file.
-- **Flat module structure.** All new modules live directly under `surge-core/src/` next to existing files. No `vibe::` / `flow::` sub-namespace. Rationale: simpler imports, IDE navigation by filename, consistent with the existing flat layout.
+- **Flat module structure.** All new modules live directly under `surge-core/src/` next to existing files. No `surge::` / `flow::` sub-namespace. Rationale: simpler imports, IDE navigation by filename, consistent with the existing flat layout.
 - **One spec, phased implementation.** This document is the single design contract for all of M1; the implementation plan (produced via `superpowers:writing-plans` after this spec is approved) sequences the work into reviewable chunks.
 
 ### 2.2 ID strategy — split by semantics

--- a/docs/superpowers/specs/2026-05-02-surge-persistence-m2-design.md
+++ b/docs/superpowers/specs/2026-05-02-surge-persistence-m2-design.md
@@ -1,4 +1,4 @@
-# M2 — `surge-persistence` storage layer for vibe-flow event log
+# M2 — `surge-persistence` storage layer for Surge event log
 
 **Status:** Design
 **Date:** 2026-05-02

--- a/docs/superpowers/specs/2026-05-03-surge-acp-bridge-m3-design.md
+++ b/docs/superpowers/specs/2026-05-03-surge-acp-bridge-m3-design.md
@@ -1,4 +1,4 @@
-# M3 — `surge-acp` bridge for vibe-flow ACP integration
+# M3 — `surge-acp` bridge for Surge ACP integration
 
 **Status:** Design
 **Date:** 2026-05-03
@@ -9,7 +9,7 @@
 
 ## 1. Goal
 
-Add a vibe-flow-shaped ACP bridge to `surge-acp` as a new `bridge` submodule, alongside the existing legacy stack (`AgentPool`, `AgentConnection`, `SurgeClient`, `Registry`, `AgentDiscovery`, `HealthTracker`, `AgentRouter`). Pure-addition strategy, same as M1 and M2.
+Add a Surge-shaped ACP bridge to `surge-acp` as a new `bridge` submodule, alongside the existing legacy stack (`AgentPool`, `AgentConnection`, `SurgeClient`, `Registry`, `AgentDiscovery`, `HealthTracker`, `AgentRouter`). Pure-addition strategy, same as M1 and M2.
 
 This milestone unblocks M5 (engine), which needs to:
 
@@ -64,7 +64,7 @@ Per the migration-strategy decision (no parallel "v1"/"v2" crates), all M3 code 
 
 The legacy `AgentPool::worker` thread runs its own `LocalSet`. The bridge spawns a **separate** OS thread with a fresh current-thread tokio runtime + `LocalSet`. Reasons:
 
-1. **Lifecycle independence.** Legacy `AgentPool` and the new `AcpBridge` are owned by different consumers (legacy orchestrator vs vibe-flow engine). Sharing one worker would couple their lifetimes — dropping the bridge would have to consider whether legacy callers are still using the same worker.
+1. **Lifecycle independence.** Legacy `AgentPool` and the new `AcpBridge` are owned by different consumers (legacy orchestrator vs Surge engine). Sharing one worker would couple their lifetimes — dropping the bridge would have to consider whether legacy callers are still using the same worker.
 2. **State isolation.** Legacy `WorkerState` (connections keyed by agent name, health, resilience config) is structurally different from `BridgeState` (sessions keyed by `SessionId`, tool injection per session, sandbox per session). Trying to share would force a union type.
 3. **Backpressure independence.** `mpsc::channel(64)` for the bridge can fill up under heavy session traffic without blocking legacy ping/prompt commands or vice versa.
 
@@ -903,7 +903,7 @@ impl Sandbox for AlwaysAllowSandbox {
 }
 ```
 
-Used by mock-agent integration tests, by `vibe doctor` smoke tests, and by the local development default (`SessionConfig::dev()` factory in M5).
+Used by mock-agent integration tests, by `surge doctor` smoke tests, and by the local development default (`SessionConfig::dev()` factory in M5).
 
 ### 6.2 `DenyListSandbox`
 

--- a/docs/superpowers/specs/2026-05-03-surge-orchestrator-engine-m5-design.md
+++ b/docs/superpowers/specs/2026-05-03-surge-orchestrator-engine-m5-design.md
@@ -2,7 +2,7 @@
 
 > Scope: milestone M5 — engine that drives a frozen `Graph` through `AcpBridge`
 > sessions, persists every observable transition into `surge-persistence`, and
-> resumes from the latest snapshot after a crash. Closes the vibe-flow loop:
+> resumes from the latest snapshot after a crash. Closes the Surge loop:
 > M1 (data) + M2 (storage) + M3 (bridge) → working autonomous runs.
 
 ## 1. Goals & non-goals
@@ -80,7 +80,7 @@
 ### 2.1 Pure addition strategy (mirrors M1 / M2 / M3)
 
 The legacy `surge-orchestrator::{pipeline, phases, executor, parallel, planner,
-qa, retry, schedule}` modules are FSM-based and predate the vibe-flow data
+qa, retry, schedule}` modules are FSM-based and predate the Surge data
 model. M5 does not modify them. A new `engine` submodule is added alongside,
 with no public re-exports that could shadow legacy names. The crate's
 `lib.rs` adds one line: `pub mod engine;`.


### PR DESCRIPTION
## Summary

- Rewrites the top-level README around the current Surge architecture, target AFK workflow, flow model, intake sources, roadmap amendments, runtime architecture, and CLI surface.
- Adds Mermaid diagrams for project bootstrap, feature flow, roadmap loops, intake normalization, runtime architecture, and run lifecycle.
- Aligns `docs/revision` and crate-level documentation comments with the newer graph-engine, daemon, intake, profile, sandbox, and Telegram direction.
- Clarifies current CLI commands versus target product commands, including where `surge spec`, `surge run`, and `surge engine run` fit today.

## Impact

This is documentation-oriented. It should make the repo easier to understand for contributors by separating implemented behavior from target product UX and by calling out current gaps such as `surge project describe`, `surge feature`, GitHub Issues intake, and Linear intake.

## Validation

- `git diff --check origin/main..HEAD`
- `cargo test --workspace --exclude surge-ui`