### PR TITLE
[codex] Complete Graph engine GA gates

### DIFF
--- a/.ai-factory/plans/feature-graph-engine-ga.md
+++ b/.ai-factory/plans/feature-graph-engine-ga.md
@@ -254,7 +254,7 @@ This plan does **not** touch already-working code paths except where wiring requ
 - **Logging:** INFO `[test][archetype]` per archetype start; DEBUG on event count.
 - **Depends on:** 4.1, 4.2, 4.3.
 
-#### Task 5.2 — Real-ACP smoke test (gated)
+#### [x] Task 5.2 — Real-ACP smoke test (gated)
 
 - **Deliverable:** A real-agent smoke test that runs `flow_minimal_agent.toml` against an actual ACP-conformant agent binary (Claude Code or Codex CLI), gated by env vars (`SURGE_REAL_ACP_BIN` and `SURGE_REAL_ACP_PROFILE`). When the env is absent, the test is skipped with a clear message — CI green path does not require a real agent. When env is present, the test asserts the run reaches `RunCompleted` and at least one `TokensConsumed` event is recorded.
 - **Files:**
@@ -264,7 +264,7 @@ This plan does **not** touch already-working code paths except where wiring requ
 - **Logging:** INFO on agent binding selection.
 - **Notes:** Per `decide-or-defer` rule: this test is genuine, opt-in, and complete — it is not a stub. The roadmap's "real agent" verification is satisfied by enabling this test in a developer's local environment. The deterministic CI path is covered by the `mock_acp_agent` subprocess in 5.1.
 
-#### Task 5.3 — Criterion bench: stage-transition p95 with CI regression gate
+#### [x] Task 5.3 — Criterion bench: stage-transition p95 with CI regression gate
 
 - **Deliverable:** A criterion bench measuring the transition latency `StageEntered → OutcomeReported → EdgeTraversed` for a `Branch` node (synchronous, no agent). p95 budget: documented as a numeric value derived from a baseline run (decision: take the p95 of the first clean baseline plus 25% headroom, encoded as `P95_BUDGET_US` constant in the bench source). CI runs `cargo bench --bench stage_transition -- --save-baseline ci` and a small Rust harness compares the latest run against the baseline; regression > 25% fails the job.
 - **Files:**
@@ -290,7 +290,7 @@ This plan does **not** touch already-working code paths except where wiring requ
 - **Logging:** N/A.
 - **Depends on:** 1.5, 2.x, 3.x, 4.x, 5.x.
 
-#### Task 6.2 — GA acceptance check and CHANGELOG entry
+#### [x] Task 6.2 — GA acceptance check and CHANGELOG entry
 
 - **Deliverable:** Run the full local acceptance suite, document results, and draft the changelog. Then commit and push the milestone branch.
   - `cargo build --workspace --exclude surge-ui` — clean.

--- a/.ai-factory/plans/feature-graph-engine-ga.md
+++ b/.ai-factory/plans/feature-graph-engine-ga.md
@@ -1,0 +1,343 @@
+# Plan: Graph Engine GA
+
+**Branch:** `feature-graph-engine-ga`
+**Created:** 2026-05-06
+**Refined:** 2026-05-06 (second iteration via `/aif-improve`)
+**Mode:** Full
+**Source roadmap milestone:** [Graph engine GA](../ROADMAP.md)
+
+## Settings
+
+- **Testing:** yes — every behavioral change ships with a covering test (unit, integration, or proptest as appropriate). New tests must be deterministic and runnable in CI without networked dependencies.
+- **Logging:** verbose — DEBUG for hook resolution, fold transitions, IPC frames; INFO for stage entry/exit, run lifecycle, daemon attach/detach; WARN for hook reject, retry exhaustion, schema-version downgrade attempts; ERROR for unsupported migrations and IPC framing failures. Use `tracing::*` macros only — no `println!` / `dbg!` in library crates.
+- **Docs:** yes — mandatory documentation checkpoint at completion. Updates routed through `/aif-docs`.
+
+## Roadmap Linkage
+
+- **Milestone:** "Graph engine GA"
+- **Rationale:** This plan delivers every remaining sub-bullet of the **Graph engine GA** roadmap milestone — hook execution chain, replay determinism proptest, schema-version migration chain, daemon-attached path completion, archetype example library, integration / criterion gates, and the documentation cut. NodeKind handlers, injected tools, and the M6 validation surface are already complete on `main` (see "Existing State" section); this plan finishes the remaining workstreams that gate `Graph engine GA → done`.
+
+## Existing State (already on `main`)
+
+Confirmed via two rounds of codebase exploration before drafting and refining this plan:
+
+- All seven NodeKind handlers fully wired in `crates/surge-orchestrator/src/engine/stage/{agent,branch,human_gate,loop_stage,notify,subgraph_stage,terminal}.rs`.
+- `BridgeCommand` (6 variants) and `BridgeEvent` (9 variants) defined in `crates/surge-acp/src/bridge/{command,event}.rs`. `BridgeCommand::ReplyToTool { session, call_id, payload, ... }` already wired with `ToolResultPayload::{Ok, Error, Unsupported}` (`crates/surge-acp/src/bridge/event.rs:197-212`).
+- 33 `EventPayload` variants with `#[non_exhaustive]` and `#[serde(tag = "type", rename_all = "snake_case")]` in `crates/surge-core/src/run_event.rs`. **`OutcomeRejectedByHook` and `HookExecuted` are defined as variants but never emitted in production code today** — only in fold round-trip tests.
+- `VersionedEventPayload { schema_version: u32, payload: EventPayload }` wrapper exists; `schema_version` hardcoded to `1`. The events table in `crates/surge-persistence/src/runs/migrations/per_run/0001_initial.sql` has a `schema_version INTEGER NOT NULL DEFAULT 1` column. **No payload-level migration registry exists** — bincode deserializes straight into `EventPayload`.
+- `validate_for_m6()` in `crates/surge-orchestrator/src/engine/validate.rs` plus `validate()` in `crates/surge-core/src/validation.rs` cover 14+3 invariants (reachability, terminal reachability, declared-outcome resolution, profile-existence on Agent nodes, edge endpoints, single-edge-per-outcome, loop iterable bounds, subgraph cycles, MCP path safety, Notify-delivered warning). Validation is **purely syntactic** today — no `ReferenceResolver` trait, no profile-existence-in-registry check.
+- `report_stage_outcome` builder produces a dynamic per-node enum from declared outcomes (`crates/surge-acp/src/bridge/tools.rs:69-100`); `request_human_input` is recognised in agent stage (`crates/surge-orchestrator/src/engine/stage/agent.rs:419`) with timeout / resolution / `HumanInputResolved` event flow.
+- `engine run --watch` and `engine run --daemon --watch` flags exist in `crates/surge-cli/src/commands/engine.rs:101-184`. **`DaemonEngineFacade` is fully implemented**, not a skeleton — `connect()`, `start_run`, `resume_run`, `stop_run`, `resolve_human_input`, `list_runs`, `subscribe_to_run`, `subscribe_global`, `unsubscribe_*` are all wired and tested by `crates/surge-daemon/tests/daemon_e2e_smoke.rs` plus 11 other daemon tests. IPC framing lives in `crates/surge-orchestrator/src/engine/ipc.rs`.
+- Hook **types** (`HookTrigger`, `Hook`, `MatcherSpec`, `HookFailureMode`, `HookInheritance`) are defined in `crates/surge-core/src/hooks.rs`. `HookTrigger` is **not** marked `#[non_exhaustive]` (project rule says retrofit). `Profile.role.extends: Option<ProfileKey>` exists but **inheritance resolution is explicitly deferred** to a later milestone (see `crates/surge-core/src/profile.rs:41-42`). The engine **does not invoke hooks** anywhere.
+- `examples/` contains exactly two flows: `flow_terminal_only.toml` and `flow_minimal_agent.toml`. Schema observed: `schema_version = 1`, `start = "<node-key>"`, `[metadata]` table, `[nodes.<key>]` flat map, `[[edges]]` array, `Graph` derives only `#[serde(default)]` (no tags / rename_all on the top level). `Graph.subgraphs: BTreeMap<SubgraphKey, Subgraph>` is `#[serde(default)]` and lives at the root.
+- Mock ACP support is the **binary** `crates/surge-acp/src/bin/mock_acp_agent.rs` driven by CLI flags / scenarios (`echo`, `report_done`, `report_outcome=K`, `crash_after=N`, `human_input`, `long_streaming`, `frozen`). There is **no** `surge_acp::testing` library module. Tests spawn the binary as a subprocess.
+- Workspace has `proptest`, `criterion`, `insta` already in `[workspace.dependencies]`. **`glob` is not** — Task 1.0 below adds it.
+- `crates/surge-core/benches/` exists with `fold_events.rs`, `validate_graphs.rs`, `toml_roundtrip.rs`, `bincode_roundtrip.rs` (all `harness = false`). `crates/surge-orchestrator/benches/` does **not** exist yet.
+- `.github/workflows/` has `ci.yml`, `release.yml`, `security.yml`. No `CHANGELOG.md` at the repo root.
+
+This plan does **not** touch already-working code paths except where wiring requires it (e.g., agent stage to call hook chain, persistence read site to call the migration registry).
+
+## Research Context
+
+> Source: roadmap milestone "Graph engine GA" plus dependent milestones that consume its primitives.
+
+### Active Summary
+
+- **Topic:** Graph engine GA — finalize end-to-end execution of every NodeKind through `flow.toml`.
+- **Constraints:** All work flows downward through the dependency layers in `.ai-factory/ARCHITECTURE.md`. Validation rules belong in `surge-core`, executed by `surge-orchestrator`. New enum variants get `#[non_exhaustive]` retrofits where missing. `surge-core` stays leaf (no `tokio`, no I/O).
+- **Cross-milestone consumers:** `Artifact format & convention library` requires the `on_outcome` reject hook as a primitive. `Bootstrap & adaptive flow generation` requires deterministic fold for replayable bootstrap stages. `Crash recovery` requires the schema-version migration chain.
+- **Out of scope (deferred):** `Profile registry` (separate milestone — covers `extends` chain resolution and bundled roles), `Bootstrap & adaptive flow generation`, MCP server lifecycle hardening, Telegram cockpit, Tracker automation tiers, Crash recovery, v0.1 release.
+
+## Tasks
+
+> 20 tasks across 6 phases. Commit checkpoints after each phase. File paths are relative to the workspace root.
+
+### Phase 1 — Hook execution chain
+
+#### [x] Task 1.0 — Preflight retrofits and workspace dependencies
+
+- **Deliverable:** Three small but project-rule-mandated edits before the rest of Phase 1:
+  - Add `#[non_exhaustive]` to `HookTrigger` in `crates/surge-core/src/hooks.rs:104` (project rule: retrofit `#[non_exhaustive]` on closed enums that may grow).
+  - Add `glob = "0.3"` to `[workspace.dependencies]` in the workspace `Cargo.toml`; depend on it from `crates/surge-core/Cargo.toml` for `MatcherSpec::file_glob` evaluation in Task 1.1.
+  - Add `surge_core::error::SurgeError::SchemaTooOld { found: u32, min: u32 }` and `SchemaTooNew { found: u32, max: u32 }` variants (the existing example referenced these but they were never added to `crates/surge-core/src/error.rs`). Task 2.2 then uses them.
+- **Files:** `crates/surge-core/src/hooks.rs`, `Cargo.toml` (workspace), `crates/surge-core/Cargo.toml`, `crates/surge-core/src/error.rs`.
+- **Tests:**
+  - Compile-check that all crates still build after the retrofit.
+  - Unit: `crates/surge-core/src/error.rs::tests` — round-trip the two new variants through `Display`.
+- **Logging:** N/A (no runtime change).
+- **Notes:** This is the only task in this plan that touches workspace `Cargo.toml`; keep the diff minimal and place `glob` adjacent to other small utility crates.
+
+#### [x] Task 1.1 — Hook resolver and executor scaffolding
+
+- **Deliverable:** A `HookExecutor` that resolves a single profile's hooks by trigger and matcher, executes them sequentially, and returns a `HookOutcome { Proceed | Reject { reason } | Suppress { outcome } }` decision to the caller. `extends` chain resolution is **out of scope** here and deferred to the `Profile registry & bundled roles` milestone — accept a single resolved `Profile` and operate on `profile.hooks.entries` directly.
+- **Files:**
+  - `crates/surge-core/src/hooks.rs` — add `Hook::matches(trigger: HookTrigger, ctx: &MatchContext) -> bool` and `MatcherSpec::matches(ctx: &MatchContext) -> bool`. `MatchContext` exposes `tool_name`, `outcome`, `node`, `tool_args_json`, `file_paths_touched`. File-glob match uses `glob::Pattern::matches_path`. Pure functions — no I/O.
+  - `crates/surge-core/src/profile.rs` — add `Profile::hooks_for_trigger(&self, trigger: HookTrigger) -> impl Iterator<Item = &Hook>` (no inheritance — direct iteration over `self.hooks.entries`).
+  - `crates/surge-orchestrator/src/engine/hooks/mod.rs` — new module. Define `HookContext { node, session, tool, outcome, last_error, run_state }`, `HookOutcome`, `HookExecutor::execute_chain(profile: &Profile, trigger: HookTrigger, ctx: HookContext) -> HookOutcome`. Spawn each hook command via `tokio::process::Command` with `timeout_seconds`; capture stdout/stderr; map exit codes per `HookFailureMode` (Reject → `HookOutcome::Reject`; Warn → log and continue; Ignore → silent continue).
+- **Tests:**
+  - Unit: `crates/surge-core/src/hooks.rs::tests` — matcher coverage (file glob via `glob::Pattern`, tool exact, outcome exact, tool-arg substring on `tool_args_json`).
+  - Unit: `crates/surge-orchestrator/src/engine/hooks/mod.rs::tests` — chain execution against an in-memory mock that records spawned commands; verifies short-circuit on Reject when `HookFailureMode::Reject`.
+- **Logging:** DEBUG `[hooks]` on resolution (`hook.resolved=N trigger=...`), DEBUG on each hook entry (`hook.start id=... cmd=...`), DEBUG on exit with exit-status, WARN on reject (`hook.reject id=... reason=...`), ERROR on hook-process spawn failure.
+- **Depends on:** 1.0.
+
+#### [x] Task 1.2 — Wire `pre_tool_use` and `post_tool_use` into agent stage
+
+- **Deliverable:** Tool calls in the agent turn loop are bracketed by `pre_tool_use` and `post_tool_use` hook chains. Pre rejection cancels the tool dispatch and emits a synthetic tool-error result back to the ACP session via `BridgeCommand::ReplyToTool { payload: ToolResultPayload::Error { message: <hook reason> } }`. Post rejection logs and proceeds (post-hooks cannot un-run a tool call) but still appends `OutcomeRejectedByHook` for replay/audit. Each invocation appends one `HookExecuted { hook_id, exit_status, on_failure }`.
+- **Files:**
+  - `crates/surge-orchestrator/src/engine/stage/agent.rs` — at the tool-dispatch site (~line 368 `session_dispatcher.dispatch()`), invoke `HookExecutor::execute_chain(profile, HookTrigger::PreToolUse, ctx)`. After dispatch, invoke `HookTrigger::PostToolUse`. On Pre-Reject, send `BridgeCommand::ReplyToTool` with `ToolResultPayload::Error` and skip the inner dispatcher; on Post-Reject, append `OutcomeRejectedByHook` and continue the loop.
+  - `crates/surge-orchestrator/src/engine/hooks/mod.rs` — add `record_hook_executed(writer, ctx, hook, status)` helper to keep `agent.rs` focused.
+- **Tests:**
+  - Integration: `crates/surge-orchestrator/tests/hooks_pre_post_tool_test.rs` — drives the engine against the existing `mock_acp_agent` binary using the `echo` scenario; profile declares a `pre_tool_use` hook with `HookFailureMode::Reject` matching the `echo` tool name; assert the dispatcher is never reached and the agent receives a `ToolResultPayload::Error`.
+  - Integration: same file — `post_tool_use` hook with `Warn` failure mode logs but does not block; assert exactly one `HookExecuted` event is appended per call.
+- **Logging:** DEBUG `[hooks][pre]` + `[hooks][post]` on entry; INFO on `HookExecuted` event written; WARN on pre-reject (with tool name).
+- **Depends on:** 1.1.
+
+#### [x] Task 1.3 — `on_outcome` hook with retry-on-reject
+
+- **Deliverable:** When an agent reports an outcome, `on_outcome` hooks run **before** `OutcomeReported` is appended. If any hook returns `Reject`, the engine appends `OutcomeRejectedByHook { node, outcome, hook_id }` (no `OutcomeReported` for the rejected attempt), surfaces the rejection to the ACP session via `BridgeCommand::ReplyToTool` against the `report_stage_outcome` call_id with `ToolResultPayload::Error { message }`, increments the attempt counter, and lets the turn loop continue so the agent can pick a different outcome. On `attempts > AgentLimits::max_retries`: append `StageFailed { reason: "on_outcome rejection budget exhausted", retry_available: false }`.
+- **Files:**
+  - `crates/surge-orchestrator/src/engine/stage/agent.rs` — at the outcome-validation site (~line 325), before recording `OutcomeReported`, run `HookTrigger::OnOutcome`. On reject: append `OutcomeRejectedByHook`, send the rejection back via `ReplyToTool`, do **not** mutate `RunMemory.outcomes` (rejection happens before the would-be `OutcomeReported`, so memory stays consistent without an explicit fold change). Honour `AgentConfig.limits.max_retries` (`crates/surge-core/src/agent_config.rs:87`, default 3).
+- **Tests:**
+  - Integration: `crates/surge-orchestrator/tests/on_outcome_retry_test.rs` — uses a custom `mock_acp_agent` scenario that reports `pass` first then `fixes_needed` on the next turn (added in Task 5.1 if missing). Profile has an `on_outcome` hook that rejects `pass` once. Assert: one `OutcomeRejectedByHook` for `pass`, one `OutcomeReported` for `fixes_needed`, run terminates per the `fixes_needed` edge.
+  - Integration: same file — retries-exhausted scenario with the agent always reporting the rejected outcome; assert `StageFailed` is the terminal stage event after `max_retries + 1` rejections.
+- **Logging:** INFO `[hooks][on_outcome]` on each evaluation; INFO on retry initiation with `attempt=N/max`; WARN on retry-budget exhausted with the rejecting `hook_id`.
+- **Depends on:** 1.1.
+
+#### [x] Task 1.4 — `on_error` hook wiring
+
+- **Deliverable:** When a stage fails (tool spawn failure, ACP transport error, validation failure, internal error caught by stage), `on_error` hooks run before `StageFailed` is appended. `HookOutcome::Suppress { outcome }` converts the failure into a successful `OutcomeReported { outcome }` (the supplied outcome must be declared on the node — validated at hook-result time; otherwise the suppression is itself rejected with a WARN and the original `StageFailed` is appended). `HookOutcome::Reject` is treated as `Proceed` (cannot reject an error); `Proceed` lets `StageFailed` be recorded as before.
+- **Files:**
+  - `crates/surge-orchestrator/src/engine/run_task.rs` — central error-classifier: at the catch-site that produces `StageFailed`, wrap with `HookExecutor::execute_chain(..., OnError, ctx_with_error)` and branch on `HookOutcome`.
+  - `crates/surge-orchestrator/src/engine/hooks/mod.rs` — add `HookContext::with_error(reason: &str)` builder.
+- **Tests:**
+  - Integration: `crates/surge-orchestrator/tests/on_error_suppress_test.rs` — uses `mock_acp_agent --scenario crash_after=1`; profile `on_error` hook returns `Suppress("retry_later")`; assert the run records `OutcomeReported { outcome: "retry_later" }` (which is declared on the node) instead of `StageFailed`, and routes correctly.
+  - Integration: same file — without the `on_error` hook the same crash produces `StageFailed`, proving the hook genuinely changed behaviour.
+  - Integration: same file — suppression with an undeclared outcome falls through to `StageFailed` and emits a WARN log.
+- **Logging:** WARN `[stage][error]` on raw error captured; INFO `[hooks][on_error]` on resolution; INFO on suppression with the substituted outcome key; WARN on suppression-with-undeclared-outcome.
+- **Depends on:** 1.1.
+
+#### [x] Task 1.5 — Fold pass-through guard for hook events
+
+- **Deliverable:** Confirm via test that `RunState::apply()` treats `HookExecuted` and `OutcomeRejectedByHook` as deterministic pass-throughs (no state mutation). `discriminant_str()` covers both. A golden insta snapshot of a synthetic event sequence containing every hook-related event guards against regressions if a future change accidentally mutates state on these events.
+- **Files:**
+  - `crates/surge-core/src/run_state.rs` — verify the existing exhaustive `match` in `apply()` covers both events as no-op pass-throughs (current code at ~line 391 already does this for unhandled-state events; add explicit arms with comments to make intent visible to future readers).
+  - `crates/surge-core/src/run_event.rs::discriminant_str` — confirm both variants present (existing M6 code).
+  - `crates/surge-core/tests/fold_hook_events.rs` (new) — synthetic 12-event sequence including `HookExecuted` and `OutcomeRejectedByHook` between `StageEntered` and `OutcomeReported`. `insta::assert_yaml_snapshot!` of the resulting `RunState` to lock the pass-through behaviour.
+- **Tests:** the golden snapshot test itself.
+- **Logging:** N/A (test fixtures).
+- **Notes:** Per refinement: `RunMemory` has no `last_outcome` field — outcomes are stored as `outcomes: BTreeMap<NodeKey, Vec<OutcomeRecord>>`. Because `on_outcome` rejection in Task 1.3 happens **before** `OutcomeReported` is appended, no fold-side mutation of `RunMemory` is required. This task documents and enforces that invariant.
+- **Depends on:** 1.3.
+
+### Phase 2 — Determinism and schema versioning
+
+#### [x] Task 2.1 — Replay determinism property test
+
+- **Deliverable:** Property test asserting that for any well-formed event sequence `E`, `fold(&E[..N])` is idempotent (running twice produces the same `RunState`) and incremental fold (`apply()` step by step) equals one-shot `fold()` byte-for-byte at every prefix `N ∈ [0, |E|]`. Custom strategy generates valid graphs and event sequences honouring the engine state machine (`NotStarted → Bootstrapping → Pipeline → Terminal`).
+- **Files:**
+  - `crates/surge-core/tests/fold_determinism_proptest.rs` (new) — proptest strategy: build a small random graph (1–5 nodes), generate the linear sequence of events that a deterministic engine would produce (with fixed timestamps from a seeded counter, no wall-clock reads), fold and assert determinism.
+  - `crates/surge-core/Cargo.toml` — `proptest` already in `[dev-dependencies]` (verified during refinement; no edit needed unless absent at implementation time).
+- **Tests:** the proptest itself; `cargo test -p surge-core --test fold_determinism_proptest` passes with default 256 cases.
+- **Logging:** N/A.
+- **Notes:** Strategy must avoid wall-clock reads; use a deterministic timestamp generator inside the strategy.
+
+#### [x] Task 2.2 — Schema-version migration registry
+
+- **Deliverable:** `surge-core` exposes an `EventMigrator` infrastructure: a `MigrationChain` that maps `(schema_version, payload_bytes) → EventPayload`. Registry currently has the identity migration for v1. The migration entry point — `migrate_payload(version: u32, bytes: &[u8]) -> Result<EventPayload, SurgeError>` — is invoked by **persistence on read** (the existing bincode read path in `surge-persistence`), not from inside `VersionedEventPayload::deserialize` (which routes through serde and would create a layering issue). Unsupported versions return `SurgeError::SchemaTooOld { found, min }` or `SchemaTooNew { found, max }` (added in Task 1.0).
+- **Files:**
+  - `crates/surge-core/src/migrations/mod.rs` (new) — define `Migration` trait, `MigrationChain`, `migrate_payload(version: u32, bytes: &[u8]) -> Result<EventPayload, SurgeError>`. Register `IdentityV1` migration. Use `bincode` (already in workspace deps) for the v1 payload deserialization.
+  - `crates/surge-core/src/lib.rs` — re-export `migrate_payload` and the chain types.
+  - `crates/surge-persistence/src/runs/<event read site>` — replace direct `bincode::deserialize::<EventPayload>(bytes)` (or wherever payload bytes are turned into `EventPayload`) with `surge_core::migrate_payload(row.schema_version, &row.payload)`. Verify by file:line during implementation.
+- **Tests:**
+  - Unit: `crates/surge-core/tests/migrations_v1_roundtrip.rs` — round-trip a v1 payload through the chain produces an equal `EventPayload`.
+  - Unit: same file — synthetic v0 payload (mocked via direct bincode encode of a valid struct then version-tag override) returns `SchemaTooOld`.
+  - Unit: same file — synthetic v999 payload returns `SchemaTooNew`.
+  - Integration: `crates/surge-persistence/tests/migration_payload_v1.rs` (new) — write events via `RunWriter::append_event`, read them back, assert the read path now traverses `migrate_payload` (verify via a `tracing-test` capture or a counter on a test-only migrator hook).
+- **Logging:** INFO `[migrations]` on each non-identity migration applied; ERROR on unsupported version with both `found` and the supported range.
+- **Notes:** Per architecture rule, `surge-core` stays leaf — `bincode` and `serde` are already permitted dependencies. No `tokio` needed in this code path. SQL DDL migrations are a separate concern handled by the existing `crates/surge-persistence/src/runs/migrations/` infrastructure and are not touched here.
+- **Depends on:** 1.0.
+
+#### [x] Task 2.3 — Validation extension: profile, template, and named-agent reference resolution
+
+- **Deliverable:** Graph validation accepts a `ReferenceResolver` trait (resolves profile names → existing profiles, template names → registered templates, named-agent IDs → registered agents). Each `Agent` node's `profile` field is resolved; missing profiles produce `ValidationError::ProfileNotFound { node, profile }`. Validation in `surge-orchestrator` injects a real resolver backed by the project's profile registry; tests inject an in-memory resolver.
+- **Files:**
+  - `crates/surge-core/src/validation.rs` — add `pub trait ReferenceResolver { fn profile_exists(&self, name: &str) -> bool; fn template_exists(&self, name: &str) -> bool; fn named_agent_exists(&self, id: &str) -> bool; }`. Add `validate_with_resolver(&Graph, &dyn ReferenceResolver) -> Result<Vec<ValidationError>, Vec<ValidationError>>`. Keep `validate(&Graph)` (current line 150) as the no-resolver variant for syntactic validation. Add `ValidationError::{ProfileNotFound, TemplateNotFound, NamedAgentNotFound}` variants.
+  - `crates/surge-orchestrator/src/engine/validate.rs` — extend `validate_for_m6()` to call `validate_with_resolver` when a registry resolver is available; the in-process and daemon paths inject the same resolver type. The existing terminal-only smoke path may pass a `NoOpResolver` that returns `true` for everything (so `flow_terminal_only.toml` still validates).
+- **Tests:**
+  - Unit: `crates/surge-core/src/validation.rs::tests` — graph with `profile = "implementer-1.0"` and a resolver that returns `false` produces `ProfileNotFound`. Resolver returning `true` removes the diagnostic.
+  - Integration: `crates/surge-orchestrator/tests/validate_with_resolver.rs` — `flow_minimal_agent.toml` validates clean against a resolver that knows `implementer@1.0`; fails when the profile is removed from the resolver.
+- **Logging:** DEBUG `[validate][resolver]` on each lookup; WARN on missing reference.
+
+### Phase 3 — Daemon-attached engine path completion
+
+> **Refinement note:** Phase 3 was rescoped after the second-iteration codebase walk found `DaemonEngineFacade`, `engine/ipc.rs` framing, server dispatch, and per-run subscription already implemented and covered by `daemon_e2e_smoke.rs`. The remaining gaps are: queued-run auto-resubscribe, global-event wire forwarding, and a parity test against the in-process facade.
+
+#### [x] Task 3.1 — Queued-run auto-resubscribe on admission
+
+- **Deliverable:** When `engine run --daemon` returns `DaemonResponse::StartRunQueued` (admission queue full, run waiting), the client's `subscribe_to_run` call must remain valid: when `AdmissionController` admits the queued run, the daemon emits `GlobalDaemonEvent::RunAccepted { run_id }` to all global subscribers, and the per-run broadcast channel created at admission time is automatically connected to the client's pre-existing local channel via the request-id correlation table on the client side.
+- **Files:**
+  - `crates/surge-daemon/src/server.rs` — at the queued-run admission site (currently in the dispatch loop around the queue-drain transition), publish a `GlobalDaemonEvent::RunAccepted` and ensure the new per-run sender is registered in the broadcast registry **before** the engine begins emitting `RunStarted`.
+  - `crates/surge-orchestrator/src/engine/daemon_facade.rs` — `start_run` already creates a local channel; ensure the background read loop (lines 76–137) routes `DaemonEvent::PerRun { run_id, event }` to the local channel even if the run was queued at start time. Add a unit-level test for the routing table.
+- **Tests:**
+  - Integration: `crates/surge-daemon/tests/daemon_queued_subscribe_test.rs` (new) — start two runs against a daemon configured with `max_active = 1, max_queue = 4`; first run admitted, second queued. Subscribe to the queued run's events. Stop the first run (so the second is admitted). Assert the second run's `RunStarted` and subsequent events stream to the subscriber without an explicit re-subscribe.
+- **Logging:** INFO `[daemon][admission]` on queued → admitted transition with run-id; DEBUG `[daemon][broadcast]` on per-run channel registration.
+
+#### [x] Task 3.2 — Global event wire forwarding
+
+- **Deliverable:** `GlobalDaemonEvent` values published by `surge-daemon::broadcast::BroadcastRegistry` are forwarded over the wire to clients that called `DaemonRequest::SubscribeGlobal`. Currently the broadcast registry has the events; the wire-forwarding loop is the missing link. Frame format: `DaemonEvent::Global(GlobalDaemonEvent)` (already defined in `crates/surge-orchestrator/src/engine/ipc.rs:283-317`). Backpressure: a slow subscriber that lags more than `1024` global events is dropped with a `SubscriberLagged` `DaemonResponse::Error` rather than blocking the daemon.
+- **Files:**
+  - `crates/surge-daemon/src/server.rs` — in the per-connection task that handles `DaemonRequest::SubscribeGlobal`, spawn a forwarder loop that reads from the broadcast `tokio::sync::broadcast::Receiver` and writes `DaemonEvent::Global` frames using `engine::ipc::write_frame`. Honour the `1024` lag limit; on lag, send the lag-error frame and close the per-connection global subscription.
+  - `crates/surge-orchestrator/src/engine/daemon_facade.rs` — `subscribe_global()` already exists; verify it consumes the `DaemonEvent::Global` frames produced by the new forwarder. Update the read-loop dispatcher (lines 79-114) if the global frame routing has gaps.
+- **Tests:**
+  - Integration: `crates/surge-daemon/tests/daemon_global_wire_test.rs` (new) — connect, `SubscribeGlobal`, start a run via another connection (or in-process), assert the subscriber sees `RunAccepted` and `RunFinished` global events.
+  - Integration: same file — slow consumer scenario simulated by holding the receiver without polling for `1100` events; assert lag eviction with `SubscriberLagged`.
+- **Logging:** INFO `[daemon][subscribe-global]` on attach/detach with subscriber-id; WARN on lag eviction; DEBUG on per-event broadcast count.
+
+#### [x] Task 3.3 — In-process / daemon parity test
+
+- **Deliverable:** A regression-guarding parity test runs `flow_terminal_only.toml`, `flow_minimal_agent.toml`, and (after Phase 4) at least one of the new archetype examples through both `LocalEngineFacade` and `DaemonEngineFacade` and asserts the resulting event sequences are identical modulo wall-clock fields (`timestamp`, durations). Diff reported as `expected vs actual` for failures.
+- **Files:**
+  - `crates/surge-orchestrator/tests/daemon_parity_test.rs` (new) — helper `normalize_event(event) -> NormalizedEvent` strips wall-clock fields and any non-deterministic IDs. Assert `Vec<NormalizedEvent>` equality.
+  - `crates/surge-orchestrator/src/test_helpers/<file>` — shared parity helper visible only under `#[cfg(any(test, feature = "test-helpers"))]`.
+- **Tests:** the parity test itself, gated to skip when daemon binary cannot be spawned (this should never apply in CI; gating exists only for offline-laptop edge-cases).
+- **Logging:** N/A (test fixtures).
+- **Depends on:** 3.1, 3.2 (and Phase 4 examples for the third archetype assertion).
+
+### Phase 4 — `flow.toml` archetype examples
+
+> Schema confirmed via existing examples: `schema_version = 1`, `start = "<key>"`, `[metadata]`, `[nodes.<key>]` flat map, `[[edges]]` array. Subgraph-using flows declare `Graph.subgraphs: BTreeMap<SubgraphKey, Subgraph>` at the root. Profile keys use the `<role>@<version>` form (e.g. `implementer@1.0`).
+
+#### [x] Task 4.1 — `linear-3` and `single-loop` archetypes
+
+- **Deliverable:** Two new examples that exercise the smallest-non-trivial graphs.
+  - `examples/flow_linear_3.toml` — `Spec → Implement → Verify → Terminal(success)`. Three Agent nodes wired to the bundled mock-friendly profile (`implementer@1.0` placeholder used by `flow_minimal_agent.toml`), declared outcomes `pass` and `fail`, fail-edge to `Terminal(failure)`.
+  - `examples/flow_single_loop.toml` — outer `Loop` over a static three-item list; body subgraph (declared in `[subgraphs.<key>]`) `Implement → Verify`; terminal on completion.
+- **Files:**
+  - `examples/flow_linear_3.toml` (new).
+  - `examples/flow_single_loop.toml` (new).
+  - `crates/surge-cli/tests/examples_smoke.rs` (new or extend existing) — for each new flow, parse + validate + run against the `mock_acp_agent` binary subprocess (spawned with `--scenario report_done`); assert the run reaches a terminal node.
+- **Tests:** smoke per archetype.
+- **Logging:** N/A (config files).
+
+#### [x] Task 4.2 — `multi-milestone-loop` and `bug-fix-with-Reproduce` archetypes
+
+- **Deliverable:**
+  - `examples/flow_multi_milestone.toml` — outer `Loop` over a 2-item milestone list; per iteration, inner `Loop` over a 2-item task list (declared via the root `subgraphs` block); inner body `Implement → Verify`; outer-loop completion → `Final Review → Terminal(success)`.
+  - `examples/flow_bug_fix.toml` — `Reproduce → Implement → Verify → Terminal`. `Verify` declares outcomes `pass` (forward) and `regressed` (`kind = "backtrack"` edge to `Reproduce`). Demonstrates a `Backtrack` edge under a realistic shape.
+- **Files:**
+  - `examples/flow_multi_milestone.toml` (new).
+  - `examples/flow_bug_fix.toml` (new).
+  - `crates/surge-cli/tests/examples_smoke.rs` — extend with golden-event-log assertions for each new flow against a scripted `mock_acp_agent` invocation. Use `insta` snapshots normalised for wall-clock fields.
+- **Tests:** smoke + golden-file event log per archetype.
+- **Logging:** N/A.
+
+#### [x] Task 4.3 — `refactor` and `spike` archetypes
+
+- **Deliverable:**
+  - `examples/flow_refactor.toml` — `Behavior Characterization → Implement → Verify → Reviewer → Terminal`. Demonstrates the convention that a refactor must capture behaviour first.
+  - `examples/flow_spike.toml` — `Implement → Terminal`. Two-node experiment flow that explicitly skips Architect / Reviewer; declared outcome `findings_recorded` only.
+- **Files:**
+  - `examples/flow_refactor.toml` (new).
+  - `examples/flow_spike.toml` (new).
+  - `crates/surge-cli/tests/examples_smoke.rs` — parse + validate + smoke run for each.
+- **Tests:** parse + smoke.
+- **Logging:** N/A.
+
+### Phase 5 — Integration and performance gates
+
+#### [x] Task 5.1 — Mock-ACP archetype suite
+
+- **Deliverable:** A single integration test file that loads each of the six new archetype examples (4.1, 4.2, 4.3) plus the two existing examples, drives each through the existing `mock_acp_agent` binary subprocess (`crates/surge-acp/src/bin/mock_acp_agent.rs`) with a per-archetype scripted scenario list, and asserts the event log shape is acceptable (no `StageFailed` unless explicitly expected by the archetype, every run terminates, no panics). If the existing scenarios (`echo`, `report_done`, `report_outcome=K`, `crash_after=N`, `human_input`, `long_streaming`, `frozen`) cannot drive an archetype (e.g., bug-fix needs a `regressed` outcome on the first turn then `pass` on the second), extend `mock_acp_agent.rs` with a new scenario such as `report_sequence=K1,K2,...` that emits the listed outcomes in order.
+- **Files:**
+  - `crates/surge-orchestrator/tests/archetypes_mock_test.rs` (new) — parameterised over `examples/*.toml`. Skip `flow_terminal_only.toml` (no agent expected) and run the rest with the mock-agent subprocess wired through the existing test pattern (`tokio::test(flavor = "multi_thread", worker_threads = 2)` per the project convention; spawn the mock binary, configure the engine to launch it as the ACP child).
+  - `crates/surge-acp/src/bin/mock_acp_agent.rs` — extend `Scenario` enum with `ReportSequence(Vec<String>)` if needed by an archetype. Honour the existing CLI-flag conventions.
+- **Tests:** the suite itself.
+- **Logging:** INFO `[test][archetype]` per archetype start; DEBUG on event count.
+- **Depends on:** 4.1, 4.2, 4.3.
+
+#### Task 5.2 — Real-ACP smoke test (gated)
+
+- **Deliverable:** A real-agent smoke test that runs `flow_minimal_agent.toml` against an actual ACP-conformant agent binary (Claude Code or Codex CLI), gated by env vars (`SURGE_REAL_ACP_BIN` and `SURGE_REAL_ACP_PROFILE`). When the env is absent, the test is skipped with a clear message — CI green path does not require a real agent. When env is present, the test asserts the run reaches `RunCompleted` and at least one `TokensConsumed` event is recorded.
+- **Files:**
+  - `crates/surge-orchestrator/tests/real_acp_smoke.rs` (new).
+  - `docs/development.md` — section "Optional: real-agent smoke test" describing how to opt in locally.
+- **Tests:** the smoke test itself.
+- **Logging:** INFO on agent binding selection.
+- **Notes:** Per `decide-or-defer` rule: this test is genuine, opt-in, and complete — it is not a stub. The roadmap's "real agent" verification is satisfied by enabling this test in a developer's local environment. The deterministic CI path is covered by the `mock_acp_agent` subprocess in 5.1.
+
+#### Task 5.3 — Criterion bench: stage-transition p95 with CI regression gate
+
+- **Deliverable:** A criterion bench measuring the transition latency `StageEntered → OutcomeReported → EdgeTraversed` for a `Branch` node (synchronous, no agent). p95 budget: documented as a numeric value derived from a baseline run (decision: take the p95 of the first clean baseline plus 25% headroom, encoded as `P95_BUDGET_US` constant in the bench source). CI runs `cargo bench --bench stage_transition -- --save-baseline ci` and a small Rust harness compares the latest run against the baseline; regression > 25% fails the job.
+- **Files:**
+  - `crates/surge-orchestrator/benches/stage_transition.rs` (new) — criterion bench. `harness = false` per project convention (matches the four existing benches in `crates/surge-core/benches/`).
+  - `crates/surge-orchestrator/Cargo.toml` — add `[[bench]] name = "stage_transition" harness = false` entry and `criterion = { workspace = true }` to `[dev-dependencies]`.
+  - `.github/workflows/ci.yml` — add a `bench` job (Linux only) that runs the bench and compares against `target/criterion/`-stored baseline. Keep the existing CI matrix (Ubuntu/Windows/macOS) untouched; the bench job runs on Linux only.
+- **Tests:** the bench itself + CI gate (manual smoke locally during this task).
+- **Logging:** N/A.
+
+### Phase 6 — Documentation and GA cut
+
+#### [x] Task 6.1 — Documentation: hooks authoring guide and archetype gallery
+
+- **Deliverable:**
+  - `docs/hooks.md` (new) — hook lifecycle (when each trigger fires), `MatcherSpec` semantics, `HookFailureMode` matrix, profile authoring example, retry semantics for `on_outcome`, suppression semantics for `on_error`, deterministic-fold guarantees. Note explicitly that `extends` chain resolution is deferred to the `Profile registry` milestone and current hooks operate on a single resolved profile.
+  - `docs/archetypes.md` (new) — gallery of all six new archetype flows (linear-3, single-loop, multi-milestone, bug-fix, refactor, spike) with mermaid diagrams and a one-paragraph description of when to use each.
+  - `docs/ARCHITECTURE.md` § 4 — replace the "Hooks" sentence with a link to `hooks.md`; remove the "_(intent)_" qualifier on the hook execution paragraph.
+  - `docs/development.md` — link to the criterion-bench job and the optional real-ACP smoke test.
+  - `docs/README.md` (if present) and root `README.md` — update navigation lists with `hooks.md` and `archetypes.md`.
+  - `.ai-factory/ROADMAP.md` — flip `[ ] Graph engine GA` to `[x]` only after Task 6.2 acceptance check passes; add a row to the Completed table with the build date.
+- **Files:** as above.
+- **Tests:** N/A.
+- **Logging:** N/A.
+- **Depends on:** 1.5, 2.x, 3.x, 4.x, 5.x.
+
+#### Task 6.2 — GA acceptance check and CHANGELOG entry
+
+- **Deliverable:** Run the full local acceptance suite, document results, and draft the changelog. Then commit and push the milestone branch.
+  - `cargo build --workspace --exclude surge-ui` — clean.
+  - `cargo test --workspace --exclude surge-ui` — green, including all proptest, criterion bench (smoke run, not gated), and integration tests added by this plan.
+  - `cargo clippy --workspace --exclude surge-ui -- -D warnings` — clean against the project's `clippy.toml`.
+  - `cargo fmt --check` — clean per `rustfmt.toml`.
+  - `cargo bench --bench stage_transition -- --save-baseline ga` — establish baseline; compare against `ci` baseline if present.
+  - Cross-reference each of the 14 sub-bullets of the **Graph engine GA** roadmap milestone with the artifacts produced by this plan; record a one-line evidence pointer per sub-bullet.
+  - Create `CHANGELOG.md` at the repo root (currently absent) with a section `## [Unreleased] — Graph engine GA` summarising hooks, determinism, daemon path, archetypes, criterion gate, and docs additions. Use Keep-a-Changelog categories.
+- **Files:** `CHANGELOG.md` (new), local-only acceptance log captured in PR description.
+- **Tests:** the acceptance suite is the test.
+- **Logging:** N/A.
+- **Depends on:** 6.1.
+
+## Commit Plan
+
+| # | After phase | Suggested commit message |
+|---|---|---|
+| 1 | Phase 1 (1.0–1.5) | `feat(engine): wire hook execution chain (pre/post-tool, on_outcome retry, on_error suppress) + retrofits` |
+| 2 | Phase 2 (2.1–2.3) | `feat(core): replay determinism proptest + schema-version migration registry + reference-resolver validation` |
+| 3 | Phase 3 (3.1–3.3) | `feat(daemon): queued-run auto-resubscribe, global-event wire forwarding, parity test` |
+| 4 | Phase 4 (4.1–4.3) | `feat(examples): six flow.toml archetypes (linear-3, single-loop, multi-milestone, bug-fix, refactor, spike)` |
+| 5 | Phase 5 (5.1–5.3) | `test: archetype suite, gated real-ACP smoke, criterion stage-transition gate` |
+| 6 | Phase 6 (6.1–6.2) | `docs: hooks guide + archetype gallery; chore(release): Graph engine GA acceptance` |
+
+Each commit must pass `cargo build --workspace --exclude surge-ui` and `cargo test --workspace --exclude surge-ui` locally before pushing.
+
+## Acceptance Criteria
+
+This plan is complete when **all** of the following hold:
+
+1. Each task above is implemented, its tests pass on Linux and Windows, and `cargo clippy --workspace -- -D warnings` is clean.
+2. Every sub-bullet of the **Graph engine GA** roadmap milestone has at least one artifact produced by this plan that demonstrates it. Cross-reference table is included in the PR description.
+3. `cargo bench --bench stage_transition` reports p95 stage-transition latency within the documented `P95_BUDGET_US`; the CI bench gate is wired and green.
+4. `docs/hooks.md` and `docs/archetypes.md` exist, link from `README.md` and `docs/ARCHITECTURE.md`, and are reviewed via `/aif-docs`.
+5. `.ai-factory/ROADMAP.md` flips `Graph engine GA` to `[x]` and the Completed table has a row with the build date.
+6. `CHANGELOG.md` exists at the repo root with the `Graph engine GA` section.
+7. The branch `feature/graph-engine-ga` merges cleanly into `main` with no `unwrap()` introductions in library code, no `anyhow` imports outside binary crates, and no `tokio` import added to `surge-core`.
+
+## Notes for `/aif-implement`
+
+- **Do not refactor** any of the seven existing NodeKind handlers beyond the minimal edits needed in tasks 1.2–1.4. The handlers are GA-quality already.
+- **Daemon path is largely done.** Phase 3 is narrowly scoped to admission-time subscription continuity, global wire forwarding, and a parity test. Do not regenerate `engine/ipc.rs`, `daemon_facade.rs`, or `server.rs` from scratch — extend them.
+- **`extends` chain resolution is OUT of scope.** Hook resolver in 1.1 operates on a single resolved profile. Multi-profile inheritance belongs to the `Profile registry & bundled roles` milestone.
+- **Test infrastructure pattern:** mock-ACP work uses the existing `mock_acp_agent` **binary** (`crates/surge-acp/src/bin/mock_acp_agent.rs`) spawned as a subprocess with `--scenario <name>` flags. There is no `surge_acp::testing` library module today; do not invent one. Extend the binary's `Scenario` enum if archetypes need a new pattern (e.g. `ReportSequence(Vec<String>)`).
+- **Test gating discipline:** new tests must be deterministic and run in CI without external services. Real-ACP smoke (5.2) is the only gated test and only via env vars.
+- **Validation:** new validation rules belong in `surge-core/src/validation.rs`; the orchestrator only invokes them. This is a project-level rule. The new `ReferenceResolver` trait is the seam.
+- **Migrations:** the v1-only chain is correct for now. Do not invent forward migrations; the chain mechanism is the deliverable. SQL DDL migrations are unrelated and live under `crates/surge-persistence/src/runs/migrations/`.
+- **`#[non_exhaustive]` retrofits:** done in Task 1.0 for `HookTrigger`. Add to any new public enum that may grow; not needed if the enum stays internal to orchestrator (e.g. `HookOutcome`).
+- **Logging discipline:** library crates use `tracing::*` only; no `println!`, `eprintln!`, or `dbg!`.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,9 +178,11 @@ jobs:
       - name: Build stage_transition bench
         run: cargo bench -p surge-orchestrator --bench stage_transition --no-run
 
-      # Quick smoke run with a single sample so CI catches runtime panics
-      # without spending the multi-minute full warmup. P95_BUDGET_US lives
-      # in the bench source — a regression beyond budget surfaces as test
-      # failure once the GA runs include the comparison harness.
-      - name: Smoke-run stage_transition bench
-        run: cargo bench -p surge-orchestrator --bench stage_transition -- --quick
+      # Quick smoke run with the explicit P95 gate enabled. `--save-baseline ci`
+      # keeps Criterion history available on the runner, while
+      # SURGE_STAGE_TRANSITION_BUDGET_CHECK makes the bench fail if the
+      # source-level P95_BUDGET_US budget is exceeded.
+      - name: Budget-check stage_transition bench
+        env:
+          SURGE_STAGE_TRANSITION_BUDGET_CHECK: "1"
+        run: cargo bench -p surge-orchestrator --bench stage_transition -- --quick --save-baseline ci

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,13 +122,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   measures `StageEntered → OutcomeReported → EdgeTraversed` for a synchronous
   Branch node. `P95_BUDGET_US` constant carries the per-transition wall-clock
   budget. CI gates the bench via a Linux-only `bench` job that builds the
-  bench and runs `cargo bench -- --quick` so a runtime panic in the bench
-  cannot land silently. Full GA baseline is local:
+  bench and runs
+  `SURGE_STAGE_TRANSITION_BUDGET_CHECK=1 cargo bench -- --quick --save-baseline ci`
+  so budget regressions and runtime panics cannot land silently. Full GA
+  baseline is local:
   `cargo bench -p surge-orchestrator --bench stage_transition -- --save-baseline ga`.
 - **Gated real-ACP smoke test:**
   `crates/surge-orchestrator/tests/real_acp_smoke.rs` opts in via
-  `SURGE_REAL_ACP_BIN` and `SURGE_REAL_ACP_PROFILE` env vars; without them
-  the test prints a `SKIPPED` banner and exits successfully. See
+  `SURGE_REAL_ACP_BIN` and `SURGE_REAL_ACP_PROFILE` env vars, runs
+  `examples/flow_minimal_agent.toml` through the engine against the real
+  ACP child, and asserts both `RunCompleted` and at least one
+  `TokensConsumed` event. Optional `SURGE_REAL_ACP_KIND` and
+  `SURGE_REAL_ACP_ARGS` override launch inference for custom agents. Without
+  the required env vars the test prints a `SKIPPED` banner and exits
+  successfully. See
   [`docs/development.md`](docs/development.md#optional-real-agent-smoke-test).
 - **Daemon-attached engine path completion (Phase 3).**
   `BroadcastRegistry::subscribe_eventual` parks a oneshot waiter that is
@@ -220,14 +227,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **`real_acp_smoke.rs` renamed and rescoped honestly.** The previous
-  `flow_minimal_agent_against_real_agent` test name implied driver +
-  `RunCompleted` / `TokensConsumed` assertions, but the body only
-  validated env vars. Renamed to `real_acp_env_contract_harness`,
-  doc-block now states scope explicitly (env-contract harness today,
-  full driver tracked as Graph-engine-GA follow-up) and the body
-  asserts the env vars resolve to an existing binary file. Caught
-  in PR #48 review.
+- **`real_acp_smoke.rs` promoted from env-contract scaffold to real
+  opt-in driver.** The test now mutates the minimal-agent example with a
+  smoke-specific prompt, swaps the engine's mock fallback for the selected
+  real ACP launch kind, waits for run completion, and verifies the persisted
+  event log contains `RunCompleted` plus `TokensConsumed`.
 
 - **Replay determinism violation in `RunState::apply`.** The proptest above
   uncovered that `apply()` generated `SessionId::new()` on `RunStarted` and

--- a/crates/surge-daemon/src/server.rs
+++ b/crates/surge-daemon/src/server.rs
@@ -761,8 +761,7 @@ async fn dispatch(
                 }
                 let rx = broadcast.subscribe_global();
                 let writer_for_task = writer.clone();
-                let handle =
-                    tokio::spawn(forward_global_to_client(rx, writer_for_task, request_id));
+                let handle = tokio::spawn(forward_global_to_client(rx, writer_for_task));
                 s.global_forwarder = Some(handle);
             }
             Some(DaemonResponse::SubscribeGlobalOk { request_id })
@@ -1009,15 +1008,13 @@ async fn forward_queued_to_client(
 async fn forward_global_to_client(
     mut rx: tokio::sync::broadcast::Receiver<GlobalDaemonEvent>,
     writer: Arc<Mutex<interprocess::local_socket::tokio::SendHalf>>,
-    request_id: RequestId,
 ) {
-    forward_global_to_writer(&mut rx, writer, request_id).await;
+    forward_global_to_writer(&mut rx, writer).await;
 }
 
 async fn forward_global_to_writer<W>(
     rx: &mut tokio::sync::broadcast::Receiver<GlobalDaemonEvent>,
     writer: Arc<Mutex<W>>,
-    request_id: RequestId,
 ) where
     W: AsyncWrite + Unpin,
 {
@@ -1037,13 +1034,9 @@ async fn forward_global_to_writer<W>(
             Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
             Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
                 tracing::warn!(dropped = n, "global forwarder lagged");
-                let err = DaemonResponse::Error {
-                    request_id,
-                    code: ErrorCode::SubscriberLagged,
-                    message: format!("global subscriber lagged by {n} events"),
-                };
+                let frame = DaemonEvent::Global(GlobalDaemonEvent::SubscriberLagged { dropped: n });
                 let mut w = writer.lock().await;
-                let _ = write_frame(&mut *w, &err).await;
+                let _ = write_frame(&mut *w, &frame).await;
                 break;
             },
         }
@@ -1068,7 +1061,7 @@ mod tests {
 
         let (client, server) = tokio::io::duplex(4096);
         let writer = Arc::new(Mutex::new(server));
-        forward_global_to_writer(&mut rx, writer, 42).await;
+        forward_global_to_writer(&mut rx, writer).await;
 
         let mut reader = BufReader::new(client);
         let frame = surge_orchestrator::engine::ipc::read_inbound_server_frame(&mut reader)
@@ -1077,18 +1070,10 @@ mod tests {
             .expect("lag response frame");
 
         match frame {
-            surge_orchestrator::engine::ipc::InboundServerFrame::Response(
-                DaemonResponse::Error {
-                    request_id,
-                    code,
-                    message,
-                },
-            ) => {
-                assert_eq!(request_id, 42);
-                assert_eq!(code, ErrorCode::SubscriberLagged);
-                assert!(message.contains("lagged"));
-            },
-            other => panic!("expected SubscriberLagged response, got {other:?}"),
+            surge_orchestrator::engine::ipc::InboundServerFrame::Event(DaemonEvent::Global(
+                GlobalDaemonEvent::SubscriberLagged { dropped },
+            )) => assert!(dropped > 0, "lagged event should report dropped count"),
+            other => panic!("expected SubscriberLagged global event, got {other:?}"),
         }
     }
 }

--- a/crates/surge-daemon/src/server.rs
+++ b/crates/surge-daemon/src/server.rs
@@ -20,7 +20,7 @@ use surge_orchestrator::engine::ipc::{
     DaemonEvent, DaemonRequest, DaemonResponse, ErrorCode, GlobalDaemonEvent, RequestId,
     read_request_frame, write_frame,
 };
-use tokio::io::{AsyncWriteExt, BufReader};
+use tokio::io::{AsyncWrite, AsyncWriteExt, BufReader};
 use tokio::sync::Mutex;
 use tokio_util::sync::CancellationToken;
 
@@ -761,7 +761,8 @@ async fn dispatch(
                 }
                 let rx = broadcast.subscribe_global();
                 let writer_for_task = writer.clone();
-                let handle = tokio::spawn(forward_global_to_client(rx, writer_for_task));
+                let handle =
+                    tokio::spawn(forward_global_to_client(rx, writer_for_task, request_id));
                 s.global_forwarder = Some(handle);
             }
             Some(DaemonResponse::SubscribeGlobalOk { request_id })
@@ -1008,7 +1009,18 @@ async fn forward_queued_to_client(
 async fn forward_global_to_client(
     mut rx: tokio::sync::broadcast::Receiver<GlobalDaemonEvent>,
     writer: Arc<Mutex<interprocess::local_socket::tokio::SendHalf>>,
+    request_id: RequestId,
 ) {
+    forward_global_to_writer(&mut rx, writer, request_id).await;
+}
+
+async fn forward_global_to_writer<W>(
+    rx: &mut tokio::sync::broadcast::Receiver<GlobalDaemonEvent>,
+    writer: Arc<Mutex<W>>,
+    request_id: RequestId,
+) where
+    W: AsyncWrite + Unpin,
+{
     loop {
         match rx.recv().await {
             Ok(event) => {
@@ -1025,7 +1037,58 @@ async fn forward_global_to_client(
             Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
             Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
                 tracing::warn!(dropped = n, "global forwarder lagged");
+                let err = DaemonResponse::Error {
+                    request_id,
+                    code: ErrorCode::SubscriberLagged,
+                    message: format!("global subscriber lagged by {n} events"),
+                };
+                let mut w = writer.lock().await;
+                let _ = write_frame(&mut *w, &err).await;
+                break;
             },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::io::BufReader;
+
+    #[tokio::test]
+    async fn global_forwarder_reports_lag_and_closes() {
+        let (tx, _) = tokio::sync::broadcast::channel(2);
+        let mut rx = tx.subscribe();
+        for _ in 0..5 {
+            tx.send(GlobalDaemonEvent::RunAccepted {
+                run_id: RunId::new(),
+            })
+            .expect("send global event");
+        }
+
+        let (client, server) = tokio::io::duplex(4096);
+        let writer = Arc::new(Mutex::new(server));
+        forward_global_to_writer(&mut rx, writer, 42).await;
+
+        let mut reader = BufReader::new(client);
+        let frame = surge_orchestrator::engine::ipc::read_inbound_server_frame(&mut reader)
+            .await
+            .expect("read lag response")
+            .expect("lag response frame");
+
+        match frame {
+            surge_orchestrator::engine::ipc::InboundServerFrame::Response(
+                DaemonResponse::Error {
+                    request_id,
+                    code,
+                    message,
+                },
+            ) => {
+                assert_eq!(request_id, 42);
+                assert_eq!(code, ErrorCode::SubscriberLagged);
+                assert!(message.contains("lagged"));
+            },
+            other => panic!("expected SubscriberLagged response, got {other:?}"),
         }
     }
 }

--- a/crates/surge-daemon/tests/daemon_parity_test.rs
+++ b/crates/surge-daemon/tests/daemon_parity_test.rs
@@ -1,24 +1,17 @@
 //! Task 3.3 — regression-guarding parity test.
 //!
-//! Runs `flow_terminal_only.toml` through both
+//! Runs `flow_terminal_only.toml`, `flow_minimal_agent.toml`, and one new
+//! archetype through both
 //! [`LocalEngineFacade`] (direct in-process) and
 //! [`DaemonEngineFacade`] (IPC over a local socket against an
 //! inline-spawned `surge-daemon` server) and asserts the resulting
 //! event sequence is identical modulo wall-clock fields.
 //!
-//! Why terminal-only: the engine reaches `RunCompleted` without
-//! needing an ACP turn loop, so events are deterministic across
-//! both paths. Agent-bearing archetypes require scenario-aware
-//! mock-ACP scripting (covered by `archetypes_mock_test.rs` in
-//! `surge-orchestrator/tests/`), and their event order against a
-//! non-deterministic mock turn loop would not parity-compare
-//! cleanly.
-//!
-//! Future extensions: once `mock_acp_agent.rs` exposes a
-//! `report_sequence` scenario that produces a deterministic event
-//! log against any of the new archetypes, this test should be
-//! extended to include it.
+//! The local bridge used here deterministically reports the first declared
+//! outcome after every agent prompt, which keeps agent-bearing flows comparable
+//! across local and daemon paths.
 
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
@@ -30,9 +23,9 @@ use surge_acp::bridge::error::{
 use surge_acp::bridge::event::{BridgeEvent, ToolResultPayload};
 use surge_acp::bridge::facade::BridgeFacade;
 use surge_acp::bridge::session::{MessageContent, SessionConfig, SessionState};
-use surge_core::SessionId;
 use surge_core::graph::Graph;
 use surge_core::id::RunId;
+use surge_core::{OutcomeKey, SessionId};
 use surge_daemon::{ServerConfig, run_server};
 use surge_orchestrator::engine::daemon_facade::DaemonEngineFacade;
 use surge_orchestrator::engine::facade::{EngineFacade, LocalEngineFacade};
@@ -42,7 +35,7 @@ use surge_orchestrator::engine::tools::worktree::WorktreeToolDispatcher;
 use surge_orchestrator::engine::{Engine, EngineConfig, EngineRunConfig};
 use surge_persistence::runs::Storage;
 use tempfile::TempDir;
-use tokio::sync::broadcast;
+use tokio::sync::{Mutex, broadcast};
 use tokio_util::sync::CancellationToken;
 
 fn examples_dir() -> PathBuf {
@@ -68,36 +61,56 @@ fn unique_socket_path(temp: &TempDir, prefix: &str) -> PathBuf {
     temp.path().join(format!("{prefix}_{pid}_{nanos}.sock"))
 }
 
-/// Minimal stub bridge for parity-test usage. The terminal-only
-/// archetype never opens an ACP session, so every method is
-/// allowed to return Err / a default. Mirrors the shape of
-/// `daemon_e2e_smoke::StubFacade` but for [`BridgeFacade`].
-struct StubBridge {
+/// Deterministic bridge for parity-test usage. Terminal-only flows
+/// never call it; agent flows receive their first declared outcome
+/// immediately after the engine sends the stage prompt.
+struct AutoOutcomeBridge {
     tx: broadcast::Sender<BridgeEvent>,
+    outcomes: Mutex<HashMap<SessionId, OutcomeKey>>,
 }
 
-impl StubBridge {
+impl AutoOutcomeBridge {
     fn new() -> Self {
         let (tx, _) = broadcast::channel(8);
-        Self { tx }
+        Self {
+            tx,
+            outcomes: Mutex::new(HashMap::new()),
+        }
     }
 }
 
 #[async_trait]
-impl BridgeFacade for StubBridge {
-    async fn open_session(&self, _config: SessionConfig) -> Result<SessionId, OpenSessionError> {
-        // Terminal-only flow never opens an ACP session, so reaching
-        // this in the parity test would be a real failure. Return a
-        // clearly-labelled error rather than a default success.
-        Err(OpenSessionError::Bridge(BridgeError::WorkerDead))
+impl BridgeFacade for AutoOutcomeBridge {
+    async fn open_session(&self, config: SessionConfig) -> Result<SessionId, OpenSessionError> {
+        let session = SessionId::new();
+        let outcome = config
+            .declared_outcomes
+            .first()
+            .cloned()
+            .unwrap_or_else(|| OutcomeKey::try_from("done").expect("'done' is a valid outcome"));
+        self.outcomes.lock().await.insert(session, outcome);
+        Ok(session)
     }
 
     async fn send_message(
         &self,
-        _session: SessionId,
+        session: SessionId,
         _content: MessageContent,
     ) -> Result<(), SendMessageError> {
-        Err(SendMessageError::Bridge(BridgeError::WorkerDead))
+        let outcome = self
+            .outcomes
+            .lock()
+            .await
+            .get(&session)
+            .cloned()
+            .unwrap_or_else(|| OutcomeKey::try_from("done").expect("'done' is a valid outcome"));
+        let _ = self.tx.send(BridgeEvent::OutcomeReported {
+            session,
+            outcome,
+            summary: "auto parity outcome".into(),
+            artifacts_produced: vec![],
+        });
+        Ok(())
     }
 
     async fn session_state(&self, _session: SessionId) -> Result<SessionState, BridgeError> {
@@ -124,7 +137,7 @@ impl BridgeFacade for StubBridge {
 
 async fn build_local_engine(dir: &Path) -> Arc<Engine> {
     let storage = Storage::open(dir).await.expect("storage");
-    let bridge = Arc::new(StubBridge::new()) as Arc<dyn BridgeFacade>;
+    let bridge = Arc::new(AutoOutcomeBridge::new()) as Arc<dyn BridgeFacade>;
     let dispatcher =
         Arc::new(WorktreeToolDispatcher::new(dir.to_path_buf())) as Arc<dyn ToolDispatcher>;
     Arc::new(Engine::new(
@@ -205,18 +218,11 @@ async fn run_through_facade<F: EngineFacade>(
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-async fn parity_flow_terminal_only_local_vs_daemon() {
+async fn parity_terminal_minimal_agent_and_spike_local_vs_daemon() {
     // --- Local path ---
     let local_dir = TempDir::new().unwrap();
     let local_engine = build_local_engine(local_dir.path()).await;
     let local_facade = LocalEngineFacade::new(local_engine);
-    let local_events = run_through_facade(
-        &local_facade,
-        "flow_terminal_only.toml",
-        local_dir.path().to_path_buf(),
-    )
-    .await;
-
     // --- Daemon path ---
     let daemon_dir = TempDir::new().unwrap();
     let daemon_engine = build_local_engine(daemon_dir.path()).await;
@@ -237,28 +243,30 @@ async fn parity_flow_terminal_only_local_vs_daemon() {
     tokio::time::sleep(Duration::from_millis(200)).await;
 
     let daemon_facade = DaemonEngineFacade::connect(socket).await.expect("connect");
-    let daemon_events = run_through_facade(
-        &daemon_facade,
+    for archetype in [
         "flow_terminal_only.toml",
-        daemon_dir.path().to_path_buf(),
-    )
-    .await;
+        "flow_minimal_agent.toml",
+        "flow_spike.toml",
+    ] {
+        let local_events =
+            run_through_facade(&local_facade, archetype, local_dir.path().to_path_buf()).await;
+        let daemon_events =
+            run_through_facade(&daemon_facade, archetype, daemon_dir.path().to_path_buf()).await;
+
+        assert_eq!(
+            local_events, daemon_events,
+            "{archetype}: local vs daemon event sequences must match modulo wall-clock fields\nLocal: {local_events:?}\nDaemon: {daemon_events:?}"
+        );
+        assert!(
+            local_events.iter().any(|e| e.starts_with("terminal:")),
+            "{archetype}: local sequence must include a Terminal event"
+        );
+        assert!(
+            daemon_events.iter().any(|e| e.starts_with("terminal:")),
+            "{archetype}: daemon sequence must include a Terminal event"
+        );
+    }
 
     shutdown.cancel();
     let _ = tokio::time::timeout(Duration::from_secs(2), server_handle).await;
-
-    // --- Parity assertion ---
-    assert_eq!(
-        local_events, daemon_events,
-        "local vs daemon event sequences must match modulo wall-clock fields\nLocal: {local_events:?}\nDaemon: {daemon_events:?}"
-    );
-    // Sanity: at least one Terminal event in both.
-    assert!(
-        local_events.iter().any(|e| e.starts_with("terminal:")),
-        "local sequence must include a Terminal event"
-    );
-    assert!(
-        daemon_events.iter().any(|e| e.starts_with("terminal:")),
-        "daemon sequence must include a Terminal event"
-    );
 }

--- a/crates/surge-orchestrator/benches/stage_transition.rs
+++ b/crates/surge-orchestrator/benches/stage_transition.rs
@@ -25,19 +25,24 @@
 //! ```
 
 use std::path::PathBuf;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use criterion::{Criterion, criterion_group, criterion_main};
 use surge_core::branch_config::{BranchArm, BranchConfig, Predicate};
-use surge_core::keys::{NodeKey, OutcomeKey};
+use surge_core::id::RunId;
+use surge_core::keys::{EdgeKey, NodeKey, OutcomeKey};
+use surge_core::run_event::{EventPayload, VersionedEventPayload};
 use surge_core::run_state::RunMemory;
 use surge_orchestrator::engine::stage::branch::{BranchStageParams, execute_branch_stage};
-use surge_persistence::runs::Storage;
+use surge_persistence::runs::{RunWriter, Storage};
 use tokio::runtime::Runtime;
 
 /// Per-transition wall-clock budget in microseconds. CI bench gate compares
 /// every run's p95 against this value. See module-level docs for the rule.
 pub const P95_BUDGET_US: u64 = 5_000;
+const BUDGET_CHECK_ENV: &str = "SURGE_STAGE_TRANSITION_BUDGET_CHECK";
+const BUDGET_SAMPLE_COUNT: usize = 64;
+const WARMUP_TRANSITIONS: usize = 8;
 
 struct BenchFixture {
     rt: Runtime,
@@ -46,6 +51,8 @@ struct BenchFixture {
     writer_path: PathBuf,
     cfg: BranchConfig,
     node: NodeKey,
+    edge: EdgeKey,
+    next: NodeKey,
     memory: RunMemory,
 }
 
@@ -81,43 +88,122 @@ fn build_fixture() -> BenchFixture {
         writer_path,
         cfg,
         node: NodeKey::try_from("decide").unwrap(),
+        edge: EdgeKey::try_from("e_decide_end").unwrap(),
+        next: NodeKey::try_from("end").unwrap(),
         memory: RunMemory::default(),
     }
 }
 
+async fn create_run_writer(fixture: &BenchFixture) -> RunWriter {
+    fixture
+        .storage
+        .create_run(RunId::new(), &fixture.writer_path, None)
+        .await
+        .expect("create_run")
+}
+
+async fn execute_one_transition(fixture: &BenchFixture, writer: &RunWriter) {
+    writer
+        .append_event(VersionedEventPayload::new(EventPayload::StageEntered {
+            node: fixture.node.clone(),
+            attempt: 1,
+        }))
+        .await
+        .expect("append StageEntered");
+
+    let outcome = execute_branch_stage(BranchStageParams {
+        node: &fixture.node,
+        branch_config: &fixture.cfg,
+        writer,
+        run_memory: &fixture.memory,
+        worktree_root: &fixture.writer_path,
+    })
+    .await
+    .expect("branch stage");
+
+    writer
+        .append_event(VersionedEventPayload::new(EventPayload::EdgeTraversed {
+            edge: fixture.edge.clone(),
+            from: fixture.node.clone(),
+            to: fixture.next.clone(),
+        }))
+        .await
+        .expect("append EdgeTraversed");
+    writer
+        .append_event(VersionedEventPayload::new(EventPayload::StageCompleted {
+            node: fixture.node.clone(),
+            outcome,
+        }))
+        .await
+        .expect("append StageCompleted");
+}
+
+fn close_writer(fixture: &BenchFixture, writer: RunWriter) {
+    fixture
+        .rt
+        .block_on(async { writer.close().await.expect("close writer") });
+}
+
+fn sample_stage_transition_latencies(fixture: &BenchFixture, samples: usize) -> Vec<Duration> {
+    let writer = fixture.rt.block_on(create_run_writer(fixture));
+    let durations = fixture.rt.block_on(async {
+        for _ in 0..WARMUP_TRANSITIONS {
+            execute_one_transition(fixture, &writer).await;
+        }
+
+        let mut durations = Vec::with_capacity(samples);
+        for _ in 0..samples {
+            let started = Instant::now();
+            execute_one_transition(fixture, &writer).await;
+            durations.push(started.elapsed());
+        }
+        durations
+    });
+    close_writer(fixture, writer);
+    durations
+}
+
+fn p95_micros(samples: &[Duration]) -> u128 {
+    assert!(!samples.is_empty(), "p95 requires at least one sample");
+    let mut micros: Vec<u128> = samples.iter().map(Duration::as_micros).collect();
+    micros.sort_unstable();
+    let rank = (micros.len() * 95).div_ceil(100).saturating_sub(1);
+    micros[rank]
+}
+
+fn enforce_budget_if_requested(fixture: &BenchFixture) {
+    if std::env::var_os(BUDGET_CHECK_ENV).is_none() {
+        return;
+    }
+
+    let samples = sample_stage_transition_latencies(fixture, BUDGET_SAMPLE_COUNT);
+    let observed_p95 = p95_micros(&samples);
+    assert!(
+        observed_p95 <= u128::from(P95_BUDGET_US),
+        "stage_transition p95 budget exceeded: observed {observed_p95}us, budget {P95_BUDGET_US}us"
+    );
+}
+
 fn branch_stage_transition(c: &mut Criterion) {
     let fixture = build_fixture();
+    enforce_budget_if_requested(&fixture);
+
     let mut group = c.benchmark_group("engine.stage_transition");
     group.measurement_time(Duration::from_secs(8));
     group.sample_size(50);
 
     group.bench_function("branch_node_one_transition", |b| {
         b.iter_custom(|iters| {
-            let start = std::time::Instant::now();
+            let writer = fixture.rt.block_on(create_run_writer(&fixture));
+            let start = Instant::now();
             fixture.rt.block_on(async {
                 for _ in 0..iters {
-                    // Each iteration runs a fresh run because RunWriter is
-                    // single-use; this dominates the measurement at low
-                    // iters but stabilises at high `iters`.
-                    let run_id = surge_core::id::RunId::new();
-                    let writer = fixture
-                        .storage
-                        .create_run(run_id, &fixture.writer_path, None)
-                        .await
-                        .expect("create_run");
-                    let _ = execute_branch_stage(BranchStageParams {
-                        node: &fixture.node,
-                        branch_config: &fixture.cfg,
-                        writer: &writer,
-                        run_memory: &fixture.memory,
-                        worktree_root: &fixture.writer_path,
-                    })
-                    .await
-                    .expect("branch stage");
-                    writer.close().await.expect("close writer");
+                    execute_one_transition(&fixture, &writer).await;
                 }
             });
-            start.elapsed()
+            let elapsed = start.elapsed();
+            close_writer(&fixture, writer);
+            elapsed
         });
     });
 

--- a/crates/surge-orchestrator/src/engine/ipc.rs
+++ b/crates/surge-orchestrator/src/engine/ipc.rs
@@ -50,6 +50,8 @@ pub enum ErrorCode {
     Internal,
     /// The daemon is in graceful shutdown and refusing new work.
     ShuttingDown,
+    /// A subscription receiver fell behind the daemon's broadcast channel.
+    SubscriberLagged,
 }
 
 /// Request frames sent from CLI to daemon.

--- a/crates/surge-orchestrator/src/engine/ipc.rs
+++ b/crates/surge-orchestrator/src/engine/ipc.rs
@@ -316,6 +316,13 @@ pub enum GlobalDaemonEvent {
     },
     /// The daemon is beginning graceful shutdown.
     DaemonShuttingDown,
+    /// This connection's global-event subscription lagged past the daemon's
+    /// broadcast buffer. The daemon stops forwarding global events after this
+    /// frame; clients should re-subscribe if they still need the stream.
+    SubscriberLagged {
+        /// Number of global events dropped before the lag was detected.
+        dropped: u64,
+    },
 }
 
 // ============================================================================

--- a/crates/surge-orchestrator/src/engine/routing.rs
+++ b/crates/surge-orchestrator/src/engine/routing.rs
@@ -134,8 +134,27 @@ pub fn edge_target_after_outcome_or_default(
     node: &NodeKey,
     outcome: &OutcomeKey,
 ) -> Result<NodeKey, RoutingError> {
-    graph
-        .edges
+    edge_target_in_edges(&graph.edges, node, outcome)
+}
+
+/// Like [`edge_target_after_outcome_or_default`], but resolves against the
+/// currently active graph/subgraph edge set. Used when pushing nested Loop or
+/// Subgraph frames so their `return_to` points to the correct graph scope.
+pub fn edge_target_after_outcome_in_active_graph(
+    graph: &Graph,
+    node: &NodeKey,
+    outcome: &OutcomeKey,
+    frames: &[crate::engine::frames::Frame],
+) -> Result<NodeKey, RoutingError> {
+    edge_target_in_edges(active_edge_set(graph, frames), node, outcome)
+}
+
+fn edge_target_in_edges(
+    edges: &[Edge],
+    node: &NodeKey,
+    outcome: &OutcomeKey,
+) -> Result<NodeKey, RoutingError> {
+    edges
         .iter()
         .find(|e| &e.from.node == node && &e.from.outcome == outcome)
         .map(|e| e.to.clone())

--- a/crates/surge-orchestrator/src/engine/run_task.rs
+++ b/crates/surge-orchestrator/src/engine/run_task.rs
@@ -288,14 +288,16 @@ pub(crate) async fn execute(params: RunTaskParams) -> RunOutcome {
                     Ok(o) => o,
                     Err(e) => return failed(&params, format!("'completed' outcome: {e}")).await,
                 };
-                let return_to = match crate::engine::routing::edge_target_after_outcome_or_default(
-                    &params.graph,
-                    &cursor.node,
-                    &completed_outcome,
-                ) {
-                    Ok(n) => n,
-                    Err(e) => return failed(&params, format!("loop return_to: {e}")).await,
-                };
+                let return_to =
+                    match crate::engine::routing::edge_target_after_outcome_in_active_graph(
+                        &params.graph,
+                        &cursor.node,
+                        &completed_outcome,
+                        &frames,
+                    ) {
+                        Ok(n) => n,
+                        Err(e) => return failed(&params, format!("loop return_to: {e}")).await,
+                    };
 
                 let effect = match crate::engine::stage::loop_stage::execute_loop_entry(
                     crate::engine::stage::loop_stage::LoopStageParams {
@@ -330,14 +332,16 @@ pub(crate) async fn execute(params: RunTaskParams) -> RunOutcome {
                     Ok(o) => o,
                     Err(e) => return failed(&params, format!("'completed' outcome: {e}")).await,
                 };
-                let return_to = match crate::engine::routing::edge_target_after_outcome_or_default(
-                    &params.graph,
-                    &cursor.node,
-                    &completed_outcome,
-                ) {
-                    Ok(n) => n,
-                    Err(e) => return failed(&params, format!("subgraph return_to: {e}")).await,
-                };
+                let return_to =
+                    match crate::engine::routing::edge_target_after_outcome_in_active_graph(
+                        &params.graph,
+                        &cursor.node,
+                        &completed_outcome,
+                        &frames,
+                    ) {
+                        Ok(n) => n,
+                        Err(e) => return failed(&params, format!("subgraph return_to: {e}")).await,
+                    };
 
                 let effect = match crate::engine::stage::subgraph_stage::execute_subgraph_entry(
                     crate::engine::stage::subgraph_stage::SubgraphStageParams {

--- a/crates/surge-orchestrator/tests/archetypes_mock_test.rs
+++ b/crates/surge-orchestrator/tests/archetypes_mock_test.rs
@@ -1,40 +1,44 @@
-//! Task 5.1 — drive every bundled `examples/flow_*.toml` archetype
-//! through the engine against [`fixtures::mock_bridge::MockBridge`].
+//! Task 5.1 — drive every bundled `examples/flow_*.toml` archetype through
+//! the engine against a deterministic mock ACP bridge.
 //!
-//! Scope vs. scope of `crates/surge-cli/tests/examples_smoke.rs`:
-//!
-//! * `examples_smoke.rs` parses each archetype and runs the syntactic
-//!   + resolver-aware validator. It guards the example shape.
-//! * This file boots the engine with a [`MockBridge`] and confirms
-//!   each archetype reaches `start_run` without error. Pure-terminal
-//!   archetypes (e.g. `flow_terminal_only.toml`) are run to
-//!   completion; agent-bearing archetypes are accepted as
-//!   "engine starts cleanly" — the mock bridge intentionally does
-//!   not script per-archetype turn loops, so a deterministic
-//!   completion would require scenario-aware mock scripting that
-//!   belongs in `crates/surge-acp/src/bin/mock_acp_agent.rs`. The
-//!   real-ACP smoke (gated, see `tests/real_acp_smoke.rs`) covers
-//!   the `flow_minimal_agent` happy path against an actual agent.
-//!
-//! Together, the three layers (validator → engine boot → real ACP)
-//! satisfy the acceptance criteria for Task 5.1: every archetype
-//! shape is parseable, validatable, and bootable; full end-to-end
-//! against a real or scripted mock agent is exercised by the gated
-//! real-ACP test and per-feature unit tests in
-//! `crates/surge-orchestrator/tests/`.
+//! The bridge chooses the first declared outcome for every agent session.
+//! The examples are authored so those first outcomes follow the happy path,
+//! which gives this suite a deterministic terminal run for every archetype
+//! without requiring an external ACP binary.
 
-mod fixtures;
-
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
+
+use async_trait::async_trait;
+use surge_acp::bridge::error::{
+    BridgeError, CloseSessionError, OpenSessionError, ReplyToToolError, SendMessageError,
+};
+use surge_acp::bridge::event::{BridgeEvent, ToolResultPayload};
 use surge_acp::bridge::facade::BridgeFacade;
+use surge_acp::bridge::session::{MessageContent, SessionConfig, SessionState};
 use surge_core::graph::Graph;
-use surge_core::id::RunId;
+use surge_core::id::{RunId, SessionId};
+use surge_core::keys::OutcomeKey;
+use surge_core::run_event::EventPayload;
 use surge_orchestrator::engine::tools::ToolDispatcher;
 use surge_orchestrator::engine::tools::worktree::WorktreeToolDispatcher;
 use surge_orchestrator::engine::{Engine, EngineConfig, EngineRunConfig, RunOutcome};
 use surge_persistence::runs::Storage;
+use surge_persistence::runs::seq::EventSeq;
+use tokio::sync::{Mutex, broadcast};
+
+const ARCHETYPES: &[&str] = &[
+    "flow_terminal_only.toml",
+    "flow_minimal_agent.toml",
+    "flow_linear_3.toml",
+    "flow_single_loop.toml",
+    "flow_multi_milestone.toml",
+    "flow_bug_fix.toml",
+    "flow_refactor.toml",
+    "flow_spike.toml",
+];
 
 fn examples_dir() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR"))
@@ -50,95 +54,130 @@ fn load_archetype(name: &str) -> Graph {
     toml::from_str(&toml_s).unwrap_or_else(|e| panic!("parse {}: {e}", path.display()))
 }
 
-/// Start a run for the given archetype and assert `start_run`
-/// returns Ok. The handle is returned so the caller can drive
-/// completion or just drop (which kills the run).
-async fn start_archetype(
-    name: &str,
-) -> (
-    Arc<Engine>,
-    surge_orchestrator::engine::handle::RunHandle,
-    tempfile::TempDir,
-) {
+struct DeterministicMockBridge {
+    tx: broadcast::Sender<BridgeEvent>,
+    outcomes: Mutex<HashMap<SessionId, OutcomeKey>>,
+}
+
+impl DeterministicMockBridge {
+    fn new() -> Self {
+        let (tx, _) = broadcast::channel(64);
+        Self {
+            tx,
+            outcomes: Mutex::new(HashMap::new()),
+        }
+    }
+}
+
+#[async_trait]
+impl BridgeFacade for DeterministicMockBridge {
+    async fn open_session(&self, config: SessionConfig) -> Result<SessionId, OpenSessionError> {
+        let session = SessionId::new();
+        let outcome = config
+            .declared_outcomes
+            .first()
+            .cloned()
+            .unwrap_or_else(|| OutcomeKey::try_from("done").expect("'done' is a valid outcome"));
+        self.outcomes.lock().await.insert(session, outcome);
+        Ok(session)
+    }
+
+    async fn send_message(
+        &self,
+        session: SessionId,
+        _content: MessageContent,
+    ) -> Result<(), SendMessageError> {
+        let outcome = self
+            .outcomes
+            .lock()
+            .await
+            .get(&session)
+            .cloned()
+            .unwrap_or_else(|| OutcomeKey::try_from("done").expect("'done' is a valid outcome"));
+        let _ = self.tx.send(BridgeEvent::OutcomeReported {
+            session,
+            outcome,
+            summary: "deterministic mock outcome".into(),
+            artifacts_produced: vec![],
+        });
+        Ok(())
+    }
+
+    async fn session_state(&self, _session: SessionId) -> Result<SessionState, BridgeError> {
+        Err(BridgeError::WorkerDead)
+    }
+
+    async fn close_session(&self, _session: SessionId) -> Result<(), CloseSessionError> {
+        Ok(())
+    }
+
+    async fn reply_to_tool(
+        &self,
+        _session: SessionId,
+        _call_id: String,
+        _payload: ToolResultPayload,
+    ) -> Result<(), ReplyToToolError> {
+        Ok(())
+    }
+
+    fn subscribe(&self) -> broadcast::Receiver<BridgeEvent> {
+        self.tx.subscribe()
+    }
+}
+
+async fn run_archetype(name: &str) -> Vec<surge_persistence::runs::reader::ReadEvent> {
     let dir = tempfile::tempdir().expect("tempdir");
     let storage = Storage::open(dir.path()).await.expect("storage");
-    let bridge = Arc::new(fixtures::mock_bridge::MockBridge::new()) as Arc<dyn BridgeFacade>;
+    let bridge = Arc::new(DeterministicMockBridge::new()) as Arc<dyn BridgeFacade>;
     let dispatcher =
         Arc::new(WorktreeToolDispatcher::new(dir.path().to_path_buf())) as Arc<dyn ToolDispatcher>;
-    let engine = Arc::new(Engine::new(
-        bridge,
-        storage,
-        dispatcher,
-        EngineConfig::default(),
-    ));
+    let engine = Engine::new(bridge, storage.clone(), dispatcher, EngineConfig::default());
 
-    let graph = load_archetype(name);
     let run_id = RunId::new();
     let handle = engine
         .start_run(
             run_id,
-            graph,
+            load_archetype(name),
             dir.path().to_path_buf(),
             EngineRunConfig::default(),
         )
         .await
         .unwrap_or_else(|e| panic!("{name}: start_run failed: {e}"));
-    (engine, handle, dir)
-}
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn flow_terminal_only_completes_against_mock_bridge() {
-    let (_engine, handle, _dir) = start_archetype("flow_terminal_only.toml").await;
-    let outcome = tokio::time::timeout(Duration::from_secs(5), handle.await_completion())
+    let outcome = tokio::time::timeout(Duration::from_secs(30), handle.await_completion())
         .await
-        .expect("flow_terminal_only.toml hung > 5s")
+        .unwrap_or_else(|_| panic!("{name}: run hung > 30s"))
         .expect("await_completion");
     match outcome {
         RunOutcome::Completed { .. } => {},
-        other => panic!("expected Completed, got {other:?}"),
+        other => panic!("{name}: expected Completed, got {other:?}"),
     }
-}
+    drop(engine);
 
-/// All non-terminal-only archetypes need ACP scripting to complete
-/// deterministically; we only assert `start_run` succeeds. The
-/// engine is dropped at end of scope which cancels the run.
-async fn assert_archetype_starts(name: &str) {
-    let (_engine, _handle, _dir) = start_archetype(name).await;
-    // Drop kills the run; the assertion is implicit in start_run not
-    // returning Err above.
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn flow_minimal_agent_starts() {
-    assert_archetype_starts("flow_minimal_agent.toml").await;
+    let reader = storage.open_run_reader(run_id).await.unwrap();
+    let last = reader.current_seq().await.unwrap();
+    reader
+        .read_events(EventSeq(0)..EventSeq(last.0 + 1))
+        .await
+        .unwrap()
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn flow_linear_3_starts() {
-    assert_archetype_starts("flow_linear_3.toml").await;
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn flow_single_loop_starts() {
-    assert_archetype_starts("flow_single_loop.toml").await;
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn flow_multi_milestone_starts() {
-    assert_archetype_starts("flow_multi_milestone.toml").await;
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn flow_bug_fix_starts() {
-    assert_archetype_starts("flow_bug_fix.toml").await;
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn flow_refactor_starts() {
-    assert_archetype_starts("flow_refactor.toml").await;
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn flow_spike_starts() {
-    assert_archetype_starts("flow_spike.toml").await;
+async fn all_archetypes_complete_against_deterministic_mock_bridge() {
+    for name in ARCHETYPES {
+        let events = run_archetype(name).await;
+        assert!(
+            events.iter().all(|ev| !matches!(
+                ev.payload.payload,
+                EventPayload::StageFailed { .. } | EventPayload::RunFailed { .. }
+            )),
+            "{name}: run contained StageFailed/RunFailed: {events:?}"
+        );
+        assert!(
+            events
+                .iter()
+                .any(|ev| matches!(ev.payload.payload, EventPayload::RunCompleted { .. })),
+            "{name}: missing RunCompleted event"
+        );
+    }
 }

--- a/crates/surge-orchestrator/tests/on_error_suppress_test.rs
+++ b/crates/surge-orchestrator/tests/on_error_suppress_test.rs
@@ -37,7 +37,8 @@ fn suppress_command(dir: &Path, outcome: &str) -> String {
     let path = dir.join(format!("suppress-{outcome}.json"));
     std::fs::write(&path, json).unwrap();
     if cfg!(target_os = "windows") {
-        format!("type {}", path.display())
+        let literal_path = path.display().to_string().replace('\'', "''");
+        format!("powershell -NoProfile -Command Get-Content -Raw -LiteralPath '{literal_path}'")
     } else {
         format!(r#"cat "{}""#, path.display())
     }

--- a/crates/surge-orchestrator/tests/on_error_suppress_test.rs
+++ b/crates/surge-orchestrator/tests/on_error_suppress_test.rs
@@ -1,0 +1,282 @@
+//! Integration tests for `on_error` hook suppression at the run-task boundary.
+//!
+//! These tests drive the public `Engine::start_run` path with a scripted
+//! `MockBridge` session crash. The assertions prove the central stage-error
+//! catch site runs hooks before deciding whether to persist `StageFailed`.
+
+#![allow(clippy::too_many_lines)]
+
+mod fixtures;
+
+use std::collections::BTreeMap;
+use std::path::Path;
+use std::sync::Arc;
+use std::time::Duration;
+
+use surge_acp::bridge::event::{BridgeEvent, SessionEndReason};
+use surge_acp::bridge::facade::BridgeFacade;
+use surge_core::agent_config::{AgentConfig, NodeLimits};
+use surge_core::edge::{Edge, EdgeKind, EdgePolicy, PortRef};
+use surge_core::graph::{Graph, GraphMetadata, SCHEMA_VERSION};
+use surge_core::hooks::{Hook, HookFailureMode, HookInheritance, HookTrigger, MatcherSpec};
+use surge_core::id::{RunId, SessionId};
+use surge_core::keys::{EdgeKey, NodeKey, OutcomeKey, ProfileKey};
+use surge_core::node::{Node, NodeConfig, OutcomeDecl, Position};
+use surge_core::run_event::EventPayload;
+use surge_core::terminal_config::{TerminalConfig, TerminalKind};
+use surge_orchestrator::engine::tools::ToolDispatcher;
+use surge_orchestrator::engine::tools::worktree::WorktreeToolDispatcher;
+use surge_orchestrator::engine::{Engine, EngineConfig, EngineRunConfig, RunOutcome};
+use surge_persistence::runs::Storage;
+use surge_persistence::runs::seq::EventSeq;
+
+use fixtures::mock_bridge::MockBridge;
+
+fn suppress_command(dir: &Path, outcome: &str) -> String {
+    let json = format!(r#"{{"action":"suppress","outcome":"{outcome}"}}"#);
+    let path = dir.join(format!("suppress-{outcome}.json"));
+    std::fs::write(&path, json).unwrap();
+    if cfg!(target_os = "windows") {
+        format!("type {}", path.display())
+    } else {
+        format!(r#"cat "{}""#, path.display())
+    }
+}
+
+fn on_error_suppress_hook(id: &str, command: String) -> Hook {
+    Hook {
+        id: id.into(),
+        trigger: HookTrigger::OnError,
+        matcher: MatcherSpec::default(),
+        command,
+        on_failure: HookFailureMode::Warn,
+        timeout_seconds: Some(5),
+        inherit: HookInheritance::Extend,
+    }
+}
+
+fn outcome_decl(id: &str) -> OutcomeDecl {
+    OutcomeDecl {
+        id: OutcomeKey::try_from(id).unwrap(),
+        description: format!("{id} outcome"),
+        edge_kind_hint: EdgeKind::Forward,
+        is_terminal: false,
+    }
+}
+
+fn agent_node(hooks: Vec<Hook>, declared_outcomes: Vec<&str>) -> Node {
+    Node {
+        id: NodeKey::try_from("agent_1").unwrap(),
+        position: Position::default(),
+        declared_outcomes: declared_outcomes.into_iter().map(outcome_decl).collect(),
+        config: NodeConfig::Agent(AgentConfig {
+            profile: ProfileKey::try_from("implementer@1.0").unwrap(),
+            prompt_overrides: None,
+            tool_overrides: None,
+            sandbox_override: None,
+            approvals_override: None,
+            bindings: vec![],
+            rules_overrides: None,
+            limits: NodeLimits::default(),
+            hooks,
+            custom_fields: BTreeMap::new(),
+        }),
+    }
+}
+
+fn terminal_node(id: &str) -> Node {
+    Node {
+        id: NodeKey::try_from(id).unwrap(),
+        position: Position::default(),
+        declared_outcomes: vec![],
+        config: NodeConfig::Terminal(TerminalConfig {
+            kind: TerminalKind::Success,
+            message: None,
+        }),
+    }
+}
+
+fn graph_with_agent(hooks: Vec<Hook>, declared_outcomes: Vec<&str>, edge_outcome: &str) -> Graph {
+    let agent = NodeKey::try_from("agent_1").unwrap();
+    let end = NodeKey::try_from("end").unwrap();
+    let mut nodes = BTreeMap::new();
+    nodes.insert(agent.clone(), agent_node(hooks, declared_outcomes));
+    nodes.insert(end.clone(), terminal_node("end"));
+
+    Graph {
+        schema_version: SCHEMA_VERSION,
+        metadata: GraphMetadata {
+            name: "on-error-suppress".into(),
+            description: None,
+            template_origin: None,
+            created_at: chrono::Utc::now(),
+            author: None,
+        },
+        start: agent.clone(),
+        nodes,
+        edges: vec![Edge {
+            id: EdgeKey::try_from("agent_to_end").unwrap(),
+            from: PortRef {
+                node: agent,
+                outcome: OutcomeKey::try_from(edge_outcome).unwrap(),
+            },
+            to: end,
+            kind: EdgeKind::Forward,
+            policy: EdgePolicy::default(),
+        }],
+        subgraphs: BTreeMap::new(),
+    }
+}
+
+async fn run_crashing_agent(
+    build_graph: impl FnOnce(&Path) -> Graph,
+) -> (RunOutcome, Vec<surge_persistence::runs::reader::ReadEvent>) {
+    let dir = tempfile::tempdir().unwrap();
+    let storage = Storage::open(dir.path()).await.unwrap();
+    let mock = Arc::new(MockBridge::new());
+    let bridge: Arc<dyn BridgeFacade> = mock.clone();
+    let dispatcher =
+        Arc::new(WorktreeToolDispatcher::new(dir.path().to_path_buf())) as Arc<dyn ToolDispatcher>;
+    let engine = Engine::new(bridge, storage.clone(), dispatcher, EngineConfig::default());
+
+    let run_id = RunId::new();
+    let session_id = SessionId::new();
+    mock.pin_next_session_id(session_id).await;
+    mock.enqueue_event(BridgeEvent::SessionEnded {
+        session: session_id,
+        reason: SessionEndReason::AgentCrashed {
+            exit_code: Some(137),
+            stderr_tail: "simulated crash".into(),
+        },
+    })
+    .await;
+
+    let graph = build_graph(dir.path());
+    let handle = engine
+        .start_run(
+            run_id,
+            graph,
+            dir.path().to_path_buf(),
+            EngineRunConfig::default(),
+        )
+        .await
+        .expect("start_run");
+
+    let mock_for_pump = mock.clone();
+    let pump = tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        mock_for_pump.pump_scripted_events().await;
+    });
+
+    let outcome = tokio::time::timeout(Duration::from_secs(10), handle.await_completion())
+        .await
+        .expect("run timed out")
+        .expect("run handle join");
+    pump.await.unwrap();
+    drop(engine);
+
+    let reader = storage.open_run_reader(run_id).await.unwrap();
+    let last = reader.current_seq().await.unwrap();
+    let events = reader
+        .read_events(EventSeq(0)..EventSeq(last.0 + 1))
+        .await
+        .unwrap();
+    (outcome, events)
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn on_error_suppresses_failure_into_declared_outcome() {
+    let (outcome, events) = run_crashing_agent(|dir| {
+        graph_with_agent(
+            vec![on_error_suppress_hook(
+                "recover",
+                suppress_command(dir, "retry_later"),
+            )],
+            vec!["retry_later"],
+            "retry_later",
+        )
+    })
+    .await;
+    let event_debug: Vec<String> = events
+        .iter()
+        .map(|ev| format!("{:?}", ev.payload.payload))
+        .collect();
+    match outcome {
+        RunOutcome::Completed { terminal } => assert_eq!(terminal.as_ref(), "end"),
+        other => panic!(
+            "expected Completed after on_error suppression, got {other:?}; events: {event_debug:#?}"
+        ),
+    }
+
+    let mut saw_hook_executed = false;
+    let mut saw_suppressed_outcome = false;
+    for ev in &events {
+        match &ev.payload.payload {
+            EventPayload::HookExecuted { hook_id, .. } if hook_id == "recover" => {
+                saw_hook_executed = true;
+            },
+            EventPayload::OutcomeReported { outcome, .. } if outcome.as_str() == "retry_later" => {
+                saw_suppressed_outcome = true;
+            },
+            EventPayload::StageFailed { .. } => {
+                panic!("suppressed failure must not persist StageFailed: {ev:?}");
+            },
+            _ => {},
+        }
+    }
+    assert!(saw_hook_executed, "missing HookExecuted audit event");
+    assert!(saw_suppressed_outcome, "missing suppressed OutcomeReported");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn without_on_error_hook_crash_records_stage_failed() {
+    let (outcome, events) =
+        run_crashing_agent(|_| graph_with_agent(vec![], vec!["done"], "done")).await;
+    match outcome {
+        RunOutcome::Failed { error } => assert!(error.contains("session ended")),
+        other => panic!("expected Failed without on_error hook, got {other:?}"),
+    }
+
+    assert!(
+        events
+            .iter()
+            .any(|ev| matches!(ev.payload.payload, EventPayload::StageFailed { .. })),
+        "missing StageFailed event"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn undeclared_suppression_falls_through_to_stage_failed() {
+    let (outcome, events) = run_crashing_agent(|dir| {
+        graph_with_agent(
+            vec![on_error_suppress_hook(
+                "rogue",
+                suppress_command(dir, "retry_later"),
+            )],
+            vec!["done"],
+            "done",
+        )
+    })
+    .await;
+    match outcome {
+        RunOutcome::Failed { error } => assert!(error.contains("session ended")),
+        other => panic!("expected Failed for undeclared suppression, got {other:?}"),
+    }
+
+    let mut saw_hook_executed = false;
+    let mut saw_stage_failed = false;
+    for ev in &events {
+        match &ev.payload.payload {
+            EventPayload::HookExecuted { hook_id, .. } if hook_id == "rogue" => {
+                saw_hook_executed = true;
+            },
+            EventPayload::StageFailed { .. } => saw_stage_failed = true,
+            EventPayload::OutcomeReported { outcome, .. } if outcome.as_str() == "retry_later" => {
+                panic!("undeclared suppression must not record retry_later outcome");
+            },
+            _ => {},
+        }
+    }
+    assert!(saw_hook_executed, "missing HookExecuted audit event");
+    assert!(saw_stage_failed, "missing StageFailed event");
+}

--- a/crates/surge-orchestrator/tests/real_acp_smoke.rs
+++ b/crates/surge-orchestrator/tests/real_acp_smoke.rs
@@ -1,97 +1,349 @@
-//! Real-agent smoke harness — env contract scaffold (full driver TBD).
+//! Opt-in real-agent smoke test for the ACP bridge + graph engine path.
 //!
-//! ## Current scope (this commit)
-//!
-//! This file is the **harness skeleton** for a future real-ACP smoke test.
-//! Today it verifies only the gating contract:
-//!
-//! - When `SURGE_REAL_ACP_BIN` and `SURGE_REAL_ACP_PROFILE` are absent /
-//!   empty / point to a non-existent path, the test prints a skip banner
-//!   and exits with success — keeping the deterministic CI green path
-//!   covered by the mock-ACP archetype suite (`archetypes_mock_test.rs`)
-//!   without requiring a real agent install.
-//! - When both env vars resolve to a real binary path, the test prints a
-//!   banner indicating the harness is ready and exits successfully.
-//!
-//! ## Out of scope (follow-up)
-//!
-//! Driving the engine with a real ACP child and asserting the observable
-//! contract (`RunCompleted` plus ≥ 1 `TokensConsumed` event) requires
-//! launching the daemon, wiring a `DaemonEngineFacade`, registering the
-//! agent profile against the resolver, and a per-binary message script.
-//! That work is tracked as a follow-up to the Graph engine GA milestone
-//! and intentionally NOT done here — committing a half-implemented driver
-//! would either silently pass on broken setups or hard-fail when the env
-//! vars happen to be set in dev environments.
-//!
-//! When the driver lands, the env-contract assertions stay (so misconfigured
-//! invocations still skip cleanly) and the post-banner section will perform
-//! the actual run + event-log assertions.
-//!
-//! ## Enabling the harness check locally
+//! The deterministic CI path stays in `archetypes_mock_test.rs`. This test is
+//! intentionally skipped unless a developer provides a real ACP-capable binary:
 //!
 //! ```text
-//! SURGE_REAL_ACP_BIN=/path/to/claude-code \
+//! SURGE_REAL_ACP_BIN=/path/to/claude \
 //! SURGE_REAL_ACP_PROFILE=implementer@1.0 \
 //!   cargo test -p surge-orchestrator --test real_acp_smoke -- --nocapture
 //! ```
 //!
-//! The binary path must exist on disk; the profile name will be passed
-//! through to the future driver via `SURGE_REAL_ACP_PROFILE` so the same
-//! harness can target Claude Code, Codex CLI, or any conformant binary
-//! without recompiling.
+//! Optional knobs:
+//!
+//! - `SURGE_REAL_ACP_KIND=claude-code|codex|gemini-cli|custom`
+//! - `SURGE_REAL_ACP_ARGS="--flag value"` (split on whitespace)
 
 use std::env;
-use std::path::Path;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use surge_acp::bridge::acp_bridge::AcpBridge;
+use surge_acp::bridge::error::{
+    BridgeError, CloseSessionError, OpenSessionError, ReplyToToolError, SendMessageError,
+};
+use surge_acp::bridge::event::{BridgeEvent, ToolResultPayload};
+use surge_acp::bridge::facade::BridgeFacade;
+use surge_acp::bridge::session::{AgentKind, MessageContent, SessionConfig, SessionState};
+use surge_core::agent_config::PromptOverride;
+use surge_core::graph::Graph;
+use surge_core::id::{RunId, SessionId};
+use surge_core::keys::{NodeKey, ProfileKey};
+use surge_core::node::NodeConfig;
+use surge_core::run_event::EventPayload;
+use surge_orchestrator::engine::tools::ToolDispatcher;
+use surge_orchestrator::engine::tools::worktree::WorktreeToolDispatcher;
+use surge_orchestrator::engine::{Engine, EngineConfig, EngineRunConfig, RunOutcome};
+use surge_persistence::runs::Storage;
+use surge_persistence::runs::seq::EventSeq;
+use tokio::sync::broadcast;
 
 const ENV_BIN: &str = "SURGE_REAL_ACP_BIN";
 const ENV_PROFILE: &str = "SURGE_REAL_ACP_PROFILE";
+const ENV_KIND: &str = "SURGE_REAL_ACP_KIND";
+const ENV_ARGS: &str = "SURGE_REAL_ACP_ARGS";
+const RUN_TIMEOUT: Duration = Duration::from_secs(180);
+
+#[derive(Clone, Copy, Debug)]
+enum RealAcpKind {
+    ClaudeCode,
+    Codex,
+    GeminiCli,
+    Custom,
+}
+
+#[derive(Clone, Debug)]
+struct RealAcpLaunch {
+    binary: PathBuf,
+    kind: RealAcpKind,
+    extra_args: Vec<String>,
+}
+
+impl RealAcpLaunch {
+    fn to_agent_kind(&self) -> AgentKind {
+        match self.kind {
+            RealAcpKind::ClaudeCode => AgentKind::ClaudeCode {
+                binary: self.binary.clone(),
+                extra_args: self.extra_args.clone(),
+            },
+            RealAcpKind::Codex => AgentKind::Codex {
+                binary: self.binary.clone(),
+                extra_args: self.extra_args.clone(),
+            },
+            RealAcpKind::GeminiCli => AgentKind::GeminiCli {
+                binary: self.binary.clone(),
+                extra_args: self.extra_args.clone(),
+            },
+            RealAcpKind::Custom => AgentKind::Custom {
+                binary: self.binary.clone(),
+                args: self.extra_args.clone(),
+            },
+        }
+    }
+
+    fn label(&self) -> &'static str {
+        match self.kind {
+            RealAcpKind::ClaudeCode => "claude-code",
+            RealAcpKind::Codex => "codex",
+            RealAcpKind::GeminiCli => "gemini-cli",
+            RealAcpKind::Custom => "custom",
+        }
+    }
+}
+
+struct RealAcpBridge {
+    inner: AcpBridge,
+    launch: RealAcpLaunch,
+}
+
+impl RealAcpBridge {
+    fn new(launch: RealAcpLaunch) -> Result<Self, BridgeError> {
+        Ok(Self {
+            inner: AcpBridge::with_defaults()?,
+            launch,
+        })
+    }
+}
+
+#[async_trait]
+impl BridgeFacade for RealAcpBridge {
+    async fn open_session(&self, mut config: SessionConfig) -> Result<SessionId, OpenSessionError> {
+        tracing::info!(
+            target: "real_acp_smoke",
+            binary = %self.launch.binary.display(),
+            kind = self.launch.label(),
+            "binding real ACP agent for smoke run"
+        );
+        config.agent_kind = self.launch.to_agent_kind();
+        self.inner.open_session(config).await
+    }
+
+    async fn send_message(
+        &self,
+        session: SessionId,
+        content: MessageContent,
+    ) -> Result<(), SendMessageError> {
+        self.inner.send_message(session, content).await
+    }
+
+    async fn session_state(&self, session: SessionId) -> Result<SessionState, BridgeError> {
+        self.inner.session_state(session).await
+    }
+
+    async fn close_session(&self, session: SessionId) -> Result<(), CloseSessionError> {
+        self.inner.close_session(session).await
+    }
+
+    async fn reply_to_tool(
+        &self,
+        session: SessionId,
+        call_id: String,
+        payload: ToolResultPayload,
+    ) -> Result<(), ReplyToToolError> {
+        self.inner.reply_to_tool(session, call_id, payload).await
+    }
+
+    fn subscribe(&self) -> broadcast::Receiver<BridgeEvent> {
+        self.inner.subscribe()
+    }
+}
+
+fn examples_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("..")
+        .join("examples")
+}
+
+fn load_minimal_agent_graph(profile: &str) -> Graph {
+    let path = examples_dir().join("flow_minimal_agent.toml");
+    let toml_s =
+        std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+    let mut graph: Graph =
+        toml::from_str(&toml_s).unwrap_or_else(|e| panic!("parse {}: {e}", path.display()));
+
+    let node_key = NodeKey::try_from("impl_1").expect("'impl_1' is a valid NodeKey");
+    let node = graph
+        .nodes
+        .get_mut(&node_key)
+        .expect("flow_minimal_agent has impl_1 node");
+    let NodeConfig::Agent(agent) = &mut node.config else {
+        panic!("flow_minimal_agent impl_1 must be an agent node");
+    };
+
+    agent.profile = ProfileKey::try_from(profile)
+        .unwrap_or_else(|e| panic!("{ENV_PROFILE}={profile:?} is not a valid profile key: {e}"));
+    agent.prompt_overrides = Some(PromptOverride {
+        system: Some(real_agent_prompt()),
+        append_system: None,
+    });
+    agent.limits.timeout_seconds = RUN_TIMEOUT.as_secs() as u32;
+    agent.limits.max_retries = 0;
+    graph
+}
+
+fn real_agent_prompt() -> String {
+    [
+        "You are running Surge's real ACP smoke test.",
+        "Do not inspect, edit, create, or delete files.",
+        "Immediately call the injected report_stage_outcome tool with outcome \"done\",",
+        "summary \"real ACP smoke completed\", and an empty artifacts_produced array.",
+        "After the tool call, stop.",
+    ]
+    .join(" ")
+}
 
 fn skip_banner(reason: &str) {
     eprintln!(
         "[real_acp_smoke] SKIPPED: {reason}\n\
-         Set {ENV_BIN} and {ENV_PROFILE} to run this harness."
+         Set {ENV_BIN} and {ENV_PROFILE} to run the real ACP smoke test."
     );
 }
 
-/// Env-contract harness: confirms `SURGE_REAL_ACP_BIN` resolves to an
-/// existing binary path and `SURGE_REAL_ACP_PROFILE` is non-empty when
-/// the user opts in. The full real-ACP driver (run through engine,
-/// assert `RunCompleted` + ≥ 1 `TokensConsumed`) is deliberately not
-/// implemented here yet — see the module-level docs.
-///
-/// Renamed from `flow_minimal_agent_against_real_agent` to make the
-/// scope honest after PR #48 review noted the previous name implied
-/// coverage that is not present.
-#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-async fn real_acp_env_contract_harness() {
-    let bin = match env::var(ENV_BIN) {
-        Ok(v) if !v.trim().is_empty() => v,
-        _ => {
-            skip_banner(&format!("{ENV_BIN} is not set"));
-            return;
-        },
+fn parse_env_args() -> Vec<String> {
+    env::var(ENV_ARGS)
+        .ok()
+        .map(|raw| raw.split_whitespace().map(str::to_owned).collect())
+        .unwrap_or_default()
+}
+
+fn infer_kind(binary: &Path) -> RealAcpKind {
+    let name = binary
+        .file_stem()
+        .or_else(|| binary.file_name())
+        .map(|s| s.to_string_lossy().to_ascii_lowercase())
+        .unwrap_or_default();
+
+    if name.contains("codex") {
+        RealAcpKind::Codex
+    } else if name.contains("gemini") {
+        RealAcpKind::GeminiCli
+    } else if name.contains("claude") {
+        RealAcpKind::ClaudeCode
+    } else {
+        RealAcpKind::Custom
+    }
+}
+
+fn parse_kind(binary: &Path) -> RealAcpKind {
+    let Ok(raw) = env::var(ENV_KIND) else {
+        return infer_kind(binary);
     };
+    match raw.trim().to_ascii_lowercase().as_str() {
+        "" => infer_kind(binary),
+        "claude" | "claude-code" => RealAcpKind::ClaudeCode,
+        "codex" => RealAcpKind::Codex,
+        "gemini" | "gemini-cli" => RealAcpKind::GeminiCli,
+        "custom" => RealAcpKind::Custom,
+        other => panic!(
+            "{ENV_KIND}={other:?} is invalid; expected claude-code, codex, gemini-cli, or custom"
+        ),
+    }
+}
+
+fn real_acp_config() -> Option<(RealAcpLaunch, String)> {
+    let Some(bin_os) = env::var_os(ENV_BIN) else {
+        skip_banner(&format!("{ENV_BIN} is not set"));
+        return None;
+    };
+    if bin_os.is_empty() {
+        skip_banner(&format!("{ENV_BIN} is empty"));
+        return None;
+    }
+
     let profile = match env::var(ENV_PROFILE) {
         Ok(v) if !v.trim().is_empty() => v,
         _ => {
             skip_banner(&format!("{ENV_PROFILE} is not set"));
-            return;
+            return None;
         },
     };
 
-    let bin_path = Path::new(&bin);
+    let binary = PathBuf::from(bin_os);
     assert!(
-        bin_path.exists(),
-        "{ENV_BIN}={bin} must point to an existing binary; saw missing path"
+        binary.exists(),
+        "{ENV_BIN}={} must point to an existing binary; saw missing path",
+        binary.display()
     );
     assert!(
-        bin_path.is_file(),
-        "{ENV_BIN}={bin} must point to a file (not a directory)"
+        binary.is_file(),
+        "{ENV_BIN}={} must point to a file (not a directory)",
+        binary.display()
     );
 
+    let launch = RealAcpLaunch {
+        kind: parse_kind(&binary),
+        binary,
+        extra_args: parse_env_args(),
+    };
+    Some((launch, profile))
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn flow_minimal_agent_against_real_acp_agent() {
+    let Some((launch, profile)) = real_acp_config() else {
+        return;
+    };
+
+    let root = tempfile::tempdir().expect("tempdir");
+    let storage_dir = root.path().join("storage");
+    let worktree_dir = root.path().join("worktree");
+    std::fs::create_dir_all(&storage_dir).expect("create storage dir");
+    std::fs::create_dir_all(&worktree_dir).expect("create worktree dir");
+
     eprintln!(
-        "[real_acp_smoke] env-contract OK: bin={bin} profile={profile}\n\
-         [real_acp_smoke] full driver (RunCompleted + TokensConsumed assertions) is a Graph-engine-GA follow-up"
+        "[real_acp_smoke] RUNNING: bin={} kind={} profile={}",
+        launch.binary.display(),
+        launch.label(),
+        profile
+    );
+
+    let storage = Storage::open(&storage_dir).await.expect("storage");
+    let bridge = Arc::new(RealAcpBridge::new(launch).expect("real ACP bridge"));
+    let dispatcher =
+        Arc::new(WorktreeToolDispatcher::new(worktree_dir.clone())) as Arc<dyn ToolDispatcher>;
+    let engine = Engine::new(bridge, storage.clone(), dispatcher, EngineConfig::default());
+
+    let run_id = RunId::new();
+    let handle = engine
+        .start_run(
+            run_id,
+            load_minimal_agent_graph(&profile),
+            worktree_dir,
+            EngineRunConfig::default(),
+        )
+        .await
+        .expect("start real ACP smoke run");
+
+    let outcome = tokio::time::timeout(RUN_TIMEOUT, handle.await_completion())
+        .await
+        .unwrap_or_else(|_| panic!("real ACP smoke hung for more than {RUN_TIMEOUT:?}"))
+        .expect("real ACP smoke completion");
+    assert!(
+        matches!(outcome, RunOutcome::Completed { .. }),
+        "expected Completed, got {outcome:?}"
+    );
+    drop(engine);
+
+    let reader = storage.open_run_reader(run_id).await.expect("open reader");
+    let last = reader.current_seq().await.expect("current seq");
+    let events = reader
+        .read_events(EventSeq::ZERO..EventSeq(last.0 + 1))
+        .await
+        .expect("read events");
+
+    assert!(
+        events
+            .iter()
+            .any(|ev| matches!(ev.payload.payload, EventPayload::RunCompleted { .. })),
+        "real ACP smoke completed without a persisted RunCompleted event: {events:?}"
+    );
+    assert!(
+        events
+            .iter()
+            .any(|ev| matches!(ev.payload.payload, EventPayload::TokensConsumed { .. })),
+        "real ACP smoke completed without a persisted TokensConsumed event: {events:?}"
     );
 }

--- a/docs/development.md
+++ b/docs/development.md
@@ -55,7 +55,7 @@ SURGE_REAL_ACP_PROFILE=implementer@1.0 \
   cargo test -p surge-orchestrator --test real_acp_smoke -- --nocapture
 ```
 
-When the env vars are missing the test prints a `SKIPPED` banner and exits successfully — CI's deterministic green path stays covered by the mock-ACP suite.
+The harness infers `claude-code`, `codex`, or `gemini-cli` launch mode from the binary name. Set `SURGE_REAL_ACP_KIND=claude-code|codex|gemini-cli|custom` to override that, and `SURGE_REAL_ACP_ARGS="--flag value"` for extra ACP process args. When the required env vars are missing the test prints a `SKIPPED` banner and exits successfully — CI's deterministic green path stays covered by the mock-ACP suite.
 
 ## Performance Bench
 
@@ -65,7 +65,13 @@ When the env vars are missing the test prints a `SKIPPED` banner and exits succe
 cargo bench -p surge-orchestrator --bench stage_transition -- --save-baseline ga
 ```
 
-`P95_BUDGET_US` is encoded in the bench source. Bumping it requires a deliberate code change so regressions surface in PR review.
+`P95_BUDGET_US` is encoded in the bench source. CI enables `SURGE_STAGE_TRANSITION_BUDGET_CHECK=1`, which makes the bench fail if the sampled P95 exceeds the source-level budget; bumping it requires a deliberate code change so regressions surface in PR review.
+
+CI records its quick benchmark history with:
+
+```bash
+cargo bench -p surge-orchestrator --bench stage_transition -- --quick --save-baseline ci
+```
 
 ## Local Runtime State
 

--- a/examples/flow_multi_milestone.toml
+++ b/examples/flow_multi_milestone.toml
@@ -111,7 +111,18 @@ on_max_exceeded = "escalate"
 # ── milestone body subgraph: inner Loop ──
 [subgraphs.milestone_body]
 start = "task_loop"
-edges = []
+
+[[subgraphs.milestone_body.edges]]
+id = "e_milestone_tasks_to_end"
+to = "milestone_body_end"
+kind = "forward"
+
+[subgraphs.milestone_body.edges.from]
+node = "task_loop"
+outcome = "completed"
+
+[subgraphs.milestone_body.edges.policy]
+on_max_exceeded = "escalate"
 
 [subgraphs.milestone_body.nodes.task_loop]
 id = "task_loop"
@@ -124,7 +135,7 @@ y = 0.0
 id = "completed"
 description = "Inner-loop tasks done"
 edge_kind_hint = "forward"
-is_terminal = true
+is_terminal = false
 
 [subgraphs.milestone_body.nodes.task_loop.config]
 node_kind = "loop"
@@ -143,6 +154,20 @@ type = "all_items"
 [subgraphs.milestone_body.nodes.task_loop.config.on_iteration_failure]
 type = "abort"
 
+[subgraphs.milestone_body.nodes.milestone_body_end]
+id = "milestone_body_end"
+declared_outcomes = []
+
+[subgraphs.milestone_body.nodes.milestone_body_end.position]
+x = 200.0
+y = 0.0
+
+[subgraphs.milestone_body.nodes.milestone_body_end.config]
+node_kind = "terminal"
+
+[subgraphs.milestone_body.nodes.milestone_body_end.config.kind]
+type = "success"
+
 # ── task body subgraph: implement → verify ──
 [subgraphs.task_body]
 start = "impl_in_task"
@@ -154,6 +179,18 @@ kind = "forward"
 
 [subgraphs.task_body.edges.from]
 node = "impl_in_task"
+outcome = "done"
+
+[subgraphs.task_body.edges.policy]
+on_max_exceeded = "escalate"
+
+[[subgraphs.task_body.edges]]
+id = "e_task_verify_to_end"
+to = "task_body_end"
+kind = "forward"
+
+[subgraphs.task_body.edges.from]
+node = "verify_in_task"
 outcome = "done"
 
 [subgraphs.task_body.edges.policy]
@@ -196,7 +233,7 @@ y = 0.0
 id = "done"
 description = "Task verification complete"
 edge_kind_hint = "forward"
-is_terminal = true
+is_terminal = false
 
 [subgraphs.task_body.nodes.verify_in_task.config]
 node_kind = "agent"
@@ -210,3 +247,17 @@ max_retries = 3
 max_tokens = 200000
 
 [subgraphs.task_body.nodes.verify_in_task.config.custom_fields]
+
+[subgraphs.task_body.nodes.task_body_end]
+id = "task_body_end"
+declared_outcomes = []
+
+[subgraphs.task_body.nodes.task_body_end.position]
+x = 400.0
+y = 0.0
+
+[subgraphs.task_body.nodes.task_body_end.config]
+node_kind = "terminal"
+
+[subgraphs.task_body.nodes.task_body_end.config.kind]
+type = "success"

--- a/examples/flow_single_loop.toml
+++ b/examples/flow_single_loop.toml
@@ -84,6 +84,18 @@ outcome = "done"
 [subgraphs.task_body.edges.policy]
 on_max_exceeded = "escalate"
 
+[[subgraphs.task_body.edges]]
+id = "e_body_verify_to_end"
+to = "body_end"
+kind = "forward"
+
+[subgraphs.task_body.edges.from]
+node = "verify_in_body"
+outcome = "done"
+
+[subgraphs.task_body.edges.policy]
+on_max_exceeded = "escalate"
+
 [subgraphs.task_body.nodes.impl_in_body]
 id = "impl_in_body"
 
@@ -121,7 +133,7 @@ y = 0.0
 id = "done"
 description = "Body iteration: verification complete"
 edge_kind_hint = "forward"
-is_terminal = true
+is_terminal = false
 
 [subgraphs.task_body.nodes.verify_in_body.config]
 node_kind = "agent"
@@ -135,3 +147,17 @@ max_retries = 3
 max_tokens = 200000
 
 [subgraphs.task_body.nodes.verify_in_body.config.custom_fields]
+
+[subgraphs.task_body.nodes.body_end]
+id = "body_end"
+declared_outcomes = []
+
+[subgraphs.task_body.nodes.body_end.position]
+x = 400.0
+y = 0.0
+
+[subgraphs.task_body.nodes.body_end.config]
+node_kind = "terminal"
+
+[subgraphs.task_body.nodes.body_end.config.kind]
+type = "success"


### PR DESCRIPTION
## Summary

Completes the Graph engine GA follow-up work on `feature-graph-engine-ga`:

- hardens daemon/engine routing and on-error hook audit behavior
- adds a real opt-in ACP smoke test that asserts `RunCompleted` and `TokensConsumed`
- tightens the stage-transition Criterion bench and wires the CI P95 budget gate
- updates archetype examples, development docs, changelog, and the AI Factory plan checkpoint

## Why

The Graph engine GA milestone needs deterministic mock coverage, an opt-in real-agent smoke path, and a CI-visible performance guard before the branch is ready for review.

## Validation

- `cargo check --workspace --exclude surge-ui`
- `cargo test --workspace --exclude surge-ui`
- `cargo clippy --workspace --exclude surge-ui -- -D warnings`
- `cargo fmt --check`
- `SURGE_STAGE_TRANSITION_BUDGET_CHECK=1 cargo bench -p surge-orchestrator --bench stage_transition -- --quick --save-baseline verify`
- GA baseline previously recorded with `cargo bench -p surge-orchestrator --bench stage_transition -- --save-baseline ga`

## Notes

Draft PR. Local unstaged AI/tooling files are not part of this branch diff.
