### PR TITLE
[codex] Add artifact convention library

### DIFF
--- a/.ai-factory/ROADMAP.md
+++ b/.ai-factory/ROADMAP.md
@@ -84,7 +84,7 @@
   - First-run UX polish: clear error messages on missing dependencies (no agent on PATH, not a git repo, etc.) with actionable next steps
   - Documentation: `getting-started.md` updated to use wizard flow as canonical onboarding path
 
-- [ ] **Artifact format & convention library** — canonical output contract for every role; surge owns *what* artifacts look like, agents own *how* they think (touches `surge-core`, `surge-orchestrator`, profiles registry, `docs/`)
+- [x] **Artifact format & convention library** — canonical output contract for every role; surge owns *what* artifacts look like, agents own *how* they think (touches `surge-core`, `surge-orchestrator`, profiles registry, `docs/`)
   - Bundled `flow.toml` templates extracted from `surge-spec/templates.rs`: Feature / Bugfix / Refactor / Performance / Security / Docs / Migration, registered for `--template=<name>` consumption
   - Profile output schemas: Description Author → markdown sections (Goal / Context / Requirements / Out-of-Scope); Roadmap Planner → `surge_core::Roadmap` typed output; Spec Author → `surge_core::Spec` typed output with subtasks + acceptance criteria; Architect → ADR with frontmatter
   - Output validation as `on_outcome` reject hook (uses Graph engine GA primitive): post-stage validator runs against schema, retries on schema violation
@@ -265,3 +265,4 @@
 | Profile registry & bundled roles | 2026-05-07 |
 | Bootstrap & adaptive flow generation | 2026-05-09 |
 | Project initialization & stable context | 2026-05-10 |
+| Artifact format & convention library | 2026-05-11 |

--- a/.ai-factory/plans/feature-artifact-format-convention-library.md
+++ b/.ai-factory/plans/feature-artifact-format-convention-library.md
@@ -1,0 +1,163 @@
+# Implementation Plan: Artifact Format & Convention Library
+
+Branch: feature/artifact-format-convention-library
+Created: 2026-05-11
+Refined: 2026-05-11
+
+## Settings
+- Testing: yes
+- Logging: verbose
+- Docs: yes
+
+## Roadmap Linkage
+Milestone: "Artifact format & convention library"
+Rationale: This is the next unchecked roadmap milestone and establishes the canonical artifact contracts that later roadmap amendments, legacy retirement, Telegram UX, and v0.1 schema freeze depend on.
+
+## Scope
+Surge should own the shape of role artifacts while agents own how they reason. This plan adds an explicit artifact naming/compatibility matrix, typed contracts and validators, bundled flow templates migrated from legacy spec-template intent, validation hooks that reject bad outputs, updated bundled profile prompts, conventions documentation, and regression coverage.
+
+Non-goals:
+- Do not remove `surge-spec`; that belongs to the later Legacy pipeline retirement milestone.
+- Do not add new `NodeKind` variants; use profiles, hooks, templates, and existing graph validation.
+- Do not make CI depend on live Claude/Codex/Gemini credentials; live cross-agent checks should be opt-in or ignored.
+- Do not make `surge-core` depend on `surge-orchestrator`; core validators stay pure and orchestrator/CLI compose higher-level graph checks.
+
+## Commit Plan
+- **Commit 1** (after tasks 1-4): "feat(core): define artifact contracts and validators"
+- **Commit 2** (after tasks 5-7): "feat(templates): register convention flow templates"
+- **Commit 3** (after tasks 8-12): "feat(engine): enforce artifact validation hooks"
+- **Commit 4** (after tasks 13-15): "docs: add artifact conventions and regression coverage"
+
+## Tasks
+
+### Phase 0: Contract Decisions
+- [x] Task 1: Define the artifact naming and compatibility matrix.
+  Deliverable: document the canonical artifact names, primary machine-readable representation, markdown compatibility surface, schema-version ownership, and validator kind for each role output: Description, Requirements, Roadmap, Spec, ADR, Story, Plan, and Flow.
+  Expected behavior: implementation has a single source of truth for whether artifacts are `description.md`, `roadmap.toml` plus `roadmap.md`, `spec.toml` plus `spec.md`, `docs/adr/<NNNN>-<slug>.md`, `stories/story-NNN.md`, or `flow.toml`; downstream tasks must not invent alternate names.
+  Files: `crates/surge-core/src/artifact_contract.rs`, `crates/surge-core/src/lib.rs`, `docs/conventions/README.md` placeholder if docs directory is introduced early.
+  Logging requirements: no runtime logging in `surge-core`; expose stable names and diagnostic codes that callers can log at DEBUG/WARN without parsing prose.
+  Dependency notes: blocks tasks 2-7 and 13 because validators, profile prompts, and docs must use the same names.
+
+### Phase 1: Core Artifact Contracts
+- [x] Task 2: Add pure artifact contract types and validation diagnostics.
+  Deliverable: create `crates/surge-core/src/artifact_contract.rs` and export it from `crates/surge-core/src/lib.rs`. Define `ARTIFACT_SCHEMA_VERSION`, `ArtifactKind`, `ArtifactContractRef`, `ArtifactValidationError`, `ArtifactValidationReport`, diagnostic severity, stable diagnostic codes, and helper APIs from Task 1.
+  Expected behavior: validators can report missing sections, invalid schema versions, invalid paths, unsupported artifact kind, and non-machine-readable acceptance criteria without touching I/O.
+  Files: `crates/surge-core/src/artifact_contract.rs`, `crates/surge-core/src/lib.rs`, `crates/surge-core/Cargo.toml` if a workspace dependency is needed.
+  Logging requirements: keep core pure; return structured diagnostics with stable codes and enough context for CLI/orchestrator callers to log at DEBUG/INFO/WARN/ERROR.
+  Dependency notes: depends on task 1; foundation for tasks 3, 4, 6, 8, and 12.
+
+- [x] Task 3: Implement pure syntax/section validators for canonical role outputs.
+  Deliverable: add pure validation functions for Description Author markdown sections, Spec Author markdown compatibility shape, Architect ADR TOML frontmatter, story-file naming/content, plan markdown sections, and `flow.toml` schema-version parsing. Do not call `surge-orchestrator::engine::validate` from `surge-core`.
+  Expected behavior: validation accepts minimal valid fixtures and rejects missing required sections, malformed frontmatter, invalid story paths, missing acceptance criteria, and unsupported `schema_version`.
+  Files: `crates/surge-core/src/artifact_contract.rs`, `crates/surge-core/tests/artifact_contract_test.rs` or inline `#[cfg(test)]` modules.
+  Logging requirements: no runtime logging in core; diagnostics must include artifact kind, field/section when known, and a short safe message suitable for hook stderr.
+  Dependency notes: depends on tasks 1-2; orchestrator-level graph validation is added in task 8.
+
+- [x] Task 4: Add typed roadmap/spec artifact wrappers without breaking existing types.
+  Deliverable: add typed `RoadmapArtifact` and `SpecArtifact` wrappers with `schema_version`, conversion to/from existing `Timeline` / `Spec` where sensible, and markdown compatibility guidance. Preserve existing `Timeline`, `RoadmapItem`, and `Spec` callers.
+  Expected behavior: Roadmap Planner and Spec Author can target typed structures while legacy code and tests using `Timeline` and `Spec` keep compiling unchanged.
+  Files: `crates/surge-core/src/roadmap.rs`, `crates/surge-core/src/spec.rs`, `crates/surge-core/src/lib.rs`, related tests.
+  Logging requirements: no runtime logging in core; parse/validation errors must include milestone/task/subtask identity so callers can log precise failures.
+  Dependency notes: depends on tasks 1-2; feeds tasks 6, 7, 13, and 14.
+
+### Phase 2: Bundled Templates And Profile Contracts
+- [x] Task 5: Migrate legacy spec-template intent into bundled flow templates with aliases.
+  Deliverable: add or align first-party `flow.toml` assets for `feature`, `bug-fix`, `refactor`, `performance`, `security`, `docs`, and `migration` based on the intent currently encoded in `crates/surge-spec/src/templates.rs`. Add alias resolution for legacy names: `bugfix`/`fix` -> `bug-fix`, `perf` -> `performance`, `sec` -> `security`, `doc` -> `docs`, `migrate` -> `migration`.
+  Expected behavior: `surge engine run --template=<name>` resolves every canonical and legacy alias; user templates still shadow bundled templates; existing archetype names keep working.
+  Files: `crates/surge-core/bundled/flows/*.toml`, `crates/surge-core/src/bundled_flows.rs`, `crates/surge-orchestrator/src/archetype_registry.rs`, relevant validation tests.
+  Logging requirements: keep existing `flow::bundled` TRACE logging and `archetype::registry` DEBUG logging; include requested name, canonical name, version, and provenance when aliases resolve.
+  Dependency notes: depends on task 1. Do not delete or rewrite `surge-spec`.
+
+- [x] Task 6: Add profile-level artifact schema declarations.
+  Deliverable: extend `ProfileOutcome` or profile metadata with optional artifact contract references that bind required artifacts to an `ArtifactKind`, canonical artifact name, and schema version.
+  Expected behavior: bundled profiles can declare that outcome `drafted` produces `description.md` with the Description contract, `spec.md` or typed spec artifact with the Spec contract, `roadmap` with the Roadmap contract, or `adr.md` with the ADR contract; old profiles without declarations continue to parse.
+  Files: `crates/surge-core/src/profile.rs`, `crates/surge-core/src/agent_config.rs` if node overrides need schema metadata, bundled profile TOML files, profile registry tests.
+  Logging requirements: when contracts are loaded by orchestrator code, log resolved contract refs at DEBUG with profile id, outcome id, artifact name, artifact kind, and schema version.
+  Dependency notes: depends on tasks 1-4 and supports tasks 10-12.
+
+- [x] Task 7: Port legacy planner prompt conventions into bundled profile prompts.
+  Deliverable: update the bundled Description Author, Roadmap Planner, Spec Author, Architect, Implementer, Verifier, Reviewer, and PR Composer profiles so their prompts reference the canonical artifact contracts instead of duplicating drifting format rules.
+  Expected behavior: profile prompts clearly state required artifact names, required sections, schema version expectations, story-file convention, ADR path convention, and acceptance criteria format from the matrix in task 1.
+  Files: `crates/surge-core/bundled/profiles/*.toml`, especially `description-author-1.0.toml`, `roadmap-planner-1.0.toml`, `spec-author-1.0.toml`, `architect-1.0.toml`, `implementer-1.0.toml`, `verifier-1.0.toml`, `reviewer-1.0.toml`, `pr-composer-1.0.toml`.
+  Logging requirements: no logging inside profile TOML; profile outcomes, artifacts, and future hook ids must be named clearly so engine logs identify which contract is being enforced.
+  Dependency notes: depends on tasks 1, 4, and 6.
+
+### Phase 3: Validation Surfaces And Hook Enforcement
+- [x] Task 8: Add a CLI validation surface that composes core and orchestrator checks.
+  Deliverable: implement `surge artifact validate --kind <kind> <path>` with optional `--format human|json`. Use pure `surge-core` validators for artifact shape and compose orchestrator graph validation for `flow.toml` in the CLI layer, not in `surge-core`.
+  Expected behavior: exit code 0 for valid artifacts; non-zero for contract failures; human output is concise enough for hook stderr; JSON output is stable for tests and future Telegram cards.
+  Files: `crates/surge-cli/src/main.rs`, `crates/surge-cli/src/commands/artifact.rs`, `crates/surge-cli/src/commands/mod.rs`, `crates/surge-cli/tests/cli_artifact_validate_test.rs`.
+  Logging requirements: use `tracing` DEBUG for validation start/end with kind/path; WARN for invalid artifacts with diagnostic count; do not log artifact contents or secrets.
+  Dependency notes: depends on tasks 2-4 and is used by tasks 11-12.
+
+- [x] Task 9: Preserve and integrate existing Flow Generator validation retry behavior.
+  Deliverable: adapt `crates/surge-orchestrator/src/engine/bootstrap.rs` so the existing Flow Generator post-processing path can reuse the new flow artifact validator while preserving current semantics: `BootstrapEditRequested`, synthetic `validation_failed`, edit-loop cap handling, and `PipelineMaterialized` on success.
+  Expected behavior: existing `bootstrap_validation_retry_test` still passes, invalid `flow.toml` still backtracks, and generic artifact validation does not create a second conflicting retry path for Flow Generator.
+  Files: `crates/surge-orchestrator/src/engine/bootstrap.rs`, `crates/surge-orchestrator/tests/bootstrap_validation_retry_test.rs`, `crates/surge-orchestrator/src/engine/validate.rs` if helper extraction is needed.
+  Logging requirements: keep `engine::bootstrap::validation` DEBUG/WARN logs, adding contract diagnostic codes where available; avoid dumping the full generated flow text.
+  Dependency notes: depends on tasks 3 and 8; must land before task 15.
+
+- [x] Task 10: Merge profile hooks with node-level hooks for effective agent execution.
+  Deliverable: update agent-stage setup so hooks declared on resolved profiles are combined with `AgentConfig.hooks`, honoring existing hook inheritance semantics where available and preserving node-level overrides.
+  Expected behavior: bundled profile `hooks.entries` actually run during `pre_tool_use`, `post_tool_use`, `on_outcome`, and `on_error`; node-level hooks still work; tests cover profile-only hooks, node-only hooks, and combined order.
+  Files: `crates/surge-orchestrator/src/engine/stage/agent.rs`, `crates/surge-orchestrator/src/engine/hooks/mod.rs`, `crates/surge-orchestrator/tests/profile_registry_e2e.rs`, `crates/surge-orchestrator/tests/on_outcome_retry_test.rs`.
+  Logging requirements: log effective hook count at DEBUG with node/profile id and counts split by profile vs node; log conflict/override decisions at DEBUG or WARN depending on severity.
+  Dependency notes: depends on task 6; must land before task 12 because profile-level validators otherwise never run.
+
+- [x] Task 11: Make hook execution worktree-aware and validator-command portable.
+  Deliverable: extend `HookContext`, `HookExecutor`, and the production process spawner so hooks can run with the run worktree as current directory and receive safe environment variables such as `SURGE_WORKTREE`, `SURGE_NODE`, `SURGE_OUTCOME`, `SURGE_SESSION`, and a portable `SURGE_BIN` path derived from the current executable when available.
+  Expected behavior: an `on_outcome` hook can validate `description.md` or `flow.toml` relative to the agent worktree on Windows, macOS, and Linux, including test/daemon environments where `surge` is not on `PATH`.
+  Files: `crates/surge-orchestrator/src/engine/hooks/mod.rs`, `crates/surge-orchestrator/src/engine/stage/agent.rs`, hook tests under `crates/surge-orchestrator/tests/`.
+  Logging requirements: log hook cwd/env setup at DEBUG without dumping full environment; log missing worktree/canonicalization failures at ERROR with node and hook id.
+  Dependency notes: depends on task 8 and supports task 12.
+
+- [x] Task 12: Wire `on_outcome` artifact validators into bundled profiles and retry flow.
+  Deliverable: add reject-mode `on_outcome` hooks to relevant bundled profiles or profile outcomes so invalid artifacts trigger the existing retry path before `OutcomeReported` is persisted.
+  Expected behavior: a malformed artifact causes `OutcomeRejectedByHook`, the agent gets another chance within `max_retries`, and exhausted retries fail the stage with the validator summary. Flow Generator keeps the specialized bootstrap retry path from task 9.
+  Files: `crates/surge-core/bundled/profiles/*.toml`, `crates/surge-orchestrator/src/engine/stage/agent.rs`, `crates/surge-core/src/run_event.rs` if rejection reason needs an optional field, `crates/surge-core/src/run_state.rs`, `crates/surge-orchestrator/tests/on_outcome_retry_test.rs`.
+  Logging requirements: log validation hook rejection at INFO with node/outcome/hook id/attempt and at WARN when retry budget is exhausted; keep validator stderr short and redact artifact content.
+  Dependency notes: depends on tasks 6, 8, 10, and 11.
+
+### Phase 4: Documentation, Fixtures, And Regression Coverage
+- [x] Task 13: Add the conventions documentation library.
+  Deliverable: create `docs/conventions/` with pages for description, requirements, roadmap, spec, story file, ADR, plan, and flow formats, plus an index linked from `docs/README.md`.
+  Expected behavior: each page has a minimal valid example, a checklist, schema version notes, artifact naming from task 1, and guidance for profile authors; story files use `stories/story-NNN.md`; ADRs use `docs/adr/<NNNN>-<slug>.md` with TOML frontmatter.
+  Files: `docs/conventions/README.md`, `docs/conventions/description.md`, `docs/conventions/requirements.md`, `docs/conventions/roadmap.md`, `docs/conventions/spec.md`, `docs/conventions/story.md`, `docs/conventions/adr.md`, `docs/conventions/plan.md`, `docs/conventions/flow.md`, `docs/README.md`.
+  Logging requirements: docs do not log; include examples that tell implementers which runtime components log validation failures and which diagnostics users will see.
+  Dependency notes: depends on tasks 1, 4, 6, and 7.
+
+- [x] Task 14: Add golden fixtures for format equivalence and validator failures.
+  Deliverable: create fixture artifacts for valid and invalid description, roadmap, spec, ADR, story, plan, and flow outputs; add golden tests that normalize agent outputs and compare contract-equivalent results independent of prose differences.
+  Expected behavior: mock-agent output can be checked in CI; real Claude/Codex/Gemini equivalence tests are ignored or feature-gated unless credentials and runtimes are available.
+  Files: `crates/surge-orchestrator/tests/fixtures/artifacts/`, `crates/surge-orchestrator/tests/artifact_contract_golden_test.rs`, `crates/surge-core/tests/artifact_contract_test.rs`, possibly `crates/surge-acp` mock-agent fixtures.
+  Logging requirements: tests should assert validator diagnostics include stable codes; test helpers may print fixture names only on failure and must not print full artifact contents unless the fixture is explicitly synthetic.
+  Dependency notes: depends on tasks 2-4 and 8; supports task 15.
+
+- [x] Task 15: Update end-to-end validation and user-facing guidance.
+  Deliverable: add integration tests for `surge engine run --template=<name>` across canonical and legacy alias templates, profile validation for all bundled profiles, validation hook retry behavior, Flow Generator retry parity, and docs references from CLI help or getting-started material where useful.
+  Expected behavior: `cargo test --workspace --exclude surge-ui`, `cargo clippy --workspace --all-targets --all-features`, and `cargo fmt --check` remain green; no live external agent is required for default CI.
+  Files: `crates/surge-cli/tests/examples_smoke.rs`, `crates/surge-orchestrator/tests/fixtures_validation.rs`, `crates/surge-orchestrator/tests/profile_registry_e2e.rs`, `crates/surge-orchestrator/tests/bootstrap_validation_retry_test.rs`, `docs/getting-started.md`, `docs/cli.md`.
+  Logging requirements: integration tests should assert key validation failures are logged or surfaced as structured diagnostics; runtime code should use DEBUG for successful validator passes and WARN/ERROR for failures.
+  Dependency notes: final verification task; depends on tasks 5, 8, 9, 10, 11, 12, and 13.
+
+## Verification Plan
+- Run `cargo fmt --all`.
+- Run `cargo test -p surge-core artifact_contract`.
+- Run `cargo test -p surge-cli --test cli_artifact_validate_test`.
+- Run `cargo test -p surge-orchestrator --test artifact_contract_golden_test`.
+- Run `cargo test -p surge-orchestrator --test on_outcome_retry_test`.
+- Run `cargo test -p surge-orchestrator --test bootstrap_validation_retry_test`.
+- Run `cargo test -p surge-cli --test examples_smoke`.
+- Run `cargo test --workspace --exclude surge-ui`.
+- Run `cargo clippy --workspace --all-targets --all-features`.
+- Run `cargo fmt --check`.
+- Run `git diff --check`.
+
+## Implementation Notes
+- Keep `surge-core` pure: no filesystem, network, process, `tokio`, `tracing`, or `surge-orchestrator` dependencies in validators.
+- Prefer structured parsers (`toml`, `serde`, existing graph/spec types) over ad hoc string checks where a typed parser exists.
+- Preserve backward compatibility for old profiles by defaulting new optional profile schema fields.
+- Preserve existing Flow Generator bootstrap retry semantics unless a parity test proves the replacement identical.
+- Make validator hooks portable across CLI, daemon, test binaries, and Windows runners; do not assume `surge` is available on `PATH`.
+- Keep validation diagnostics short, stable, and safe to show in future Telegram cards.
+- Do not remove or rewrite `surge-spec`; only copy its template intent into graph-template assets.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,7 @@ Surge is a local-first meta-orchestrator for AFK AI coding workflows in Rust. A 
 │
 ├── docs/                            # Project documentation
 │   ├── ARCHITECTURE.md              # Canonical architecture document
+│   ├── conventions/                 # Generated artifact contracts, examples, validator guidance
 │   └── README.md
 │
 ├── .ai-factory/                     # AI Factory context (this run)
@@ -78,10 +79,12 @@ Surge is a local-first meta-orchestrator for AFK AI coding workflows in Rust. A 
 | `crates/surge-cli/src/main.rs` | `surge` CLI binary entrypoint — clap-derived command tree (init, project, agents, specs, worktrees, engine, daemon, registry). |
 | `crates/surge-cli/src/commands/init.rs` | `surge init` wizard and `--default` project onboarding. |
 | `crates/surge-cli/src/commands/project.rs` | `surge project describe` stable project-context command. |
+| `crates/surge-cli/src/commands/artifact.rs` | `surge artifact validate` contract validation surface for generated artifacts. |
 | `crates/surge-cli/src/commands/` | Other per-subcommand modules. |
 | `crates/surge-daemon/src/main.rs` | `surge-daemon` binary entrypoint. |
 | `crates/surge-daemon/src/lib.rs` | Daemon library: `admission`, `broadcast`, `intake_completion`, `lifecycle`, `pidfile`, `server`, `inbox`. |
 | `crates/surge-core/src/lib.rs` | Leaf core types: graph, node, edge, event, profile, sandbox, validation. No I/O. |
+| `crates/surge-core/src/artifact_contract.rs` | Canonical artifact contracts and pure validators for description, roadmap, spec, ADR, story, plan, and flow artifacts. |
 | `crates/surge-orchestrator/src/project_context.rs` | Deterministic project scan, `project.md` generation, and run-level context seeding helpers. |
 | `surge.toml` / `surge.example.toml` | User-facing runtime configuration. The `.example` file documents every field. |
 | `project.md` | Generated stable project summary captured into new runs as `project_context` when present. |
@@ -101,6 +104,7 @@ Surge is a local-first meta-orchestrator for AFK AI coding workflows in Rust. A 
 | Bootstrap | `docs/bootstrap.md` | Adaptive prompt → description → roadmap → flow generation, approvals, archetypes, template skip. |
 | Workflow | `docs/workflow.md` | AFK workflow, flow model, intake sources, run lifecycle. |
 | Architecture | `docs/ARCHITECTURE.md` | Canonical architecture document: positioning, principles, flow model, engine, ACP bridge, intake, storage, crate layout, non-goals. |
+| Artifact Conventions | `docs/conventions/README.md` | Canonical generated artifact names, schemas, validators, minimal examples, and profile author guidance. |
 | Development | `docs/development.md` | `cargo` checks, ignored long-running tests, local runtime state. |
 | User config example | `surge.example.toml` | Annotated example of every `surge.toml` field. |
 

--- a/crates/surge-acp/src/connection.rs
+++ b/crates/surge-acp/src/connection.rs
@@ -542,8 +542,8 @@ mod tests {
         #[tokio::test]
         async fn test_wait_or_kill_grace_period() {
             #[cfg(windows)]
-            let mut child = Command::new("cmd")
-                .args(["/C", "ping", "-n", "100", "127.0.0.1"])
+            let mut child = Command::new("powershell")
+                .args(["-NoProfile", "-Command", "Start-Sleep -Seconds 100"])
                 .stdin(Stdio::null())
                 .stdout(Stdio::null())
                 .stderr(Stdio::null())
@@ -576,7 +576,7 @@ mod tests {
 
             // Should have taken approximately the grace period (allow some overhead)
             assert!(
-                elapsed >= std::time::Duration::from_millis(100),
+                elapsed >= std::time::Duration::from_millis(80),
                 "Should wait for grace period"
             );
             assert!(

--- a/crates/surge-cli/src/commands/artifact.rs
+++ b/crates/surge-cli/src/commands/artifact.rs
@@ -1,0 +1,161 @@
+//! `surge artifact` commands.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result, bail};
+use clap::{Subcommand, ValueEnum};
+use surge_core::{
+    ArtifactDiagnosticCode, ArtifactKind, ArtifactValidationDiagnostic, ArtifactValidationReport,
+    Graph, validate_artifact,
+};
+
+/// Subcommands under `surge artifact`.
+#[derive(Subcommand, Debug)]
+pub enum ArtifactCommands {
+    /// Validate an artifact against a Surge artifact contract.
+    Validate {
+        /// Artifact contract kind, for example `description`, `roadmap`, `spec`, `adr`, or `flow`.
+        #[arg(long)]
+        kind: ArtifactKind,
+        /// Artifact path to read and validate.
+        path: PathBuf,
+        /// Output format.
+        #[arg(long, value_enum, default_value_t = ArtifactOutputFormat::Human)]
+        format: ArtifactOutputFormat,
+    },
+}
+
+/// Validation output format.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum ArtifactOutputFormat {
+    /// Human-readable diagnostics.
+    Human,
+    /// Pretty-printed JSON report.
+    Json,
+}
+
+/// Top-level dispatcher for `surge artifact`.
+pub fn run(command: ArtifactCommands) -> Result<()> {
+    match command {
+        ArtifactCommands::Validate { kind, path, format } => validate_command(kind, &path, format),
+    }
+}
+
+fn validate_command(kind: ArtifactKind, path: &Path, format: ArtifactOutputFormat) -> Result<()> {
+    let content =
+        std::fs::read_to_string(path).with_context(|| format!("read {}", path.display()))?;
+    let report = validate_loaded_artifact(kind, path, &content);
+    write_report(path, &report, format)?;
+
+    if report.is_valid() {
+        Ok(())
+    } else {
+        bail!(
+            "artifact validation failed with {} error(s)",
+            report.error_count()
+        )
+    }
+}
+
+fn validate_loaded_artifact(
+    kind: ArtifactKind,
+    path: &Path,
+    content: &str,
+) -> ArtifactValidationReport {
+    let mut report = validate_artifact(kind, Some(path), content);
+    if kind == ArtifactKind::Flow && report.is_valid() {
+        validate_flow_graph(content, &mut report);
+    }
+    report
+}
+
+fn validate_flow_graph(content: &str, report: &mut ArtifactValidationReport) {
+    match toml::from_str::<Graph>(content) {
+        Ok(graph) => {
+            if let Err(error) = surge_orchestrator::engine::validate::validate_for_m6(&graph) {
+                report.push(ArtifactValidationDiagnostic::error(
+                    ArtifactKind::Flow,
+                    ArtifactDiagnosticCode::GraphValidationFailed,
+                    None,
+                    format!("flow graph validation failed: {error}"),
+                ));
+            }
+        },
+        Err(error) => report.push(ArtifactValidationDiagnostic::error(
+            ArtifactKind::Flow,
+            ArtifactDiagnosticCode::GraphValidationFailed,
+            None,
+            format!("flow graph parse failed: {error}"),
+        )),
+    }
+}
+
+fn write_report(
+    path: &Path,
+    report: &ArtifactValidationReport,
+    format: ArtifactOutputFormat,
+) -> Result<()> {
+    match format {
+        ArtifactOutputFormat::Human => write_human_report(path, report),
+        ArtifactOutputFormat::Json => {
+            println!("{}", serde_json::to_string_pretty(report)?);
+            Ok(())
+        },
+    }
+}
+
+fn write_human_report(path: &Path, report: &ArtifactValidationReport) -> Result<()> {
+    if report.is_valid() {
+        println!("OK {} {}", report.kind, path.display());
+        return Ok(());
+    }
+
+    eprintln!(
+        "INVALID {} {} ({} error(s), {} warning(s))",
+        report.kind,
+        path.display(),
+        report.error_count(),
+        report.warning_count()
+    );
+    for diagnostic in &report.diagnostics {
+        let location = diagnostic
+            .location
+            .as_deref()
+            .map_or(String::new(), |location| format!(" at {location}"));
+        eprintln!(
+            "- {:?} [{}]{} {}",
+            diagnostic.severity, diagnostic.code, location, diagnostic.message
+        );
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validates_flow_with_engine_errors() {
+        let report = validate_loaded_artifact(
+            ArtifactKind::Flow,
+            Path::new("flow.toml"),
+            r#"schema_version = 1
+start = "missing"
+edges = []
+
+[metadata]
+name = "broken"
+created_at = "2026-05-11T00:00:00Z"
+
+[nodes]
+"#,
+        );
+
+        assert!(
+            report
+                .diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.code == ArtifactDiagnosticCode::GraphValidationFailed)
+        );
+    }
+}

--- a/crates/surge-cli/src/commands/artifact.rs
+++ b/crates/surge-cli/src/commands/artifact.rs
@@ -63,7 +63,7 @@ fn validate_loaded_artifact(
     content: &str,
 ) -> ArtifactValidationReport {
     let mut report = validate_artifact(kind, Some(path), content);
-    if kind == ArtifactKind::Flow && report.is_valid() {
+    if kind == ArtifactKind::Flow {
         validate_flow_graph(content, &mut report);
     }
     report
@@ -83,7 +83,7 @@ fn validate_flow_graph(content: &str, report: &mut ArtifactValidationReport) {
         },
         Err(error) => report.push(ArtifactValidationDiagnostic::error(
             ArtifactKind::Flow,
-            ArtifactDiagnosticCode::GraphValidationFailed,
+            ArtifactDiagnosticCode::GraphParseFailed,
             None,
             format!("flow graph parse failed: {error}"),
         )),
@@ -151,6 +151,60 @@ created_at = "2026-05-11T00:00:00Z"
 "#,
         );
 
+        assert!(
+            report
+                .diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.code == ArtifactDiagnosticCode::GraphValidationFailed)
+        );
+    }
+
+    #[test]
+    fn validates_flow_reports_parse_errors_separately() {
+        let report = validate_loaded_artifact(
+            ArtifactKind::Flow,
+            Path::new("flow.toml"),
+            "schema_version = 1\nstart = [",
+        );
+
+        assert!(
+            report
+                .diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.code == ArtifactDiagnosticCode::InvalidToml)
+        );
+        assert!(
+            report
+                .diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.code == ArtifactDiagnosticCode::GraphParseFailed)
+        );
+    }
+
+    #[test]
+    fn validates_flow_reports_graph_errors_with_contract_errors() {
+        let report = validate_loaded_artifact(
+            ArtifactKind::Flow,
+            Path::new("flow.toml"),
+            r#"schema_version = 2
+start = "missing"
+edges = []
+
+[metadata]
+name = "broken"
+created_at = "2026-05-11T00:00:00Z"
+
+[nodes]
+"#,
+        );
+
+        assert!(
+            report
+                .diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.code
+                    == ArtifactDiagnosticCode::UnsupportedSchemaVersion)
+        );
         assert!(
             report
                 .diagnostics

--- a/crates/surge-cli/src/commands/mod.rs
+++ b/crates/surge-cli/src/commands/mod.rs
@@ -1,5 +1,6 @@
 pub mod agent;
 pub mod analytics;
+pub mod artifact;
 pub mod bootstrap;
 pub mod config;
 pub mod daemon;

--- a/crates/surge-cli/src/main.rs
+++ b/crates/surge-cli/src/main.rs
@@ -63,6 +63,12 @@ enum Commands {
         command: SpecCommands,
     },
 
+    /// Validate and inspect Surge artifacts.
+    Artifact {
+        #[command(subcommand)]
+        command: commands::artifact::ArtifactCommands,
+    },
+
     /// Run a spec through the full pipeline
     Run {
         /// Spec ID or filename
@@ -348,6 +354,7 @@ async fn main() -> Result<()> {
             | Commands::Config { .. }
             | Commands::Bootstrap(_)
             | Commands::Engine { .. }
+            | Commands::Artifact { .. }
             | Commands::Tracker { .. }
             | Commands::Daemon { .. }
             | Commands::Profile { .. }
@@ -468,6 +475,10 @@ async fn run_command(command: Commands) -> Result<()> {
 
         Commands::Spec { command } => {
             commands::spec::run(command)?;
+        },
+
+        Commands::Artifact { command } => {
+            commands::artifact::run(command)?;
         },
 
         Commands::Run {

--- a/crates/surge-cli/tests/examples_smoke.rs
+++ b/crates/surge-cli/tests/examples_smoke.rs
@@ -90,6 +90,41 @@ fn flow_spike_validates() {
 }
 
 #[test]
+fn bundled_template_names_and_legacy_aliases_start_runs() {
+    let temp = tempfile::tempdir().unwrap();
+    let home = temp.path().join("home");
+    std::fs::create_dir_all(&home).unwrap();
+    let worktree = temp.path().join("worktree");
+    std::fs::create_dir_all(&worktree).unwrap();
+
+    for template in [
+        "feature",
+        "bug-fix",
+        "bugfix",
+        "fix",
+        "refactor",
+        "performance",
+        "perf",
+        "security",
+        "sec",
+        "docs",
+        "doc",
+        "migration",
+        "migrate",
+    ] {
+        Command::cargo_bin("surge")
+            .unwrap()
+            .args(["engine", "run", "--template", template])
+            .current_dir(&worktree)
+            .env("HOME", &home)
+            .env("USERPROFILE", &home)
+            .assert()
+            .success()
+            .stdout(contains("run-"));
+    }
+}
+
+#[test]
 fn onboarding_smoke_can_init_describe_and_start_example_run() {
     let temp = tempfile::tempdir().unwrap();
     let home = temp.path().join("home");

--- a/crates/surge-cli/tests/examples_smoke.rs
+++ b/crates/surge-cli/tests/examples_smoke.rs
@@ -94,6 +94,8 @@ fn bundled_template_names_and_legacy_aliases_start_runs() {
     let temp = tempfile::tempdir().unwrap();
     let home = temp.path().join("home");
     std::fs::create_dir_all(&home).unwrap();
+    let surge_home = home.join(".surge");
+    std::fs::create_dir_all(&surge_home).unwrap();
     let worktree = temp.path().join("worktree");
     std::fs::create_dir_all(&worktree).unwrap();
 
@@ -118,6 +120,7 @@ fn bundled_template_names_and_legacy_aliases_start_runs() {
             .current_dir(&worktree)
             .env("HOME", &home)
             .env("USERPROFILE", &home)
+            .env("SURGE_HOME", &surge_home)
             .assert()
             .success()
             .stdout(contains("run-"));

--- a/crates/surge-core/bundled/flows/docs-1.0.toml
+++ b/crates/surge-core/bundled/flows/docs-1.0.toml
@@ -1,0 +1,136 @@
+# Documentation convention flow: outline, write, review, terminal success.
+
+schema_version = 1
+start = "research_outline"
+
+[metadata]
+name = "docs"
+created_at = "2026-05-11T00:00:00Z"
+
+[nodes.research_outline]
+id = "research_outline"
+
+[nodes.research_outline.position]
+x = 0.0
+y = 0.0
+
+[[nodes.research_outline.declared_outcomes]]
+id = "outlined"
+description = "Audience and outline are clear"
+edge_kind_hint = "forward"
+is_terminal = false
+
+[nodes.research_outline.config]
+node_kind = "agent"
+profile = "implementer@1.0"
+bindings = []
+hooks = []
+
+[nodes.research_outline.config.limits]
+timeout_seconds = 900
+max_retries = 3
+max_tokens = 200000
+
+[nodes.research_outline.config.custom_fields]
+
+[nodes.write_docs]
+id = "write_docs"
+
+[nodes.write_docs.position]
+x = 200.0
+y = 0.0
+
+[[nodes.write_docs.declared_outcomes]]
+id = "written"
+description = "Documentation draft written with examples"
+edge_kind_hint = "forward"
+is_terminal = false
+
+[nodes.write_docs.config]
+node_kind = "agent"
+profile = "implementer@1.0"
+bindings = []
+hooks = []
+
+[nodes.write_docs.config.limits]
+timeout_seconds = 900
+max_retries = 3
+max_tokens = 200000
+
+[nodes.write_docs.config.custom_fields]
+
+[nodes.review_publish]
+id = "review_publish"
+
+[nodes.review_publish.position]
+x = 400.0
+y = 0.0
+
+[[nodes.review_publish.declared_outcomes]]
+id = "published"
+description = "Documentation reviewed and ready to publish"
+edge_kind_hint = "forward"
+is_terminal = false
+
+[nodes.review_publish.config]
+node_kind = "agent"
+profile = "reviewer@1.0"
+bindings = []
+hooks = []
+
+[nodes.review_publish.config.limits]
+timeout_seconds = 900
+max_retries = 3
+max_tokens = 200000
+
+[nodes.review_publish.config.custom_fields]
+
+[nodes.end]
+id = "end"
+declared_outcomes = []
+
+[nodes.end.position]
+x = 600.0
+y = 0.0
+
+[nodes.end.config]
+node_kind = "terminal"
+
+[nodes.end.config.kind]
+type = "success"
+
+[[edges]]
+id = "e_outline_to_write"
+to = "write_docs"
+kind = "forward"
+
+[edges.from]
+node = "research_outline"
+outcome = "outlined"
+
+[edges.policy]
+on_max_exceeded = "escalate"
+
+[[edges]]
+id = "e_write_to_review"
+to = "review_publish"
+kind = "forward"
+
+[edges.from]
+node = "write_docs"
+outcome = "written"
+
+[edges.policy]
+on_max_exceeded = "escalate"
+
+[[edges]]
+id = "e_review_to_end"
+to = "end"
+kind = "forward"
+
+[edges.from]
+node = "review_publish"
+outcome = "published"
+
+[edges.policy]
+on_max_exceeded = "escalate"

--- a/crates/surge-core/bundled/flows/feature-1.0.toml
+++ b/crates/surge-core/bundled/flows/feature-1.0.toml
@@ -1,0 +1,136 @@
+# Feature convention flow: design, implement, integrate, terminal success.
+
+schema_version = 1
+start = "design_plan"
+
+[metadata]
+name = "feature"
+created_at = "2026-05-11T00:00:00Z"
+
+[nodes.design_plan]
+id = "design_plan"
+
+[nodes.design_plan.position]
+x = 0.0
+y = 0.0
+
+[[nodes.design_plan.declared_outcomes]]
+id = "planned"
+description = "Approach documented with acceptance criteria"
+edge_kind_hint = "forward"
+is_terminal = false
+
+[nodes.design_plan.config]
+node_kind = "agent"
+profile = "implementer@1.0"
+bindings = []
+hooks = []
+
+[nodes.design_plan.config.limits]
+timeout_seconds = 900
+max_retries = 3
+max_tokens = 200000
+
+[nodes.design_plan.config.custom_fields]
+
+[nodes.implement_core]
+id = "implement_core"
+
+[nodes.implement_core.position]
+x = 200.0
+y = 0.0
+
+[[nodes.implement_core.declared_outcomes]]
+id = "implemented"
+description = "Core feature logic implemented"
+edge_kind_hint = "forward"
+is_terminal = false
+
+[nodes.implement_core.config]
+node_kind = "agent"
+profile = "implementer@1.0"
+bindings = []
+hooks = []
+
+[nodes.implement_core.config.limits]
+timeout_seconds = 900
+max_retries = 3
+max_tokens = 200000
+
+[nodes.implement_core.config.custom_fields]
+
+[nodes.integrate_verify]
+id = "integrate_verify"
+
+[nodes.integrate_verify.position]
+x = 400.0
+y = 0.0
+
+[[nodes.integrate_verify.declared_outcomes]]
+id = "verified"
+description = "Feature integration and tests pass"
+edge_kind_hint = "forward"
+is_terminal = false
+
+[nodes.integrate_verify.config]
+node_kind = "agent"
+profile = "implementer@1.0"
+bindings = []
+hooks = []
+
+[nodes.integrate_verify.config.limits]
+timeout_seconds = 900
+max_retries = 3
+max_tokens = 200000
+
+[nodes.integrate_verify.config.custom_fields]
+
+[nodes.end]
+id = "end"
+declared_outcomes = []
+
+[nodes.end.position]
+x = 600.0
+y = 0.0
+
+[nodes.end.config]
+node_kind = "terminal"
+
+[nodes.end.config.kind]
+type = "success"
+
+[[edges]]
+id = "e_design_to_impl"
+to = "implement_core"
+kind = "forward"
+
+[edges.from]
+node = "design_plan"
+outcome = "planned"
+
+[edges.policy]
+on_max_exceeded = "escalate"
+
+[[edges]]
+id = "e_impl_to_verify"
+to = "integrate_verify"
+kind = "forward"
+
+[edges.from]
+node = "implement_core"
+outcome = "implemented"
+
+[edges.policy]
+on_max_exceeded = "escalate"
+
+[[edges]]
+id = "e_verify_to_end"
+to = "end"
+kind = "forward"
+
+[edges.from]
+node = "integrate_verify"
+outcome = "verified"
+
+[edges.policy]
+on_max_exceeded = "escalate"

--- a/crates/surge-core/bundled/flows/migration-1.0.toml
+++ b/crates/surge-core/bundled/flows/migration-1.0.toml
@@ -1,0 +1,136 @@
+# Migration convention flow: plan, migrate, rollback-validate, terminal success.
+
+schema_version = 1
+start = "migration_plan"
+
+[metadata]
+name = "migration"
+created_at = "2026-05-11T00:00:00Z"
+
+[nodes.migration_plan]
+id = "migration_plan"
+
+[nodes.migration_plan.position]
+x = 0.0
+y = 0.0
+
+[[nodes.migration_plan.declared_outcomes]]
+id = "planned"
+description = "Migration and rollback plan documented"
+edge_kind_hint = "forward"
+is_terminal = false
+
+[nodes.migration_plan.config]
+node_kind = "agent"
+profile = "implementer@1.0"
+bindings = []
+hooks = []
+
+[nodes.migration_plan.config.limits]
+timeout_seconds = 900
+max_retries = 3
+max_tokens = 200000
+
+[nodes.migration_plan.config.custom_fields]
+
+[nodes.implement_migration]
+id = "implement_migration"
+
+[nodes.implement_migration.position]
+x = 200.0
+y = 0.0
+
+[[nodes.implement_migration.declared_outcomes]]
+id = "migrated"
+description = "Migration implemented and data integrity checked"
+edge_kind_hint = "forward"
+is_terminal = false
+
+[nodes.implement_migration.config]
+node_kind = "agent"
+profile = "implementer@1.0"
+bindings = []
+hooks = []
+
+[nodes.implement_migration.config.limits]
+timeout_seconds = 900
+max_retries = 3
+max_tokens = 200000
+
+[nodes.implement_migration.config.custom_fields]
+
+[nodes.validate_rollback]
+id = "validate_rollback"
+
+[nodes.validate_rollback.position]
+x = 400.0
+y = 0.0
+
+[[nodes.validate_rollback.declared_outcomes]]
+id = "validated"
+description = "Rollback procedure tested and confirmed"
+edge_kind_hint = "forward"
+is_terminal = false
+
+[nodes.validate_rollback.config]
+node_kind = "agent"
+profile = "implementer@1.0"
+bindings = []
+hooks = []
+
+[nodes.validate_rollback.config.limits]
+timeout_seconds = 900
+max_retries = 3
+max_tokens = 200000
+
+[nodes.validate_rollback.config.custom_fields]
+
+[nodes.end]
+id = "end"
+declared_outcomes = []
+
+[nodes.end.position]
+x = 600.0
+y = 0.0
+
+[nodes.end.config]
+node_kind = "terminal"
+
+[nodes.end.config.kind]
+type = "success"
+
+[[edges]]
+id = "e_plan_to_migrate"
+to = "implement_migration"
+kind = "forward"
+
+[edges.from]
+node = "migration_plan"
+outcome = "planned"
+
+[edges.policy]
+on_max_exceeded = "escalate"
+
+[[edges]]
+id = "e_migrate_to_rollback"
+to = "validate_rollback"
+kind = "forward"
+
+[edges.from]
+node = "implement_migration"
+outcome = "migrated"
+
+[edges.policy]
+on_max_exceeded = "escalate"
+
+[[edges]]
+id = "e_rollback_to_end"
+to = "end"
+kind = "forward"
+
+[edges.from]
+node = "validate_rollback"
+outcome = "validated"
+
+[edges.policy]
+on_max_exceeded = "escalate"

--- a/crates/surge-core/bundled/flows/performance-1.0.toml
+++ b/crates/surge-core/bundled/flows/performance-1.0.toml
@@ -1,0 +1,136 @@
+# Performance convention flow: baseline, optimize, benchmark, terminal success.
+
+schema_version = 1
+start = "profile_baseline"
+
+[metadata]
+name = "performance"
+created_at = "2026-05-11T00:00:00Z"
+
+[nodes.profile_baseline]
+id = "profile_baseline"
+
+[nodes.profile_baseline.position]
+x = 0.0
+y = 0.0
+
+[[nodes.profile_baseline.declared_outcomes]]
+id = "profiled"
+description = "Benchmark baseline and bottlenecks documented"
+edge_kind_hint = "forward"
+is_terminal = false
+
+[nodes.profile_baseline.config]
+node_kind = "agent"
+profile = "implementer@1.0"
+bindings = []
+hooks = []
+
+[nodes.profile_baseline.config.limits]
+timeout_seconds = 900
+max_retries = 3
+max_tokens = 200000
+
+[nodes.profile_baseline.config.custom_fields]
+
+[nodes.optimize_hot_paths]
+id = "optimize_hot_paths"
+
+[nodes.optimize_hot_paths.position]
+x = 200.0
+y = 0.0
+
+[[nodes.optimize_hot_paths.declared_outcomes]]
+id = "optimized"
+description = "Targeted optimizations implemented"
+edge_kind_hint = "forward"
+is_terminal = false
+
+[nodes.optimize_hot_paths.config]
+node_kind = "agent"
+profile = "implementer@1.0"
+bindings = []
+hooks = []
+
+[nodes.optimize_hot_paths.config.limits]
+timeout_seconds = 900
+max_retries = 3
+max_tokens = 200000
+
+[nodes.optimize_hot_paths.config.custom_fields]
+
+[nodes.benchmark_validate]
+id = "benchmark_validate"
+
+[nodes.benchmark_validate.position]
+x = 400.0
+y = 0.0
+
+[[nodes.benchmark_validate.declared_outcomes]]
+id = "validated"
+description = "Benchmarks confirm improvement without correctness regressions"
+edge_kind_hint = "forward"
+is_terminal = false
+
+[nodes.benchmark_validate.config]
+node_kind = "agent"
+profile = "implementer@1.0"
+bindings = []
+hooks = []
+
+[nodes.benchmark_validate.config.limits]
+timeout_seconds = 900
+max_retries = 3
+max_tokens = 200000
+
+[nodes.benchmark_validate.config.custom_fields]
+
+[nodes.end]
+id = "end"
+declared_outcomes = []
+
+[nodes.end.position]
+x = 600.0
+y = 0.0
+
+[nodes.end.config]
+node_kind = "terminal"
+
+[nodes.end.config.kind]
+type = "success"
+
+[[edges]]
+id = "e_profile_to_optimize"
+to = "optimize_hot_paths"
+kind = "forward"
+
+[edges.from]
+node = "profile_baseline"
+outcome = "profiled"
+
+[edges.policy]
+on_max_exceeded = "escalate"
+
+[[edges]]
+id = "e_optimize_to_benchmark"
+to = "benchmark_validate"
+kind = "forward"
+
+[edges.from]
+node = "optimize_hot_paths"
+outcome = "optimized"
+
+[edges.policy]
+on_max_exceeded = "escalate"
+
+[[edges]]
+id = "e_benchmark_to_end"
+to = "end"
+kind = "forward"
+
+[edges.from]
+node = "benchmark_validate"
+outcome = "validated"
+
+[edges.policy]
+on_max_exceeded = "escalate"

--- a/crates/surge-core/bundled/flows/security-1.0.toml
+++ b/crates/surge-core/bundled/flows/security-1.0.toml
@@ -1,0 +1,136 @@
+# Security convention flow: audit, fix, test, terminal success.
+
+schema_version = 1
+start = "security_audit"
+
+[metadata]
+name = "security"
+created_at = "2026-05-11T00:00:00Z"
+
+[nodes.security_audit]
+id = "security_audit"
+
+[nodes.security_audit.position]
+x = 0.0
+y = 0.0
+
+[[nodes.security_audit.declared_outcomes]]
+id = "audited"
+description = "Security findings documented"
+edge_kind_hint = "forward"
+is_terminal = false
+
+[nodes.security_audit.config]
+node_kind = "agent"
+profile = "implementer@1.0"
+bindings = []
+hooks = []
+
+[nodes.security_audit.config.limits]
+timeout_seconds = 900
+max_retries = 3
+max_tokens = 200000
+
+[nodes.security_audit.config.custom_fields]
+
+[nodes.implement_fixes]
+id = "implement_fixes"
+
+[nodes.implement_fixes.position]
+x = 200.0
+y = 0.0
+
+[[nodes.implement_fixes.declared_outcomes]]
+id = "fixed"
+description = "Security fixes implemented"
+edge_kind_hint = "forward"
+is_terminal = false
+
+[nodes.implement_fixes.config]
+node_kind = "agent"
+profile = "implementer@1.0"
+bindings = []
+hooks = []
+
+[nodes.implement_fixes.config.limits]
+timeout_seconds = 900
+max_retries = 3
+max_tokens = 200000
+
+[nodes.implement_fixes.config.custom_fields]
+
+[nodes.security_tests]
+id = "security_tests"
+
+[nodes.security_tests.position]
+x = 400.0
+y = 0.0
+
+[[nodes.security_tests.declared_outcomes]]
+id = "verified"
+description = "Security regression tests pass"
+edge_kind_hint = "forward"
+is_terminal = false
+
+[nodes.security_tests.config]
+node_kind = "agent"
+profile = "implementer@1.0"
+bindings = []
+hooks = []
+
+[nodes.security_tests.config.limits]
+timeout_seconds = 900
+max_retries = 3
+max_tokens = 200000
+
+[nodes.security_tests.config.custom_fields]
+
+[nodes.end]
+id = "end"
+declared_outcomes = []
+
+[nodes.end.position]
+x = 600.0
+y = 0.0
+
+[nodes.end.config]
+node_kind = "terminal"
+
+[nodes.end.config.kind]
+type = "success"
+
+[[edges]]
+id = "e_audit_to_fix"
+to = "implement_fixes"
+kind = "forward"
+
+[edges.from]
+node = "security_audit"
+outcome = "audited"
+
+[edges.policy]
+on_max_exceeded = "escalate"
+
+[[edges]]
+id = "e_fix_to_tests"
+to = "security_tests"
+kind = "forward"
+
+[edges.from]
+node = "implement_fixes"
+outcome = "fixed"
+
+[edges.policy]
+on_max_exceeded = "escalate"
+
+[[edges]]
+id = "e_tests_to_end"
+to = "end"
+kind = "forward"
+
+[edges.from]
+node = "security_tests"
+outcome = "verified"
+
+[edges.policy]
+on_max_exceeded = "escalate"

--- a/crates/surge-core/bundled/profiles/architect-1.0.toml
+++ b/crates/surge-core/bundled/profiles/architect-1.0.toml
@@ -29,7 +29,11 @@ default_skills = ["aif-architecture"]
 id = "drafted"
 description = "ADR drafted with frontmatter and decision rationale."
 edge_kind_hint = "forward"
-required_artifacts = ["adr.md"]
+required_artifacts = ["docs/adr/<NNNN>-<slug>.md"]
+
+[[outcomes.produced_artifacts]]
+path = "docs/adr/<NNNN>-<slug>.md"
+contract = { kind = "adr", schema_version = 1 }
 
 [[outcomes]]
 id = "no_decision_needed"
@@ -44,8 +48,9 @@ source = { source = "node_output", from_role = "spec-author" }
 system = """\
 You are the Architect. Read `{{spec}}` and decide whether the work merits an ADR.
 
-If yes, output `adr.md` with:
-- TOML frontmatter: `status`, `deciders`, `date`, `supersedes` (or `none`).
+If yes, output one ADR contract file at `docs/adr/<NNNN>-<slug>.md` with:
+- TOML frontmatter delimited by `+++`: `status`, `deciders`, `date`, and optional `supersedes`.
+- `## Status` — mirror the frontmatter status for human readers.
 - `## Context` — why this decision is up for grabs now.
 - `## Decision` — the chosen direction in plain prose.
 - `## Alternatives considered` — at least two, with the reason each was rejected.
@@ -54,6 +59,6 @@ If yes, output `adr.md` with:
 If the spec is purely tactical (a one-file fix, a cleanup), report `no_decision_needed`.
 
 Rules:
-- File path is `docs/adr/<NNNN>-<slug>.md` where `NNNN` is the next free number.
+- File path is `docs/adr/<NNNN>-<slug>.md` where `NNNN` is the next free number; do not emit root-level `adr.md`.
 - Decisions, not opinions. If you can't justify with at least one trade-off, you're not making a decision worth recording.
 """

--- a/crates/surge-core/bundled/profiles/description-author-1.0.toml
+++ b/crates/surge-core/bundled/profiles/description-author-1.0.toml
@@ -32,6 +32,10 @@ description = "Description.md drafted and ready for human review."
 edge_kind_hint = "forward"
 required_artifacts = ["description.md"]
 
+[[outcomes.produced_artifacts]]
+path = "description.md"
+contract = { kind = "description", schema_version = 1 }
+
 [[outcomes]]
 id = "needs_clarification"
 description = "Task is too ambiguous to draft a description without human input."
@@ -51,6 +55,14 @@ name = "project_context"
 source = { source = "run_artifact" }
 optional = true
 
+[[hooks.entries]]
+id = "validate-description-md"
+trigger = "on_outcome"
+matcher = { outcome = "drafted" }
+command = "{surge} artifact validate --kind description description.md"
+on_failure = "reject"
+timeout_seconds = 30
+
 [prompt]
 system = """\
 You are the Description Author for Surge bootstrap.
@@ -68,11 +80,11 @@ Operator feedback from the previous edit cycle, if any:
 
 # Mission
 
-Turn the user request into one artifact: `description.md`. This artifact is the
+Turn the user request into the Description contract artifact: `description.md`. This artifact is the
 source of truth for the Roadmap Planner and Flow Generator, so write it as if the
 next agent will not see the original conversation.
 
-Output schema (Markdown sections in this order):
+Description contract (Markdown; no schema_version field):
 - `## Goal` — one paragraph; the *what* and the *why*.
 - `## Context` — what already exists in the project that this work touches.
 - `## Requirements` — bulleted, testable, prioritized.

--- a/crates/surge-core/bundled/profiles/flow-generator-1.0.toml
+++ b/crates/surge-core/bundled/profiles/flow-generator-1.0.toml
@@ -32,6 +32,10 @@ description = "flow.toml drafted and passes graph validation."
 edge_kind_hint = "forward"
 required_artifacts = ["flow.toml"]
 
+[[outcomes.produced_artifacts]]
+path = "flow.toml"
+contract = { kind = "flow", schema_version = 1 }
+
 [[outcomes]]
 id = "validation_failed"
 description = "Generated flow.toml failed graph validation; re-emit with the validator's errors fed back."
@@ -66,7 +70,7 @@ Original user request:
 Approved or edited `description.md`:
 {{description_artifact}}
 
-Approved or edited `roadmap.md`:
+Approved or edited Roadmap contract artifact (`roadmap.toml`, with `roadmap.md` as compatibility context when present):
 {{roadmap_artifact}}
 
 Validator or operator feedback from the previous edit cycle, if any:
@@ -74,15 +78,21 @@ Validator or operator feedback from the previous edit cycle, if any:
 
 # Mission
 
-Emit one valid `flow.toml` graph. Use typed nodes, declared outcomes, and profile
+Emit one valid Flow contract artifact: `flow.toml` with `schema_version = 1`.
+Use typed nodes, declared outcomes, and profile
 references; do not write free-form execution instructions into graph nodes.
 
 Pick exactly one archetype and include it in `[metadata.archetype]`:
+- `feature` — design/plan -> implement core -> integration/tests for standard feature work.
 - `linear-3` — single small task: Spec Author -> Implementer -> Verifier -> Terminal.
 - `linear-with-review` — one milestone with 5-7 tasks and an explicit Review node.
 - `multi-milestone` — outer Loop over `roadmap.milestones` wrapping per-milestone task Loops.
 - `bug-fix` — starts with reproduction / failing-case characterization before implementation.
 - `refactor` — starts with behavior characterization before implementation.
+- `performance` — baseline/profile -> optimize -> benchmark/validate.
+- `security` — security audit -> fixes -> security regression tests.
+- `docs` — outline -> write -> review/publish documentation.
+- `migration` — migration plan -> implementation -> rollback validation.
 - `spike` — bounded research/prototype path; may skip Architect and Reviewer when appropriate.
 - `single-task` — one focused Agent node plus Terminal for tiny, low-risk work.
 

--- a/crates/surge-core/bundled/profiles/implementer-1.0.toml
+++ b/crates/surge-core/bundled/profiles/implementer-1.0.toml
@@ -55,11 +55,13 @@ elevation = true
 
 [prompt]
 system = """\
-You are the Implementer. Implement the work described by `{{spec}}`. When `{{adr}}` is
-bound, treat its `## Decision` section as locked.
+You are the Implementer. Implement the work described by the Spec contract artifact
+`{{spec}}` (`spec.toml`, or `spec.md` compatibility text). When `{{adr}}` is bound,
+treat its ADR contract `## Decision` section as locked.
 
 Process:
 1. Read the spec, the ADR (if any), the project rules, and the architecture doc.
+   Treat every `[[spec.subtasks.acceptance_criteria]]` entry or `## Acceptance Criteria` checkbox as required.
 2. Use existing code patterns. Match the surrounding crate's style. Do not introduce a new pattern when one exists.
 3. Add tests when the spec calls for them; do not invent test scaffolding the spec did not ask for.
 4. Use `tracing::*` for logs (`debug` for hot paths, `info` for state changes, `warn` for recoverable degradations, `error` for failures).
@@ -68,6 +70,7 @@ Process:
 Rules:
 - No `unwrap()` / `expect()` / `dbg!` / `println!` in library code.
 - `anyhow` only in binary crates; libraries use `thiserror`-derived enums.
+- Story files, when referenced, live at `stories/story-NNN.md` and carry `## Context`, `## What needs to be done`, `## Files to modify`, and `## Acceptance criteria`.
 - If a task is ambiguous, prefer the smaller change and report `blocked` with the question.
 - If you make partial progress, report `partial` with a one-line summary per remaining subtask.
 """

--- a/crates/surge-core/bundled/profiles/pr-composer-1.0.toml
+++ b/crates/surge-core/bundled/profiles/pr-composer-1.0.toml
@@ -44,7 +44,9 @@ optional = true
 
 [prompt]
 system = """\
-You are the PR Composer. Draft `pr.md` with two sections separated by `---`:
+You are the PR Composer. Draft `pr.md` from the diff plus upstream artifacts:
+Spec contract (`spec.toml` or `spec.md`) and ADR contract (`docs/adr/<NNNN>-<slug>.md`) when present.
+Use two sections separated by `---`:
 
 1. Title (single line, < 70 characters, conventional-commit prefix where it fits: `feat(area): ...`).
 2. Body, in this exact order:

--- a/crates/surge-core/bundled/profiles/reviewer-1.0.toml
+++ b/crates/surge-core/bundled/profiles/reviewer-1.0.toml
@@ -47,7 +47,8 @@ optional = true
 
 [prompt]
 system = """\
-You are the Reviewer. Read `{{diff}}` (and `{{spec}}` if available) and produce a structured review.
+You are the Reviewer. Read `{{diff}}` (and the Spec contract artifact `{{spec}}`
+if available) and produce a structured review.
 
 Output sections:
 - `## Blocking issues` — bugs, broken invariants, regressions, missing required tests.
@@ -56,6 +57,7 @@ Output sections:
 
 Rules:
 - A change is blocking if shipping it as-is creates a real risk: incorrect behavior, data loss, security, performance regression, breaking public API without migration.
+- Missing required Spec acceptance criteria, story-file requirements, or ADR decisions are blocking.
 - Style nits and personal preference go under Suggestions, never Blocking.
 - If `## Blocking issues` is non-empty, report `changes_requested` with a one-line summary per issue. Otherwise `approved`.
 """

--- a/crates/surge-core/bundled/profiles/roadmap-planner-1.0.toml
+++ b/crates/surge-core/bundled/profiles/roadmap-planner-1.0.toml
@@ -1,7 +1,7 @@
 # Roadmap Planner — bootstrap stage 2.
 #
-# Consumes description.md and emits a roadmap.md with milestones,
-# tasks, and dependency edges, ready for the Flow Generator.
+# Consumes description.md and emits roadmap.toml plus a human roadmap.md
+# compatibility view, ready for the Flow Generator.
 
 schema_version = 1
 
@@ -10,7 +10,7 @@ id = "roadmap-planner"
 version = "1.0.0"
 display_name = "Roadmap Planner"
 category = "_bootstrap"
-description = "Turns description.md into a milestoned, dependency-aware roadmap.md."
+description = "Turns description.md into a milestoned, dependency-aware roadmap.toml plus roadmap.md."
 when_to_use = "Second bootstrap stage — after Description Author and before Flow Generator."
 
 [runtime]
@@ -27,9 +27,17 @@ default_skills = ["aif-architecture"]
 
 [[outcomes]]
 id = "drafted"
-description = "Roadmap.md drafted with milestones and dependencies."
+description = "Roadmap artifacts drafted with milestones and dependencies."
 edge_kind_hint = "forward"
-required_artifacts = ["roadmap.md"]
+required_artifacts = ["roadmap.toml", "roadmap.md"]
+
+[[outcomes.produced_artifacts]]
+path = "roadmap.toml"
+contract = { kind = "roadmap", schema_version = 1 }
+
+[[outcomes.produced_artifacts]]
+path = "roadmap.md"
+contract = { kind = "roadmap", schema_version = 1 }
 
 [[outcomes]]
 id = "needs_clarification"
@@ -49,6 +57,22 @@ name = "edit_feedback"
 source = { source = "any" }
 optional = true
 
+[[hooks.entries]]
+id = "validate-roadmap-toml"
+trigger = "on_outcome"
+matcher = { outcome = "drafted" }
+command = "{surge} artifact validate --kind roadmap roadmap.toml"
+on_failure = "reject"
+timeout_seconds = 30
+
+[[hooks.entries]]
+id = "validate-roadmap-md"
+trigger = "on_outcome"
+matcher = { outcome = "drafted" }
+command = "{surge} artifact validate --kind roadmap roadmap.md"
+on_failure = "reject"
+timeout_seconds = 30
+
 [prompt]
 system = """\
 You are the Roadmap Planner for Surge bootstrap.
@@ -66,11 +90,18 @@ Operator feedback from the previous edit cycle, if any:
 
 # Mission
 
-Turn `description.md` into one artifact: `roadmap.md`. The roadmap must be
-milestoned, dependency-aware, and specific enough for the Flow Generator to
-compile into a `flow.toml` graph without inventing scope.
+Turn `description.md` into Roadmap contract artifacts:
+- Primary machine-readable artifact: `roadmap.toml` with `schema_version = 1`.
+- Human compatibility artifact: `roadmap.md`.
 
-Output schema:
+`roadmap.toml` schema:
+- Top-level `schema_version = 1`.
+- `[[milestones]]` with `id`, `title`, and nested `[[milestones.tasks]]`.
+- Each task has `id`, `title`, optional `description`, and optional `acceptance_criteria = [...]`.
+- `[[dependencies]]` uses `from`, `to`, and optional `reason`.
+- `[[risks]]` uses `description` and optional `mitigation`.
+
+`roadmap.md` compatibility sections:
 - `## Milestones` — ordered list. Each milestone has a heading and 3-15 task bullets sized to scope.
 - `## Dependencies` — explicit edges between milestones when one must finish before another can start.
 - `## Risks` — short bulleted list of what could break the plan.
@@ -80,9 +111,9 @@ Rules:
 - Milestones are deliverable-focused, not phase-focused (no "Planning" / "Implementation" / "Testing" milestones).
 - Calibrate task sizes against the existing project: a "2-day" task is roughly 8 plan-tasks.
 - If the description is missing requirements you need to plan, report `needs_clarification` with the gaps.
-- No code in this artifact. Roadmap describes what ships, not how.
+- No code in these artifacts. Roadmap describes what ships, not how.
 
 When finished:
-1. Write the markdown artifact to `roadmap.md`.
-2. Call `report_stage_outcome` with outcome `drafted` and `artifacts_produced = ["roadmap.md"]`.
+1. Write `roadmap.toml` and `roadmap.md`.
+2. Call `report_stage_outcome` with outcome `drafted` and `artifacts_produced = ["roadmap.toml", "roadmap.md"]`.
 """

--- a/crates/surge-core/bundled/profiles/spec-author-1.0.toml
+++ b/crates/surge-core/bundled/profiles/spec-author-1.0.toml
@@ -27,9 +27,17 @@ default_skills = ["aif-best-practices"]
 
 [[outcomes]]
 id = "drafted"
-description = "Spec drafted with subtasks and acceptance criteria."
+description = "Spec artifacts drafted with subtasks and acceptance criteria."
 edge_kind_hint = "forward"
-required_artifacts = ["spec.md"]
+required_artifacts = ["spec.toml", "spec.md"]
+
+[[outcomes.produced_artifacts]]
+path = "spec.toml"
+contract = { kind = "spec", schema_version = 1 }
+
+[[outcomes.produced_artifacts]]
+path = "spec.md"
+contract = { kind = "spec", schema_version = 1 }
 
 [[outcomes]]
 id = "needs_clarification"
@@ -50,24 +58,50 @@ name = "project_context"
 source = { source = "run_artifact" }
 optional = true
 
+[[hooks.entries]]
+id = "validate-spec-toml"
+trigger = "on_outcome"
+matcher = { outcome = "drafted" }
+command = "{surge} artifact validate --kind spec spec.toml"
+on_failure = "reject"
+timeout_seconds = 30
+
+[[hooks.entries]]
+id = "validate-spec-md"
+trigger = "on_outcome"
+matcher = { outcome = "drafted" }
+command = "{surge} artifact validate --kind spec spec.md"
+on_failure = "reject"
+timeout_seconds = 30
+
 [prompt]
 system = """\
 You are the Spec Author. Read `{{milestone}}`, `{{description}}`, and the optional
-stable project context below, then emit `spec.md` following the project's Spec convention.
+stable project context below, then emit Spec contract artifacts: `spec.toml` and
+the human compatibility view `spec.md`.
 
 Stable project context:
 {{project_context}}
 
-Output schema:
+`spec.toml` schema:
+- Top-level `schema_version = 1`.
+- `[spec]` contains `id`, `title`, `description`, `complexity`, and `subtasks`.
+- Each `[[spec.subtasks]]` contains `id`, `title`, `description`, `complexity`, optional `files`, optional `depends_on`, and optional `story_file`.
+- Each subtask has one or more `[[spec.subtasks.acceptance_criteria]]` entries with `description`.
+
+`spec.md` compatibility sections:
 - `## Goal` — restated for this milestone.
-- `## Subtasks` — numbered list. Each subtask has a one-line summary and a bullet list of
-  acceptance criteria (machine-readable, used by Verifier).
-- `## Story Files` — when subtasks reference long-form stories, list them under `stories/story-NNN.md`.
+- `## Subtasks` — numbered list. Each subtask has a one-line summary and a bullet list of acceptance criteria.
+- `## Acceptance Criteria` — grouped by subtask and written as testable checkboxes.
+- `## Story Files` — long-form story paths under `stories/story-NNN.md` when needed.
 - `## Constraints` — performance budgets, public API stability, deprecation deadlines.
 
 Rules:
 - Acceptance criteria are testable: "X compiles", "test Y passes", "metric Z under N ms".
-- No code in this artifact. Spec describes *what* must hold, not *how* to make it hold.
-- Each subtask is independently completable; sequencing is captured by explicit `dependsOn` lists, not by ordering.
+- No code in these artifacts. Spec describes *what* must hold, not *how* to make it hold.
+- Each subtask is independently completable; sequencing is captured by explicit `depends_on` lists, not by ordering.
+- If a subtask needs long context, create `stories/story-NNN.md` with `## Context`, `## What needs to be done`, `## Architecture decisions`, `## Files to modify`, `## Acceptance criteria`, and `## Out of scope`.
 - If the milestone is missing context you need, report `needs_clarification` with the specific gap.
+
+When finished, call `report_stage_outcome` with outcome `drafted` and `artifacts_produced = ["spec.toml", "spec.md"]`.
 """

--- a/crates/surge-core/bundled/profiles/verifier-1.0.toml
+++ b/crates/surge-core/bundled/profiles/verifier-1.0.toml
@@ -45,13 +45,14 @@ policy = "on-request"
 
 [prompt]
 system = """\
-You are the Verifier. Run the project's verification commands and check the spec's
-acceptance criteria.
+You are the Verifier. Run the project's verification commands and check the Spec
+contract acceptance criteria from `{{spec}}` (`spec.toml` entries and/or
+`spec.md` compatibility checkboxes).
 
 Process:
 1. Run, in order, only the commands the project actually uses (read `Makefile` / `justfile` / `taskfile.yml` / `package.json` / `Cargo.toml` first).
 2. For Rust workspaces: `cargo build --workspace`, `cargo test --workspace`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo doc --workspace --no-deps`.
-3. For each acceptance criterion in `{{spec}}`, evaluate it (compile-check / test-pass / metric-under-budget) and note the result.
+3. For each `[[spec.subtasks.acceptance_criteria]]` entry or `## Acceptance Criteria` checkbox in `{{spec}}`, evaluate it (compile-check / test-pass / metric-under-budget) and note the result.
 
 Rules:
 - Do not edit code. Verification is read-only over the implementation.

--- a/crates/surge-core/src/artifact_contract.rs
+++ b/crates/surge-core/src/artifact_contract.rs
@@ -564,8 +564,8 @@ fn validate_spec_toml_acceptance(report: &mut ArtifactValidationReport, content:
     report.push(ArtifactValidationDiagnostic::error(
         report.kind,
         ArtifactDiagnosticCode::MissingAcceptanceCriteria,
-        Some("spec.acceptance_criteria".to_string()),
-        "spec artifact must include machine-readable acceptance criteria",
+        Some("spec.subtasks.acceptance_criteria".to_string()),
+        "every spec subtask must include machine-readable acceptance criteria",
     ));
 }
 
@@ -635,17 +635,15 @@ fn toml_field<'a>(value: &'a toml::Value, path: &str) -> Option<&'a toml::Value>
 }
 
 fn spec_toml_has_acceptance_criteria(value: &toml::Value) -> bool {
-    if toml_array_is_non_empty(value, "acceptance_criteria") {
-        return true;
-    }
     let spec = value.get("spec").unwrap_or(value);
     let Some(subtasks) = spec.get("subtasks").and_then(toml::Value::as_array) else {
         return false;
     };
 
-    subtasks
-        .iter()
-        .any(|subtask| toml_array_is_non_empty(subtask, "acceptance_criteria"))
+    !subtasks.is_empty()
+        && subtasks
+            .iter()
+            .all(|subtask| toml_array_is_non_empty(subtask, "acceptance_criteria"))
 }
 
 fn toml_array_is_non_empty(value: &toml::Value, field: &str) -> bool {
@@ -1051,6 +1049,47 @@ Build a validator.
         );
 
         assert!(report.is_valid(), "{report:#?}");
+    }
+
+    #[test]
+    fn validates_spec_toml_when_every_subtask_has_acceptance_criteria() {
+        let report = validate_artifact(
+            ArtifactKind::Spec,
+            Some(Path::new("spec.toml")),
+            r#"schema_version = 1
+
+[spec]
+subtasks = [
+  { id = "one", acceptance_criteria = ["first check passes"] },
+  { id = "two", acceptance_criteria = ["second check passes"] },
+]
+"#,
+        );
+
+        assert!(report.is_valid(), "{report:#?}");
+    }
+
+    #[test]
+    fn rejects_spec_toml_when_any_subtask_lacks_acceptance_criteria() {
+        let report = validate_artifact(
+            ArtifactKind::Spec,
+            Some(Path::new("spec.toml")),
+            r#"schema_version = 1
+acceptance_criteria = ["global criteria must not mask per-subtask gaps"]
+
+[spec]
+subtasks = [
+  { id = "one", acceptance_criteria = ["first check passes"] },
+  { id = "two" },
+]
+"#,
+        );
+
+        assert!(!report.is_valid());
+        assert!(report.diagnostics.iter().any(|diagnostic| {
+            diagnostic.code == ArtifactDiagnosticCode::MissingAcceptanceCriteria
+                && diagnostic.location.as_deref() == Some("spec.subtasks.acceptance_criteria")
+        }));
     }
 
     #[test]

--- a/crates/surge-core/src/artifact_contract.rs
+++ b/crates/surge-core/src/artifact_contract.rs
@@ -130,7 +130,7 @@ impl ArtifactContractRef {
     pub const fn current(kind: ArtifactKind) -> Self {
         Self {
             kind,
-            schema_version: ARTIFACT_SCHEMA_VERSION,
+            schema_version: schema_version_for_kind(kind),
         }
     }
 }
@@ -169,6 +169,8 @@ pub enum ArtifactDiagnosticCode {
     UnsupportedArtifactKind,
     /// Flow graph parsed as TOML but failed engine-level graph validation.
     GraphValidationFailed,
+    /// Flow graph failed to deserialize into the engine graph model.
+    GraphParseFailed,
 }
 
 impl ArtifactDiagnosticCode {
@@ -186,6 +188,7 @@ impl ArtifactDiagnosticCode {
             Self::MissingAcceptanceCriteria => "missing_acceptance_criteria",
             Self::UnsupportedArtifactKind => "unsupported_artifact_kind",
             Self::GraphValidationFailed => "graph_validation_failed",
+            Self::GraphParseFailed => "graph_parse_failed",
         }
     }
 }
@@ -481,7 +484,7 @@ fn validate_roadmap(report: &mut ArtifactValidationReport, path: Option<&Path>, 
     if is_markdown_artifact(path, content) {
         require_markdown_sections(report, content, &["Milestones", "Dependencies", "Risks"]);
     } else {
-        validate_toml_artifact(report, content, &["milestones"]);
+        let _ = validate_toml_artifact(report, content, &["milestones"]);
     }
 }
 
@@ -494,8 +497,9 @@ fn validate_spec(report: &mut ArtifactValidationReport, path: Option<&Path>, con
         );
         require_acceptance_criteria(report, content);
     } else {
-        validate_toml_artifact(report, content, &["spec"]);
-        validate_spec_toml_acceptance(report, content);
+        if let Some(value) = validate_toml_artifact(report, content, &["spec"]) {
+            validate_spec_toml_acceptance(report, &value);
+        }
     }
 }
 
@@ -546,19 +550,15 @@ fn validate_toml_artifact(
     report: &mut ArtifactValidationReport,
     content: &str,
     required_fields: &[&str],
-) {
-    let Some(value) = parse_toml_value(report, content) else {
-        return;
-    };
+) -> Option<toml::Value> {
+    let value = parse_toml_value(report, content)?;
     validate_schema_version(report, &value, ARTIFACT_SCHEMA_VERSION);
     require_toml_fields(report, &value, required_fields);
+    Some(value)
 }
 
-fn validate_spec_toml_acceptance(report: &mut ArtifactValidationReport, content: &str) {
-    let Some(value) = content.parse::<toml::Value>().ok() else {
-        return;
-    };
-    if spec_toml_has_acceptance_criteria(&value) {
+fn validate_spec_toml_acceptance(report: &mut ArtifactValidationReport, value: &toml::Value) {
+    if spec_toml_has_acceptance_criteria(value) {
         return;
     }
     report.push(ArtifactValidationDiagnostic::error(
@@ -740,9 +740,24 @@ fn strip_trailing_heading_marker(heading: &str) -> &str {
 }
 
 fn is_markdown_artifact(path: Option<&Path>, content: &str) -> bool {
-    path.is_some_and(|path| path.extension().is_some_and(|ext| ext == "md"))
-        || content.trim_start().starts_with('#')
-        || content.trim_start().starts_with("+++")
+    if let Some(extension) = path
+        .and_then(Path::extension)
+        .and_then(|extension| extension.to_str())
+    {
+        return extension.eq_ignore_ascii_case("md");
+    }
+
+    let trimmed = content.trim_start();
+    trimmed.starts_with('#') || trimmed.starts_with("+++")
+}
+
+const fn schema_version_for_kind(kind: ArtifactKind) -> u32 {
+    match contract_for(kind).schema_version_owner {
+        SchemaVersionOwner::Graph => crate::graph::SCHEMA_VERSION,
+        SchemaVersionOwner::ArtifactContract | SchemaVersionOwner::HumanReadable => {
+            ARTIFACT_SCHEMA_VERSION
+        },
+    }
 }
 
 fn normalize_path(path: &Path) -> String {
@@ -918,6 +933,22 @@ mod tests {
     }
 
     #[test]
+    fn artifact_contract_refs_follow_schema_version_owner() {
+        assert_eq!(
+            ArtifactContractRef::current(ArtifactKind::Flow).schema_version,
+            crate::graph::SCHEMA_VERSION
+        );
+        assert_eq!(
+            contract_for(ArtifactKind::Flow).reference().schema_version,
+            crate::graph::SCHEMA_VERSION
+        );
+        assert_eq!(
+            ArtifactContractRef::current(ArtifactKind::Spec).schema_version,
+            ARTIFACT_SCHEMA_VERSION
+        );
+    }
+
+    #[test]
     fn validation_report_counts_errors_and_warnings() {
         let mut report = ArtifactValidationReport::new(ArtifactKind::Description);
         report.push(ArtifactValidationDiagnostic::warning(
@@ -1067,6 +1098,36 @@ subtasks = [
         );
 
         assert!(report.is_valid(), "{report:#?}");
+    }
+
+    #[test]
+    fn toml_paths_with_leading_comments_are_not_markdown() {
+        let roadmap = validate_artifact(
+            ArtifactKind::Roadmap,
+            Some(Path::new("roadmap.toml")),
+            r#"# Roadmap comment
+schema_version = 1
+
+[[milestones]]
+id = "m1"
+title = "Ship contract validation"
+"#,
+        );
+        assert!(roadmap.is_valid(), "{roadmap:#?}");
+
+        let spec = validate_artifact(
+            ArtifactKind::Spec,
+            Some(Path::new("spec.toml")),
+            r#"# Spec comment
+schema_version = 1
+
+[spec]
+subtasks = [
+  { id = "one", acceptance_criteria = ["first check passes"] },
+]
+"#,
+        );
+        assert!(spec.is_valid(), "{spec:#?}");
     }
 
     #[test]

--- a/crates/surge-core/src/artifact_contract.rs
+++ b/crates/surge-core/src/artifact_contract.rs
@@ -1,0 +1,1062 @@
+//! Artifact contract metadata.
+//!
+//! This module is intentionally pure: it defines canonical artifact names,
+//! schema ownership, and validator identifiers without reading files or
+//! invoking runtime services. CLI and orchestrator code compose these contracts
+//! with I/O, logging, and engine-specific validation.
+
+use serde::{Deserialize, Serialize};
+use std::fmt;
+use std::path::Path;
+use std::str::FromStr;
+
+/// Current schema version used by Surge-owned artifact contracts.
+pub const ARTIFACT_SCHEMA_VERSION: u32 = 1;
+
+/// Role artifact families that Surge validates.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum ArtifactKind {
+    /// Bootstrap description artifact.
+    Description,
+    /// Product requirements artifact.
+    Requirements,
+    /// Roadmap Planner artifact.
+    Roadmap,
+    /// Spec Author artifact.
+    Spec,
+    /// Architect decision artifact.
+    Adr,
+    /// Long-form subtask story artifact.
+    Story,
+    /// Implementation plan artifact.
+    Plan,
+    /// Executable `flow.toml` graph artifact.
+    Flow,
+}
+
+impl ArtifactKind {
+    /// Stable kebab-case identifier used in profile metadata and CLI flags.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Description => "description",
+            Self::Requirements => "requirements",
+            Self::Roadmap => "roadmap",
+            Self::Spec => "spec",
+            Self::Adr => "adr",
+            Self::Story => "story",
+            Self::Plan => "plan",
+            Self::Flow => "flow",
+        }
+    }
+
+    /// Return the contract metadata for this kind.
+    #[must_use]
+    pub const fn contract(self) -> ArtifactContract {
+        contract_for(self)
+    }
+}
+
+impl fmt::Display for ArtifactKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Parse an artifact kind from a stable CLI/profile identifier.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[error("unknown artifact kind {input:?}")]
+pub struct ParseArtifactKindError {
+    input: String,
+}
+
+impl FromStr for ArtifactKind {
+    type Err = ParseArtifactKindError;
+
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
+        match input.trim().to_ascii_lowercase().as_str() {
+            "description" | "description-md" => Ok(Self::Description),
+            "requirements" | "requirements-md" => Ok(Self::Requirements),
+            "roadmap" | "roadmap-md" | "roadmap-toml" => Ok(Self::Roadmap),
+            "spec" | "spec-md" | "spec-toml" => Ok(Self::Spec),
+            "adr" | "architecture-decision-record" => Ok(Self::Adr),
+            "story" | "story-file" => Ok(Self::Story),
+            "plan" | "implementation-plan" => Ok(Self::Plan),
+            "flow" | "flow-toml" => Ok(Self::Flow),
+            _ => Err(ParseArtifactKindError {
+                input: input.to_owned(),
+            }),
+        }
+    }
+}
+
+/// Primary serialization format for an artifact contract.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum ArtifactFormat {
+    /// Markdown with required headings and optional structured sections.
+    Markdown,
+    /// Human-authored TOML parsed into typed Rust structures.
+    Toml,
+    /// `flow.toml` graph parsed as [`crate::graph::Graph`].
+    FlowToml,
+}
+
+/// Component that owns the schema-version field for a contract.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SchemaVersionOwner {
+    /// Generic artifact contract version from [`ARTIFACT_SCHEMA_VERSION`].
+    ArtifactContract,
+    /// The graph schema version in [`crate::graph::SCHEMA_VERSION`].
+    Graph,
+    /// No machine-readable schema-version field is required.
+    HumanReadable,
+}
+
+/// Stable reference embedded in profiles and diagnostics.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ArtifactContractRef {
+    /// Artifact family.
+    pub kind: ArtifactKind,
+    /// Expected schema version for this artifact family.
+    pub schema_version: u32,
+}
+
+impl ArtifactContractRef {
+    /// Create a reference for the current version of `kind`.
+    #[must_use]
+    pub const fn current(kind: ArtifactKind) -> Self {
+        Self {
+            kind,
+            schema_version: ARTIFACT_SCHEMA_VERSION,
+        }
+    }
+}
+
+/// Severity for artifact validation diagnostics.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ArtifactDiagnosticSeverity {
+    /// Validation cannot accept the artifact.
+    Error,
+    /// Validation accepts the artifact but found a compatibility issue.
+    Warning,
+}
+
+/// Stable diagnostic code emitted by artifact validators.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ArtifactDiagnosticCode {
+    /// Artifact path/name does not match the selected contract.
+    InvalidArtifactPath,
+    /// Required markdown section is missing.
+    MissingSection,
+    /// Required machine-readable field is missing.
+    MissingField,
+    /// `schema_version` is missing.
+    MissingSchemaVersion,
+    /// `schema_version` is present but unsupported.
+    UnsupportedSchemaVersion,
+    /// TOML content failed to parse.
+    InvalidToml,
+    /// Markdown frontmatter is missing or malformed.
+    InvalidFrontmatter,
+    /// Acceptance criteria are missing.
+    MissingAcceptanceCriteria,
+    /// Artifact kind is not supported by this validator.
+    UnsupportedArtifactKind,
+    /// Flow graph parsed as TOML but failed engine-level graph validation.
+    GraphValidationFailed,
+}
+
+impl ArtifactDiagnosticCode {
+    /// Stable snake-case code for CLI JSON and tests.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::InvalidArtifactPath => "invalid_artifact_path",
+            Self::MissingSection => "missing_section",
+            Self::MissingField => "missing_field",
+            Self::MissingSchemaVersion => "missing_schema_version",
+            Self::UnsupportedSchemaVersion => "unsupported_schema_version",
+            Self::InvalidToml => "invalid_toml",
+            Self::InvalidFrontmatter => "invalid_frontmatter",
+            Self::MissingAcceptanceCriteria => "missing_acceptance_criteria",
+            Self::UnsupportedArtifactKind => "unsupported_artifact_kind",
+            Self::GraphValidationFailed => "graph_validation_failed",
+        }
+    }
+}
+
+impl fmt::Display for ArtifactDiagnosticCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// One validation diagnostic.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ArtifactValidationDiagnostic {
+    /// Stable machine-readable code.
+    pub code: ArtifactDiagnosticCode,
+    /// Severity of the finding.
+    pub severity: ArtifactDiagnosticSeverity,
+    /// Artifact family being validated.
+    pub kind: ArtifactKind,
+    /// Optional path or logical field location.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub location: Option<String>,
+    /// Short user-safe message. Do not include full artifact contents.
+    pub message: String,
+}
+
+impl ArtifactValidationDiagnostic {
+    /// Construct an error diagnostic.
+    #[must_use]
+    pub fn error(
+        kind: ArtifactKind,
+        code: ArtifactDiagnosticCode,
+        location: Option<String>,
+        message: impl Into<String>,
+    ) -> Self {
+        Self {
+            code,
+            severity: ArtifactDiagnosticSeverity::Error,
+            kind,
+            location,
+            message: message.into(),
+        }
+    }
+
+    /// Construct a warning diagnostic.
+    #[must_use]
+    pub fn warning(
+        kind: ArtifactKind,
+        code: ArtifactDiagnosticCode,
+        location: Option<String>,
+        message: impl Into<String>,
+    ) -> Self {
+        Self {
+            code,
+            severity: ArtifactDiagnosticSeverity::Warning,
+            kind,
+            location,
+            message: message.into(),
+        }
+    }
+}
+
+/// Validation report for one artifact.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ArtifactValidationReport {
+    /// Artifact kind selected by the caller.
+    pub kind: ArtifactKind,
+    /// Diagnostics emitted by the validator.
+    #[serde(default)]
+    pub diagnostics: Vec<ArtifactValidationDiagnostic>,
+}
+
+impl ArtifactValidationReport {
+    /// Start an empty report for `kind`.
+    #[must_use]
+    pub const fn new(kind: ArtifactKind) -> Self {
+        Self {
+            kind,
+            diagnostics: Vec::new(),
+        }
+    }
+
+    /// Append a diagnostic.
+    pub fn push(&mut self, diagnostic: ArtifactValidationDiagnostic) {
+        self.diagnostics.push(diagnostic);
+    }
+
+    /// Return true when no error-severity diagnostics are present.
+    #[must_use]
+    pub fn is_valid(&self) -> bool {
+        self.error_count() == 0
+    }
+
+    /// Count error-severity diagnostics.
+    #[must_use]
+    pub fn error_count(&self) -> usize {
+        self.diagnostics
+            .iter()
+            .filter(|diagnostic| diagnostic.severity == ArtifactDiagnosticSeverity::Error)
+            .count()
+    }
+
+    /// Count warning-severity diagnostics.
+    #[must_use]
+    pub fn warning_count(&self) -> usize {
+        self.diagnostics
+            .iter()
+            .filter(|diagnostic| diagnostic.severity == ArtifactDiagnosticSeverity::Warning)
+            .count()
+    }
+
+    /// Convert this report into a result that fails when errors exist.
+    ///
+    /// # Errors
+    /// Returns [`ArtifactValidationError`] with the full report when any
+    /// error-severity diagnostic is present.
+    pub fn into_result(self) -> Result<(), ArtifactValidationError> {
+        if self.is_valid() {
+            Ok(())
+        } else {
+            Err(ArtifactValidationError { report: self })
+        }
+    }
+}
+
+/// Error wrapper for invalid artifacts.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[error(
+    "{} artifact validation error(s) for {}",
+    .report.error_count(),
+    .report.kind
+)]
+pub struct ArtifactValidationError {
+    /// Full validation report.
+    pub report: ArtifactValidationReport,
+}
+
+/// Canonical metadata for one artifact family.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ArtifactContract {
+    /// Artifact family.
+    pub kind: ArtifactKind,
+    /// Canonical path or path pattern relative to the run worktree.
+    pub canonical_path: &'static str,
+    /// Primary representation agents should produce.
+    pub primary_format: ArtifactFormat,
+    /// Optional compatibility artifact when humans also need Markdown.
+    pub markdown_compatibility: Option<&'static str>,
+    /// Schema-version ownership.
+    pub schema_version_owner: SchemaVersionOwner,
+    /// Stable validator id used by CLI flags and diagnostics.
+    pub validator_kind: &'static str,
+    /// Accepted historical or ergonomic aliases for the artifact path/name.
+    pub aliases: &'static [&'static str],
+}
+
+impl ArtifactContract {
+    /// Return a versioned reference to this contract.
+    #[must_use]
+    pub const fn reference(self) -> ArtifactContractRef {
+        ArtifactContractRef::current(self.kind)
+    }
+
+    /// True if `path` matches the canonical path or one of the accepted aliases.
+    #[must_use]
+    pub fn accepts_path(self, path: &Path) -> bool {
+        let normalized = normalize_path(path);
+        if normalized == self.canonical_path {
+            return true;
+        }
+        self.aliases.iter().any(|alias| normalized == *alias)
+            || self.accepts_pattern(normalized.as_str())
+    }
+
+    fn accepts_pattern(self, normalized: &str) -> bool {
+        match self.kind {
+            ArtifactKind::Adr => is_adr_path(normalized),
+            ArtifactKind::Story => is_story_path(normalized),
+            _ => false,
+        }
+    }
+}
+
+/// Return every canonical artifact contract in stable order.
+#[must_use]
+pub const fn all_contracts() -> &'static [ArtifactContract] {
+    &CONTRACTS
+}
+
+/// Return the contract metadata for `kind`.
+#[must_use]
+pub const fn contract_for(kind: ArtifactKind) -> ArtifactContract {
+    match kind {
+        ArtifactKind::Description => DESCRIPTION_CONTRACT,
+        ArtifactKind::Requirements => REQUIREMENTS_CONTRACT,
+        ArtifactKind::Roadmap => ROADMAP_CONTRACT,
+        ArtifactKind::Spec => SPEC_CONTRACT,
+        ArtifactKind::Adr => ADR_CONTRACT,
+        ArtifactKind::Story => STORY_CONTRACT,
+        ArtifactKind::Plan => PLAN_CONTRACT,
+        ArtifactKind::Flow => FLOW_CONTRACT,
+    }
+}
+
+/// Validate an artifact path and contents against the selected contract.
+#[must_use]
+pub fn validate_artifact(
+    kind: ArtifactKind,
+    path: Option<&Path>,
+    content: &str,
+) -> ArtifactValidationReport {
+    let mut report = ArtifactValidationReport::new(kind);
+    if let Some(path) = path {
+        validate_artifact_path_into(&mut report, path);
+    }
+    validate_artifact_text_into(&mut report, path, content);
+    report
+}
+
+/// Validate an artifact path against the selected contract.
+#[must_use]
+pub fn validate_artifact_path(kind: ArtifactKind, path: &Path) -> ArtifactValidationReport {
+    let mut report = ArtifactValidationReport::new(kind);
+    validate_artifact_path_into(&mut report, path);
+    report
+}
+
+/// Validate artifact contents against the selected contract's primary format.
+#[must_use]
+pub fn validate_artifact_text(kind: ArtifactKind, content: &str) -> ArtifactValidationReport {
+    let mut report = ArtifactValidationReport::new(kind);
+    validate_artifact_text_into(&mut report, None, content);
+    report
+}
+
+fn validate_artifact_path_into(report: &mut ArtifactValidationReport, path: &Path) {
+    let contract = contract_for(report.kind);
+    if contract.accepts_path(path) {
+        return;
+    }
+
+    report.push(ArtifactValidationDiagnostic::error(
+        report.kind,
+        ArtifactDiagnosticCode::InvalidArtifactPath,
+        Some(normalize_path(path)),
+        format!(
+            "expected artifact path matching {} for {}",
+            contract.canonical_path, report.kind
+        ),
+    ));
+}
+
+fn validate_artifact_text_into(
+    report: &mut ArtifactValidationReport,
+    path: Option<&Path>,
+    content: &str,
+) {
+    match report.kind {
+        ArtifactKind::Description => validate_description_markdown(report, content),
+        ArtifactKind::Requirements => validate_requirements_markdown(report, content),
+        ArtifactKind::Roadmap => validate_roadmap(report, path, content),
+        ArtifactKind::Spec => validate_spec(report, path, content),
+        ArtifactKind::Adr => validate_adr_markdown(report, content),
+        ArtifactKind::Story => validate_story_markdown(report, content),
+        ArtifactKind::Plan => validate_plan_markdown(report, content),
+        ArtifactKind::Flow => validate_flow_toml(report, content),
+    }
+}
+
+fn validate_description_markdown(report: &mut ArtifactValidationReport, content: &str) {
+    require_markdown_sections(
+        report,
+        content,
+        &["Goal", "Context", "Requirements", "Out of Scope"],
+    );
+}
+
+fn validate_requirements_markdown(report: &mut ArtifactValidationReport, content: &str) {
+    require_markdown_sections(
+        report,
+        content,
+        &[
+            "Overview",
+            "User Stories",
+            "Functional Requirements",
+            "Success Criteria",
+            "Out of Scope",
+        ],
+    );
+}
+
+fn validate_roadmap(report: &mut ArtifactValidationReport, path: Option<&Path>, content: &str) {
+    if is_markdown_artifact(path, content) {
+        require_markdown_sections(report, content, &["Milestones", "Dependencies", "Risks"]);
+    } else {
+        validate_toml_artifact(report, content, &["milestones"]);
+    }
+}
+
+fn validate_spec(report: &mut ArtifactValidationReport, path: Option<&Path>, content: &str) {
+    if is_markdown_artifact(path, content) {
+        require_markdown_sections(
+            report,
+            content,
+            &["Goal", "Subtasks", "Acceptance Criteria"],
+        );
+        require_acceptance_criteria(report, content);
+    } else {
+        validate_toml_artifact(report, content, &["spec"]);
+        validate_spec_toml_acceptance(report, content);
+    }
+}
+
+fn validate_story_markdown(report: &mut ArtifactValidationReport, content: &str) {
+    require_markdown_sections(
+        report,
+        content,
+        &[
+            "Context",
+            "What needs to be done",
+            "Architecture decisions",
+            "Files to modify",
+            "Acceptance criteria",
+            "Out of scope",
+        ],
+    );
+    require_acceptance_criteria(report, content);
+}
+
+fn validate_plan_markdown(report: &mut ArtifactValidationReport, content: &str) {
+    require_markdown_sections(report, content, &["Settings", "Tasks"]);
+}
+
+fn validate_adr_markdown(report: &mut ArtifactValidationReport, content: &str) {
+    validate_adr_frontmatter(report, content);
+    require_markdown_sections(
+        report,
+        content,
+        &[
+            "Status",
+            "Context",
+            "Decision",
+            "Alternatives considered",
+            "Consequences",
+        ],
+    );
+}
+
+fn validate_flow_toml(report: &mut ArtifactValidationReport, content: &str) {
+    let Some(value) = parse_toml_value(report, content) else {
+        return;
+    };
+    validate_schema_version(report, &value, crate::graph::SCHEMA_VERSION);
+    require_toml_fields(report, &value, &["metadata", "start", "nodes", "edges"]);
+}
+
+fn validate_toml_artifact(
+    report: &mut ArtifactValidationReport,
+    content: &str,
+    required_fields: &[&str],
+) {
+    let Some(value) = parse_toml_value(report, content) else {
+        return;
+    };
+    validate_schema_version(report, &value, ARTIFACT_SCHEMA_VERSION);
+    require_toml_fields(report, &value, required_fields);
+}
+
+fn validate_spec_toml_acceptance(report: &mut ArtifactValidationReport, content: &str) {
+    let Some(value) = content.parse::<toml::Value>().ok() else {
+        return;
+    };
+    if spec_toml_has_acceptance_criteria(&value) {
+        return;
+    }
+    report.push(ArtifactValidationDiagnostic::error(
+        report.kind,
+        ArtifactDiagnosticCode::MissingAcceptanceCriteria,
+        Some("spec.acceptance_criteria".to_string()),
+        "spec artifact must include machine-readable acceptance criteria",
+    ));
+}
+
+fn parse_toml_value(report: &mut ArtifactValidationReport, content: &str) -> Option<toml::Value> {
+    match content.parse::<toml::Value>() {
+        Ok(value) => Some(value),
+        Err(error) => {
+            report.push(ArtifactValidationDiagnostic::error(
+                report.kind,
+                ArtifactDiagnosticCode::InvalidToml,
+                None,
+                format!("artifact TOML failed to parse: {error}"),
+            ));
+            None
+        },
+    }
+}
+
+fn validate_schema_version(
+    report: &mut ArtifactValidationReport,
+    value: &toml::Value,
+    expected: u32,
+) {
+    let Some(schema_version) = value.get("schema_version") else {
+        report.push(ArtifactValidationDiagnostic::error(
+            report.kind,
+            ArtifactDiagnosticCode::MissingSchemaVersion,
+            Some("schema_version".to_string()),
+            "artifact is missing schema_version",
+        ));
+        return;
+    };
+
+    if schema_version.as_integer() == Some(i64::from(expected)) {
+        return;
+    }
+
+    report.push(ArtifactValidationDiagnostic::error(
+        report.kind,
+        ArtifactDiagnosticCode::UnsupportedSchemaVersion,
+        Some("schema_version".to_string()),
+        format!("expected schema_version {expected}"),
+    ));
+}
+
+fn require_toml_fields(
+    report: &mut ArtifactValidationReport,
+    value: &toml::Value,
+    required_fields: &[&str],
+) {
+    for field in required_fields {
+        if toml_field(value, field).is_some() {
+            continue;
+        }
+        report.push(ArtifactValidationDiagnostic::error(
+            report.kind,
+            ArtifactDiagnosticCode::MissingField,
+            Some((*field).to_string()),
+            format!("artifact is missing required field {field}"),
+        ));
+    }
+}
+
+fn toml_field<'a>(value: &'a toml::Value, path: &str) -> Option<&'a toml::Value> {
+    path.split('.')
+        .try_fold(value, |current, segment| current.get(segment))
+}
+
+fn spec_toml_has_acceptance_criteria(value: &toml::Value) -> bool {
+    if toml_array_is_non_empty(value, "acceptance_criteria") {
+        return true;
+    }
+    let spec = value.get("spec").unwrap_or(value);
+    let Some(subtasks) = spec.get("subtasks").and_then(toml::Value::as_array) else {
+        return false;
+    };
+
+    subtasks
+        .iter()
+        .any(|subtask| toml_array_is_non_empty(subtask, "acceptance_criteria"))
+}
+
+fn toml_array_is_non_empty(value: &toml::Value, field: &str) -> bool {
+    value
+        .get(field)
+        .and_then(toml::Value::as_array)
+        .is_some_and(|items| !items.is_empty())
+}
+
+fn validate_adr_frontmatter(report: &mut ArtifactValidationReport, content: &str) {
+    let Some(frontmatter) = parse_toml_frontmatter(report, content) else {
+        return;
+    };
+    require_toml_fields(report, &frontmatter, &["status", "deciders", "date"]);
+}
+
+fn parse_toml_frontmatter(
+    report: &mut ArtifactValidationReport,
+    content: &str,
+) -> Option<toml::Value> {
+    let mut lines = content.lines();
+    if lines.next().map(str::trim) != Some("+++") {
+        report.push(ArtifactValidationDiagnostic::error(
+            report.kind,
+            ArtifactDiagnosticCode::InvalidFrontmatter,
+            Some("frontmatter".to_string()),
+            "ADR must start with TOML frontmatter delimited by +++",
+        ));
+        return None;
+    }
+
+    let mut frontmatter = Vec::new();
+    for line in lines {
+        if line.trim() == "+++" {
+            return parse_toml_value(report, &frontmatter.join("\n"));
+        }
+        frontmatter.push(line);
+    }
+
+    report.push(ArtifactValidationDiagnostic::error(
+        report.kind,
+        ArtifactDiagnosticCode::InvalidFrontmatter,
+        Some("frontmatter".to_string()),
+        "ADR TOML frontmatter is missing the closing +++ delimiter",
+    ));
+    None
+}
+
+fn require_markdown_sections(
+    report: &mut ArtifactValidationReport,
+    content: &str,
+    required_sections: &[&str],
+) {
+    for section in required_sections {
+        if has_markdown_heading(content, section) {
+            continue;
+        }
+        report.push(ArtifactValidationDiagnostic::error(
+            report.kind,
+            ArtifactDiagnosticCode::MissingSection,
+            Some(format!("## {section}")),
+            format!("artifact is missing required section ## {section}"),
+        ));
+    }
+}
+
+fn require_acceptance_criteria(report: &mut ArtifactValidationReport, content: &str) {
+    if has_markdown_heading(content, "Acceptance Criteria")
+        || content.to_ascii_lowercase().contains("acceptance criteria")
+    {
+        return;
+    }
+    report.push(ArtifactValidationDiagnostic::error(
+        report.kind,
+        ArtifactDiagnosticCode::MissingAcceptanceCriteria,
+        Some("Acceptance Criteria".to_string()),
+        "artifact must include acceptance criteria",
+    ));
+}
+
+fn has_markdown_heading(content: &str, expected: &str) -> bool {
+    content.lines().any(|line| {
+        let trimmed = line.trim_start();
+        if !trimmed.starts_with('#') {
+            return false;
+        }
+        let heading = trimmed.trim_start_matches('#').trim();
+        strip_trailing_heading_marker(heading).eq_ignore_ascii_case(expected)
+    })
+}
+
+fn strip_trailing_heading_marker(heading: &str) -> &str {
+    heading.trim_end_matches('#').trim_end()
+}
+
+fn is_markdown_artifact(path: Option<&Path>, content: &str) -> bool {
+    path.is_some_and(|path| path.extension().is_some_and(|ext| ext == "md"))
+        || content.trim_start().starts_with('#')
+        || content.trim_start().starts_with("+++")
+}
+
+fn normalize_path(path: &Path) -> String {
+    path.components()
+        .filter_map(|component| match component {
+            std::path::Component::Normal(part) => Some(part.to_string_lossy()),
+            _ => None,
+        })
+        .collect::<Vec<_>>()
+        .join("/")
+}
+
+fn is_adr_path(path: &str) -> bool {
+    let Some(rest) = path.strip_prefix("docs/adr/") else {
+        return false;
+    };
+    if !rest.ends_with(".md") {
+        return false;
+    }
+    let stem = rest.trim_end_matches(".md");
+    let Some((number, slug)) = stem.split_once('-') else {
+        return false;
+    };
+    number.len() == 4 && number.chars().all(|ch| ch.is_ascii_digit()) && !slug.is_empty()
+}
+
+fn is_story_path(path: &str) -> bool {
+    let Some(rest) = path.strip_prefix("stories/story-") else {
+        return false;
+    };
+    let Some(number) = rest.strip_suffix(".md") else {
+        return false;
+    };
+    number.len() == 3 && number.chars().all(|ch| ch.is_ascii_digit())
+}
+
+const DESCRIPTION_ALIASES: &[&str] = &[];
+const REQUIREMENTS_ALIASES: &[&str] = &["requirements.md"];
+const ROADMAP_ALIASES: &[&str] = &["roadmap.md"];
+const SPEC_ALIASES: &[&str] = &["spec.md"];
+const ADR_ALIASES: &[&str] = &["adr.md"];
+const STORY_ALIASES: &[&str] = &[];
+const PLAN_ALIASES: &[&str] = &["plan.md"];
+const FLOW_ALIASES: &[&str] = &[];
+
+const DESCRIPTION_CONTRACT: ArtifactContract = ArtifactContract {
+    kind: ArtifactKind::Description,
+    canonical_path: "description.md",
+    primary_format: ArtifactFormat::Markdown,
+    markdown_compatibility: None,
+    schema_version_owner: SchemaVersionOwner::HumanReadable,
+    validator_kind: "description",
+    aliases: DESCRIPTION_ALIASES,
+};
+
+const REQUIREMENTS_CONTRACT: ArtifactContract = ArtifactContract {
+    kind: ArtifactKind::Requirements,
+    canonical_path: "requirements.md",
+    primary_format: ArtifactFormat::Markdown,
+    markdown_compatibility: None,
+    schema_version_owner: SchemaVersionOwner::HumanReadable,
+    validator_kind: "requirements",
+    aliases: REQUIREMENTS_ALIASES,
+};
+
+const ROADMAP_CONTRACT: ArtifactContract = ArtifactContract {
+    kind: ArtifactKind::Roadmap,
+    canonical_path: "roadmap.toml",
+    primary_format: ArtifactFormat::Toml,
+    markdown_compatibility: Some("roadmap.md"),
+    schema_version_owner: SchemaVersionOwner::ArtifactContract,
+    validator_kind: "roadmap",
+    aliases: ROADMAP_ALIASES,
+};
+
+const SPEC_CONTRACT: ArtifactContract = ArtifactContract {
+    kind: ArtifactKind::Spec,
+    canonical_path: "spec.toml",
+    primary_format: ArtifactFormat::Toml,
+    markdown_compatibility: Some("spec.md"),
+    schema_version_owner: SchemaVersionOwner::ArtifactContract,
+    validator_kind: "spec",
+    aliases: SPEC_ALIASES,
+};
+
+const ADR_CONTRACT: ArtifactContract = ArtifactContract {
+    kind: ArtifactKind::Adr,
+    canonical_path: "docs/adr/<NNNN>-<slug>.md",
+    primary_format: ArtifactFormat::Markdown,
+    markdown_compatibility: None,
+    schema_version_owner: SchemaVersionOwner::HumanReadable,
+    validator_kind: "adr",
+    aliases: ADR_ALIASES,
+};
+
+const STORY_CONTRACT: ArtifactContract = ArtifactContract {
+    kind: ArtifactKind::Story,
+    canonical_path: "stories/story-NNN.md",
+    primary_format: ArtifactFormat::Markdown,
+    markdown_compatibility: None,
+    schema_version_owner: SchemaVersionOwner::HumanReadable,
+    validator_kind: "story",
+    aliases: STORY_ALIASES,
+};
+
+const PLAN_CONTRACT: ArtifactContract = ArtifactContract {
+    kind: ArtifactKind::Plan,
+    canonical_path: "plan.md",
+    primary_format: ArtifactFormat::Markdown,
+    markdown_compatibility: None,
+    schema_version_owner: SchemaVersionOwner::HumanReadable,
+    validator_kind: "plan",
+    aliases: PLAN_ALIASES,
+};
+
+const FLOW_CONTRACT: ArtifactContract = ArtifactContract {
+    kind: ArtifactKind::Flow,
+    canonical_path: "flow.toml",
+    primary_format: ArtifactFormat::FlowToml,
+    markdown_compatibility: None,
+    schema_version_owner: SchemaVersionOwner::Graph,
+    validator_kind: "flow",
+    aliases: FLOW_ALIASES,
+};
+
+const CONTRACTS: [ArtifactContract; 8] = [
+    DESCRIPTION_CONTRACT,
+    REQUIREMENTS_CONTRACT,
+    ROADMAP_CONTRACT,
+    SPEC_CONTRACT,
+    ADR_CONTRACT,
+    STORY_CONTRACT,
+    PLAN_CONTRACT,
+    FLOW_CONTRACT,
+];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn contracts_are_in_stable_order() {
+        let kinds: Vec<_> = all_contracts()
+            .iter()
+            .map(|contract| contract.kind)
+            .collect();
+        assert_eq!(
+            kinds,
+            vec![
+                ArtifactKind::Description,
+                ArtifactKind::Requirements,
+                ArtifactKind::Roadmap,
+                ArtifactKind::Spec,
+                ArtifactKind::Adr,
+                ArtifactKind::Story,
+                ArtifactKind::Plan,
+                ArtifactKind::Flow,
+            ]
+        );
+    }
+
+    #[test]
+    fn artifact_kind_parses_aliases() {
+        assert_eq!(
+            "flow-toml".parse::<ArtifactKind>().unwrap(),
+            ArtifactKind::Flow
+        );
+        assert_eq!(
+            "spec-md".parse::<ArtifactKind>().unwrap(),
+            ArtifactKind::Spec
+        );
+        assert!("unknown".parse::<ArtifactKind>().is_err());
+    }
+
+    #[test]
+    fn validation_report_counts_errors_and_warnings() {
+        let mut report = ArtifactValidationReport::new(ArtifactKind::Description);
+        report.push(ArtifactValidationDiagnostic::warning(
+            ArtifactKind::Description,
+            ArtifactDiagnosticCode::InvalidArtifactPath,
+            Some("description.txt".to_string()),
+            "non-canonical path",
+        ));
+        report.push(ArtifactValidationDiagnostic::error(
+            ArtifactKind::Description,
+            ArtifactDiagnosticCode::MissingSection,
+            Some("## Goal".to_string()),
+            "missing section",
+        ));
+
+        assert!(!report.is_valid());
+        assert_eq!(report.error_count(), 1);
+        assert_eq!(report.warning_count(), 1);
+        assert!(report.into_result().is_err());
+    }
+
+    #[test]
+    fn validates_description_markdown_sections() {
+        let report = validate_artifact_text(
+            ArtifactKind::Description,
+            r#"# Description
+
+## Goal
+Ship the feature.
+
+## Context
+Existing project context.
+
+## Requirements
+- Must be testable.
+
+## Out of Scope
+- Deployment.
+"#,
+        );
+
+        assert!(report.is_valid(), "{report:#?}");
+    }
+
+    #[test]
+    fn reports_missing_markdown_sections() {
+        let report = validate_artifact_text(ArtifactKind::Description, "## Goal\nOnly goal.");
+
+        assert!(!report.is_valid());
+        assert!(
+            report
+                .diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.code == ArtifactDiagnosticCode::MissingSection)
+        );
+    }
+
+    #[test]
+    fn validates_adr_toml_frontmatter() {
+        let report = validate_artifact(
+            ArtifactKind::Adr,
+            Some(Path::new("docs/adr/0001-record-choice.md")),
+            r#"+++
+status = "accepted"
+deciders = ["core team"]
+date = "2026-05-11"
++++
+
+# ADR 0001: Record choice
+
+## Status
+Accepted.
+
+## Context
+We need a decision.
+
+## Decision
+Use the contract module.
+
+## Alternatives considered
+- Keep conventions implicit.
+
+## Consequences
+- Validators can share diagnostics.
+"#,
+        );
+
+        assert!(report.is_valid(), "{report:#?}");
+    }
+
+    #[test]
+    fn validates_flow_schema_version_without_graph_validation() {
+        let report = validate_artifact_text(
+            ArtifactKind::Flow,
+            r#"schema_version = 2
+start = "missing"
+edges = []
+
+[metadata]
+name = "Invalid"
+
+[nodes]
+"#,
+        );
+
+        assert_eq!(report.error_count(), 1);
+        assert_eq!(
+            report.diagnostics[0].code,
+            ArtifactDiagnosticCode::UnsupportedSchemaVersion
+        );
+    }
+
+    #[test]
+    fn validates_spec_markdown_acceptance_criteria() {
+        let report = validate_artifact(
+            ArtifactKind::Spec,
+            Some(Path::new("spec.md")),
+            r#"# Spec
+
+## Goal
+Build a validator.
+
+## Subtasks
+- Add the pure core module.
+
+## Acceptance Criteria
+- [ ] Invalid schema versions produce diagnostics.
+"#,
+        );
+
+        assert!(report.is_valid(), "{report:#?}");
+    }
+
+    #[test]
+    fn path_patterns_accept_expected_locations() {
+        assert!(contract_for(ArtifactKind::Adr).accepts_path(Path::new("docs/adr/0001-choice.md")));
+        assert!(contract_for(ArtifactKind::Story).accepts_path(Path::new("stories/story-001.md")));
+        assert!(!contract_for(ArtifactKind::Story).accepts_path(Path::new("stories/story-1.md")));
+    }
+}

--- a/crates/surge-core/src/bundled_flows.rs
+++ b/crates/surge-core/src/bundled_flows.rs
@@ -9,17 +9,22 @@ use semver::Version;
 use crate::graph::Graph;
 
 const BOOTSTRAP_1_0_TOML: &str = include_str!("../bundled/flows/bootstrap-1.0.toml");
+const FEATURE_1_0_TOML: &str = include_str!("../bundled/flows/feature-1.0.toml");
 const LINEAR_3_1_0_TOML: &str = include_str!("../bundled/flows/linear-3-1.0.toml");
 const LINEAR_WITH_REVIEW_1_0_TOML: &str =
     include_str!("../bundled/flows/linear-with-review-1.0.toml");
 const MULTI_MILESTONE_1_0_TOML: &str = include_str!("../bundled/flows/multi-milestone-1.0.toml");
 const BUG_FIX_1_0_TOML: &str = include_str!("../bundled/flows/bug-fix-1.0.toml");
 const REFACTOR_1_0_TOML: &str = include_str!("../bundled/flows/refactor-1.0.toml");
+const PERFORMANCE_1_0_TOML: &str = include_str!("../bundled/flows/performance-1.0.toml");
+const SECURITY_1_0_TOML: &str = include_str!("../bundled/flows/security-1.0.toml");
+const DOCS_1_0_TOML: &str = include_str!("../bundled/flows/docs-1.0.toml");
+const MIGRATION_1_0_TOML: &str = include_str!("../bundled/flows/migration-1.0.toml");
 const SPIKE_1_0_TOML: &str = include_str!("../bundled/flows/spike-1.0.toml");
 const SINGLE_TASK_1_0_TOML: &str = include_str!("../bundled/flows/single-task-1.0.toml");
 
 /// Total number of bundled flow assets registered in [`BundledFlows`].
-pub const BUNDLED_FLOW_COUNT: usize = 8;
+pub const BUNDLED_FLOW_COUNT: usize = 13;
 
 /// Parsed bundled flow plus registry metadata derived from the asset name.
 #[derive(Debug, Clone, PartialEq)]
@@ -37,6 +42,19 @@ pub struct BundledFlow {
 pub struct BundledFlows;
 
 impl BundledFlows {
+    /// Return the canonical bundled-flow name for a user-supplied lookup name.
+    #[must_use]
+    pub fn canonical_name(name: &str) -> String {
+        match name.trim().to_ascii_lowercase().as_str() {
+            "bugfix" | "fix" => "bug-fix".to_string(),
+            "perf" => "performance".to_string(),
+            "sec" => "security".to_string(),
+            "doc" => "docs".to_string(),
+            "migrate" => "migration".to_string(),
+            canonical => canonical.to_string(),
+        }
+    }
+
     /// Return every bundled flow, freshly parsed.
     ///
     /// # Panics
@@ -46,11 +64,16 @@ impl BundledFlows {
     pub fn all() -> Vec<BundledFlow> {
         vec![
             parse(BOOTSTRAP_1_0_TOML, "bootstrap", "1.0.0"),
+            parse(FEATURE_1_0_TOML, "feature", "1.0.0"),
             parse(LINEAR_3_1_0_TOML, "linear-3", "1.0.0"),
             parse(LINEAR_WITH_REVIEW_1_0_TOML, "linear-with-review", "1.0.0"),
             parse(MULTI_MILESTONE_1_0_TOML, "multi-milestone", "1.0.0"),
             parse(BUG_FIX_1_0_TOML, "bug-fix", "1.0.0"),
             parse(REFACTOR_1_0_TOML, "refactor", "1.0.0"),
+            parse(PERFORMANCE_1_0_TOML, "performance", "1.0.0"),
+            parse(SECURITY_1_0_TOML, "security", "1.0.0"),
+            parse(DOCS_1_0_TOML, "docs", "1.0.0"),
+            parse(MIGRATION_1_0_TOML, "migration", "1.0.0"),
             parse(SPIKE_1_0_TOML, "spike", "1.0.0"),
             parse(SINGLE_TASK_1_0_TOML, "single-task", "1.0.0"),
         ]
@@ -59,6 +82,7 @@ impl BundledFlows {
     /// Find a bundled flow by exact `(name, version)`.
     #[must_use]
     pub fn by_name_version(name: &str, version: &Version) -> Option<BundledFlow> {
+        let name = Self::canonical_name(name);
         Self::all()
             .into_iter()
             .find(|flow| flow.name == name && &flow.version == version)
@@ -67,6 +91,7 @@ impl BundledFlows {
     /// Find the highest-version bundled flow with the given name.
     #[must_use]
     pub fn by_name_latest(name: &str) -> Option<BundledFlow> {
+        let name = Self::canonical_name(name);
         Self::all()
             .into_iter()
             .filter(|flow| flow.name == name)
@@ -129,17 +154,37 @@ mod tests {
     #[test]
     fn archetype_templates_resolve_by_latest_name() {
         for name in [
+            "feature",
             "linear-3",
             "linear-with-review",
             "multi-milestone",
             "bug-fix",
             "refactor",
+            "performance",
+            "security",
+            "docs",
+            "migration",
             "spike",
             "single-task",
         ] {
             let flow = BundledFlows::by_name_latest(name).expect("archetype flow is bundled");
             assert_eq!(flow.name, name);
             assert_eq!(flow.version, Version::new(1, 0, 0));
+        }
+    }
+
+    #[test]
+    fn legacy_template_aliases_resolve_to_canonical_names() {
+        for (alias, canonical) in [
+            ("bugfix", "bug-fix"),
+            ("fix", "bug-fix"),
+            ("perf", "performance"),
+            ("sec", "security"),
+            ("doc", "docs"),
+            ("migrate", "migration"),
+        ] {
+            let flow = BundledFlows::by_name_latest(alias).expect("alias resolves");
+            assert_eq!(flow.name, canonical);
         }
     }
 }

--- a/crates/surge-core/src/lib.rs
+++ b/crates/surge-core/src/lib.rs
@@ -33,6 +33,7 @@ pub mod state;
 pub mod agent_config;
 pub mod approvals;
 pub mod archetype;
+pub mod artifact_contract;
 pub mod branch_config;
 pub mod bundled_flows;
 pub mod content_hash;
@@ -64,12 +65,23 @@ pub use event::{
     ToolLocation, VersionedEvent,
 };
 pub use id::{RunId, SessionId, SpecId, SubtaskId, TaskId};
-pub use roadmap::{Priority, RoadmapItem, RoadmapStatus, Timeline, TimelineBatch};
-pub use spec::{AcceptanceCriteria, Complexity, Spec, Subtask, SubtaskExecution, SubtaskState};
+pub use roadmap::{
+    Priority, RoadmapArtifact, RoadmapDependency, RoadmapItem, RoadmapMilestone, RoadmapRisk,
+    RoadmapStatus, RoadmapTask, Timeline, TimelineBatch,
+};
+pub use spec::{
+    AcceptanceCriteria, Complexity, Spec, SpecArtifact, Subtask, SubtaskExecution, SubtaskState,
+};
 pub use state::TaskState;
 
 // ── New re-exports (Surge data model) ──
 pub use archetype::{ArchetypeMetadata, ArchetypeName};
+pub use artifact_contract::{
+    ARTIFACT_SCHEMA_VERSION, ArtifactContract, ArtifactContractRef, ArtifactDiagnosticCode,
+    ArtifactDiagnosticSeverity, ArtifactFormat, ArtifactKind, ArtifactValidationDiagnostic,
+    ArtifactValidationError, ArtifactValidationReport, SchemaVersionOwner, all_contracts,
+    contract_for, validate_artifact, validate_artifact_path, validate_artifact_text,
+};
 pub use bundled_flows::{BUNDLED_FLOW_COUNT, BundledFlow, BundledFlows};
 pub use content_hash::ContentHash;
 pub use edge::{Edge, EdgeKind, EdgePolicy, ExceededAction, PortRef};
@@ -84,7 +96,9 @@ pub use profile::keyref::{KeyRefParseError, ProfileKeyRef, parse_key_ref};
 pub use profile::registry::{
     MAX_EXTENDS_DEPTH, Provenance, ResolvedProfile, collect_chain, merge_chain, merge_pair,
 };
-pub use profile::{Profile, Role, RoleCategory, RuntimeCfg};
+pub use profile::{
+    Profile, ProfileArtifactDeclaration, ProfileOutcome, Role, RoleCategory, RuntimeCfg,
+};
 pub use run_event::{
     BootstrapDecision, BootstrapStage, ElevationDecision, EventPayload, RunConfig, RunEvent,
     SessionDisposition, VersionedEventPayload,

--- a/crates/surge-core/src/profile.rs
+++ b/crates/surge-core/src/profile.rs
@@ -1,6 +1,7 @@
 //! Profile (role) configuration.
 
 use crate::approvals::ApprovalConfig;
+use crate::artifact_contract::ArtifactContractRef;
 use crate::edge::EdgeKind;
 use crate::hooks::{Hook, HookTrigger};
 use crate::keys::{OutcomeKey, ProfileKey};
@@ -119,6 +120,14 @@ pub struct ProfileOutcome {
     pub edge_kind_hint: EdgeKind,
     #[serde(default)]
     pub required_artifacts: Vec<String>,
+    #[serde(default)]
+    pub produced_artifacts: Vec<ProfileArtifactDeclaration>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ProfileArtifactDeclaration {
+    pub path: String,
+    pub contract: ArtifactContractRef,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
@@ -193,6 +202,7 @@ pub enum InspectorFieldKind {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::artifact_contract::{ARTIFACT_SCHEMA_VERSION, ArtifactKind};
 
     #[test]
     fn minimal_profile_roundtrips() {
@@ -223,6 +233,7 @@ mod tests {
                 description: "Success".into(),
                 edge_kind_hint: EdgeKind::Forward,
                 required_artifacts: vec![],
+                produced_artifacts: vec![],
             }],
             bindings: ProfileBindings::default(),
             hooks: ProfileHooks::default(),
@@ -234,6 +245,55 @@ mod tests {
         let toml_s = toml::to_string(&p).unwrap();
         let parsed: Profile = toml::from_str(&toml_s).unwrap();
         assert_eq!(p, parsed);
+    }
+
+    #[test]
+    fn outcome_artifact_declarations_roundtrip() {
+        let text = r#"
+            schema_version = 1
+
+            [role]
+            id = "description-author"
+            version = "1.0.0"
+            display_name = "Description Author"
+            category = "_bootstrap"
+            description = "Drafts description artifacts"
+            when_to_use = "Bootstrap"
+
+            [runtime]
+            recommended_model = "claude-opus-4-7"
+
+            [[outcomes]]
+            id = "drafted"
+            description = "Drafted"
+            edge_kind_hint = "forward"
+            required_artifacts = ["description.md"]
+
+            [[outcomes.produced_artifacts]]
+            path = "description.md"
+            contract = { kind = "description", schema_version = 1 }
+
+            [prompt]
+            system = "Draft description.md"
+        "#;
+
+        let parsed: Profile = toml::from_str(text).unwrap();
+
+        assert_eq!(parsed.outcomes[0].produced_artifacts.len(), 1);
+        assert_eq!(
+            parsed.outcomes[0].produced_artifacts[0].path,
+            "description.md"
+        );
+        assert_eq!(
+            parsed.outcomes[0].produced_artifacts[0].contract.kind,
+            ArtifactKind::Description
+        );
+        assert_eq!(
+            parsed.outcomes[0].produced_artifacts[0]
+                .contract
+                .schema_version,
+            ARTIFACT_SCHEMA_VERSION
+        );
     }
 
     #[test]

--- a/crates/surge-core/src/profile/bundled.rs
+++ b/crates/surge-core/src/profile/bundled.rs
@@ -140,6 +140,7 @@ fn parse(raw: &str, expected_name: &str) -> Profile {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::artifact_contract::ArtifactKind;
 
     #[test]
     fn all_returns_expected_count() {
@@ -179,6 +180,36 @@ mod tests {
     fn implementer_default_agent_is_claude_code() {
         let p = BundledRegistry::by_name_latest("implementer").expect("bundled");
         assert_eq!(p.runtime.agent_id, "claude-code");
+    }
+
+    #[test]
+    fn bootstrap_profiles_declare_produced_artifact_contracts() {
+        for (profile, kind, path) in [
+            (
+                "description-author",
+                ArtifactKind::Description,
+                "description.md",
+            ),
+            ("roadmap-planner", ArtifactKind::Roadmap, "roadmap.toml"),
+            ("flow-generator", ArtifactKind::Flow, "flow.toml"),
+            ("spec-author", ArtifactKind::Spec, "spec.toml"),
+            ("architect", ArtifactKind::Adr, "docs/adr/<NNNN>-<slug>.md"),
+        ] {
+            let profile = BundledRegistry::by_name_latest(profile).expect("bundled profile");
+            let drafted = profile
+                .outcomes
+                .iter()
+                .find(|outcome| outcome.id.as_ref() == "drafted")
+                .expect("drafted outcome");
+            let declaration = drafted
+                .produced_artifacts
+                .iter()
+                .find(|artifact| artifact.contract.kind == kind)
+                .expect("artifact declaration");
+
+            assert_eq!(declaration.path, path);
+            assert_eq!(declaration.contract.schema_version, 1);
+        }
     }
 
     #[test]

--- a/crates/surge-core/src/profile/registry.rs
+++ b/crates/surge-core/src/profile/registry.rs
@@ -415,6 +415,7 @@ mod tests {
                 description: "Success".into(),
                 edge_kind_hint: EdgeKind::Forward,
                 required_artifacts: vec![],
+                produced_artifacts: vec![],
             }],
             bindings: ProfileBindings::default(),
             hooks: ProfileHooks::default(),
@@ -486,6 +487,7 @@ mod tests {
             description: "Rejected".into(),
             edge_kind_hint: EdgeKind::Backtrack,
             required_artifacts: vec![],
+            produced_artifacts: vec![],
         }];
         let merged = merge_pair(&parent, &child);
         assert_eq!(merged.outcomes.len(), 1);

--- a/crates/surge-core/src/roadmap.rs
+++ b/crates/surge-core/src/roadmap.rs
@@ -2,8 +2,124 @@
 
 use serde::{Deserialize, Serialize};
 
+use crate::artifact_contract::ARTIFACT_SCHEMA_VERSION;
 use crate::id::SpecId;
 use crate::spec::Complexity;
+
+/// Machine-readable `roadmap.toml` artifact.
+///
+/// This is the planning artifact that agents exchange before a concrete
+/// `flow.toml` is generated. The older [`Timeline`] scheduling model remains
+/// available for runtime planning; this wrapper captures the authored roadmap
+/// shape and schema version.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RoadmapArtifact {
+    /// Artifact contract schema version.
+    #[serde(default = "default_artifact_schema_version")]
+    pub schema_version: u32,
+    /// Deliverable-focused milestones in execution order.
+    #[serde(default)]
+    pub milestones: Vec<RoadmapMilestone>,
+    /// Cross-milestone dependencies.
+    #[serde(default)]
+    pub dependencies: Vec<RoadmapDependency>,
+    /// Known delivery risks.
+    #[serde(default)]
+    pub risks: Vec<RoadmapRisk>,
+}
+
+impl RoadmapArtifact {
+    /// Create a roadmap artifact with the current schema version.
+    #[must_use]
+    pub fn new(milestones: Vec<RoadmapMilestone>) -> Self {
+        Self {
+            schema_version: ARTIFACT_SCHEMA_VERSION,
+            milestones,
+            dependencies: Vec::new(),
+            risks: Vec::new(),
+        }
+    }
+}
+
+impl Default for RoadmapArtifact {
+    fn default() -> Self {
+        Self::new(Vec::new())
+    }
+}
+
+/// One deliverable-focused roadmap milestone.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RoadmapMilestone {
+    /// Stable human-authored identifier, for example `m1`.
+    pub id: String,
+    /// Human-readable milestone title.
+    pub title: String,
+    /// Ordered tasks within this milestone.
+    #[serde(default)]
+    pub tasks: Vec<RoadmapTask>,
+}
+
+impl RoadmapMilestone {
+    /// Create an empty milestone.
+    #[must_use]
+    pub fn new(id: impl Into<String>, title: impl Into<String>) -> Self {
+        Self {
+            id: id.into(),
+            title: title.into(),
+            tasks: Vec::new(),
+        }
+    }
+}
+
+/// One task within a roadmap milestone.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RoadmapTask {
+    /// Stable human-authored identifier, for example `m1-t1`.
+    pub id: String,
+    /// Human-readable task title.
+    pub title: String,
+    /// Optional short description.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    /// Acceptance criteria that downstream spec/story authors can refine.
+    #[serde(default)]
+    pub acceptance_criteria: Vec<String>,
+}
+
+impl RoadmapTask {
+    /// Create a task with no optional description or criteria.
+    #[must_use]
+    pub fn new(id: impl Into<String>, title: impl Into<String>) -> Self {
+        Self {
+            id: id.into(),
+            title: title.into(),
+            description: None,
+            acceptance_criteria: Vec::new(),
+        }
+    }
+}
+
+/// Directed dependency between roadmap milestones.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RoadmapDependency {
+    /// Milestone that must finish first.
+    pub from: String,
+    /// Milestone that depends on `from`.
+    pub to: String,
+    /// Human-readable reason for the dependency.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub reason: String,
+}
+
+/// Risk tracked by the roadmap artifact.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RoadmapRisk {
+    /// Risk description.
+    pub description: String,
+    /// Optional mitigation plan.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mitigation: Option<String>,
+}
 
 /// A single item in a project roadmap.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -94,6 +210,10 @@ pub struct TimelineBatch {
     /// Why this batch is ordered this way.
     #[serde(default)]
     pub reason: String,
+}
+
+fn default_artifact_schema_version() -> u32 {
+    ARTIFACT_SCHEMA_VERSION
 }
 
 impl Timeline {
@@ -276,6 +396,38 @@ mod tests {
         assert_eq!(deserialized.title, "Test item");
         assert_eq!(deserialized.status, RoadmapStatus::Pending);
         assert_eq!(deserialized.priority, Priority::Medium);
+    }
+
+    #[test]
+    fn test_roadmap_artifact_toml_roundtrip() {
+        let mut milestone = RoadmapMilestone::new("m1", "Artifact contracts");
+        let mut task = RoadmapTask::new("m1-t1", "Define schema");
+        task.acceptance_criteria
+            .push("schema_version is present".to_string());
+        milestone.tasks.push(task);
+
+        let mut artifact = RoadmapArtifact::new(vec![milestone]);
+        artifact.dependencies.push(RoadmapDependency {
+            from: "m1".to_string(),
+            to: "m2".to_string(),
+            reason: "contracts unblock validators".to_string(),
+        });
+        artifact.risks.push(RoadmapRisk {
+            description: "legacy markdown drift".to_string(),
+            mitigation: Some("keep compatibility docs".to_string()),
+        });
+
+        let toml_str = toml::to_string(&artifact).unwrap();
+        let deserialized: RoadmapArtifact = toml::from_str(&toml_str).unwrap();
+
+        assert_eq!(deserialized.schema_version, ARTIFACT_SCHEMA_VERSION);
+        assert_eq!(deserialized.milestones[0].id, "m1");
+        assert_eq!(deserialized.milestones[0].tasks[0].id, "m1-t1");
+        assert_eq!(deserialized.dependencies[0].to, "m2");
+        assert_eq!(
+            deserialized.risks[0].mitigation.as_deref(),
+            Some("keep compatibility docs")
+        );
     }
 
     #[test]

--- a/crates/surge-core/src/spec.rs
+++ b/crates/surge-core/src/spec.rs
@@ -1,7 +1,51 @@
 //! Spec types for Surge task definitions.
 
+use crate::artifact_contract::ARTIFACT_SCHEMA_VERSION;
 use crate::id::{SpecId, SubtaskId};
 use serde::{Deserialize, Serialize};
+
+/// Machine-readable `spec.toml` artifact wrapper.
+///
+/// The existing [`Spec`] type remains the execution model. This wrapper adds
+/// the artifact contract schema version around it so authored files can evolve
+/// independently from the in-memory spec fields.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SpecArtifact {
+    /// Artifact contract schema version.
+    #[serde(default = "default_artifact_schema_version")]
+    pub schema_version: u32,
+    /// Executable spec payload.
+    pub spec: Spec,
+}
+
+impl SpecArtifact {
+    /// Wrap a spec with the current artifact schema version.
+    #[must_use]
+    pub fn new(spec: Spec) -> Self {
+        Self {
+            schema_version: ARTIFACT_SCHEMA_VERSION,
+            spec,
+        }
+    }
+
+    /// Consume the artifact and return the underlying execution spec.
+    #[must_use]
+    pub fn into_spec(self) -> Spec {
+        self.spec
+    }
+}
+
+impl From<Spec> for SpecArtifact {
+    fn from(spec: Spec) -> Self {
+        Self::new(spec)
+    }
+}
+
+impl From<SpecArtifact> for Spec {
+    fn from(artifact: SpecArtifact) -> Self {
+        artifact.spec
+    }
+}
 
 /// Execution state of a single subtask.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
@@ -113,6 +157,10 @@ pub struct Spec {
     pub subtasks: Vec<Subtask>,
 }
 
+fn default_artifact_schema_version() -> u32 {
+    ARTIFACT_SCHEMA_VERSION
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -184,6 +232,35 @@ mod tests {
         assert_eq!(
             deserialized.subtasks[0].acceptance_criteria[0].description,
             "It compiles"
+        );
+    }
+
+    #[test]
+    fn test_spec_artifact_toml_roundtrip() {
+        let spec = Spec {
+            id: SpecId::new(),
+            title: "Artifact spec".to_string(),
+            description: "A versioned specification".to_string(),
+            complexity: Complexity::Standard,
+            subtasks: vec![Subtask {
+                acceptance_criteria: vec![AcceptanceCriteria {
+                    description: "Artifact validates".to_string(),
+                    met: false,
+                }],
+                ..make_subtask()
+            }],
+        };
+        let artifact = SpecArtifact::new(spec);
+
+        let toml_str = toml::to_string(&artifact).unwrap();
+        let deserialized: SpecArtifact = toml::from_str(&toml_str).unwrap();
+        let roundtrip_spec = deserialized.into_spec();
+
+        assert!(toml_str.contains("schema_version = 1"));
+        assert_eq!(roundtrip_spec.title, "Artifact spec");
+        assert_eq!(
+            roundtrip_spec.subtasks[0].acceptance_criteria[0].description,
+            "Artifact validates"
         );
     }
 

--- a/crates/surge-core/tests/profile_registry_proptest.rs
+++ b/crates/surge-core/tests/profile_registry_proptest.rs
@@ -45,6 +45,7 @@ fn make_profile(name: &str) -> Profile {
             description: "Success".into(),
             edge_kind_hint: EdgeKind::Forward,
             required_artifacts: vec![],
+            produced_artifacts: vec![],
         }],
         bindings: ProfileBindings::default(),
         hooks: ProfileHooks::default(),

--- a/crates/surge-core/tests/snapshots/profile_registry_proptest__merged_three_step_with_dedup.snap
+++ b/crates/surge-core/tests/snapshots/profile_registry_proptest__merged_three_step_with_dedup.snap
@@ -45,6 +45,7 @@ id = "done"
 description = "Success"
 edge_kind_hint = "forward"
 required_artifacts = []
+produced_artifacts = []
 
 [bindings]
 expected = []

--- a/crates/surge-core/tests/snapshots/profile_registry_proptest__merged_two_step_chain.snap
+++ b/crates/surge-core/tests/snapshots/profile_registry_proptest__merged_two_step_chain.snap
@@ -45,6 +45,7 @@ id = "done"
 description = "Success"
 edge_kind_hint = "forward"
 required_artifacts = []
+produced_artifacts = []
 
 [[bindings.expected]]
 name = "spec"

--- a/crates/surge-orchestrator/src/archetype_registry.rs
+++ b/crates/surge-orchestrator/src/archetype_registry.rs
@@ -84,12 +84,17 @@ impl ArchetypeRegistry {
     /// template exists.
     pub fn resolve(&self, name: &str) -> Result<ResolvedArchetype, SurgeError> {
         let canonical_name = BundledFlows::canonical_name(name);
-        if let Some(template) = self.disk.iter().find(|template| {
-            template.graph.metadata.name == name
-                || template.file_stem == name
-                || template.graph.metadata.name == canonical_name
-                || template.file_stem == canonical_name
-        }) {
+        let template = self
+            .disk
+            .iter()
+            .find(|template| template.graph.metadata.name == name || template.file_stem == name)
+            .or_else(|| {
+                self.disk.iter().find(|template| {
+                    template.graph.metadata.name == canonical_name
+                        || template.file_stem == canonical_name
+                })
+            });
+        if let Some(template) = template {
             tracing::debug!(
                 target: "archetype::registry",
                 requested_name = name,
@@ -226,6 +231,41 @@ mod tests {
 
         assert_eq!(resolved.graph.metadata.name, "custom-linear");
         assert!(matches!(resolved.provenance, ArchetypeProvenance::User(_)));
+    }
+
+    #[test]
+    fn disk_exact_name_beats_alias_fallback() {
+        let tmp = tempfile::tempdir().unwrap();
+
+        let mut alias_target = BundledFlows::by_name_latest("bug-fix").unwrap().graph;
+        alias_target.metadata.name = "bug-fix".into();
+        std::fs::write(
+            tmp.path().join("bug-fix.toml"),
+            toml::to_string(&alias_target).unwrap(),
+        )
+        .unwrap();
+
+        let mut exact = BundledFlows::by_name_latest("bug-fix").unwrap().graph;
+        exact.metadata.name = "bugfix".into();
+        std::fs::write(
+            tmp.path().join("bugfix.toml"),
+            toml::to_string(&exact).unwrap(),
+        )
+        .unwrap();
+
+        let registry = ArchetypeRegistry::from_dir(tmp.path()).unwrap();
+        let resolved = registry.resolve("bugfix").unwrap();
+
+        assert_eq!(resolved.graph.metadata.name, "bugfix");
+        match resolved.provenance {
+            ArchetypeProvenance::User(path) => {
+                assert_eq!(
+                    path.file_name().and_then(|name| name.to_str()),
+                    Some("bugfix.toml")
+                );
+            },
+            ArchetypeProvenance::Bundled => panic!("expected user template"),
+        }
     }
 
     #[test]

--- a/crates/surge-orchestrator/src/archetype_registry.rs
+++ b/crates/surge-orchestrator/src/archetype_registry.rs
@@ -83,32 +83,39 @@ impl ArchetypeRegistry {
     /// Returns [`SurgeError::NotFound`] when no matching disk or bundled
     /// template exists.
     pub fn resolve(&self, name: &str) -> Result<ResolvedArchetype, SurgeError> {
-        if let Some(template) = self
-            .disk
-            .iter()
-            .find(|template| template.graph.metadata.name == name || template.file_stem == name)
-        {
+        let canonical_name = BundledFlows::canonical_name(name);
+        if let Some(template) = self.disk.iter().find(|template| {
+            template.graph.metadata.name == name
+                || template.file_stem == name
+                || template.graph.metadata.name == canonical_name
+                || template.file_stem == canonical_name
+        }) {
             tracing::debug!(
                 target: "archetype::registry",
-                name,
+                requested_name = name,
+                canonical_name = %canonical_name,
+                provenance = "user",
                 path = %template.path.display(),
                 "resolved disk archetype template"
             );
             return Ok(ResolvedArchetype {
-                name: name.to_owned(),
+                name: canonical_name.clone(),
                 graph: template.graph.clone(),
                 provenance: ArchetypeProvenance::User(template.path.clone()),
             });
         }
 
-        if let Some(BundledFlow { graph, .. }) = BundledFlows::by_name_latest(name) {
+        if let Some(BundledFlow { graph, version, .. }) = BundledFlows::by_name_latest(name) {
             tracing::debug!(
                 target: "archetype::registry",
-                name,
+                requested_name = name,
+                canonical_name = %graph.metadata.name,
+                version = %version,
+                provenance = "bundled",
                 "resolved bundled archetype template"
             );
             return Ok(ResolvedArchetype {
-                name: name.to_owned(),
+                name: graph.metadata.name.clone(),
                 graph,
                 provenance: ArchetypeProvenance::Bundled,
             });
@@ -187,11 +194,16 @@ mod tests {
     fn bundled_archetype_templates_validate() {
         let registry = ArchetypeRegistry::from_dir(Path::new("definitely-missing")).unwrap();
         for name in [
+            "feature",
             "linear-3",
             "linear-with-review",
             "multi-milestone",
             "bug-fix",
             "refactor",
+            "performance",
+            "security",
+            "docs",
+            "migration",
             "spike",
             "single-task",
         ] {
@@ -214,5 +226,23 @@ mod tests {
 
         assert_eq!(resolved.graph.metadata.name, "custom-linear");
         assert!(matches!(resolved.provenance, ArchetypeProvenance::User(_)));
+    }
+
+    #[test]
+    fn legacy_template_aliases_resolve_to_bundled_flows() {
+        let registry = ArchetypeRegistry::from_dir(Path::new("definitely-missing")).unwrap();
+        for (alias, canonical) in [
+            ("bugfix", "bug-fix"),
+            ("fix", "bug-fix"),
+            ("perf", "performance"),
+            ("sec", "security"),
+            ("doc", "docs"),
+            ("migrate", "migration"),
+        ] {
+            let resolved = registry.resolve(alias).unwrap();
+            assert_eq!(resolved.name, canonical);
+            assert_eq!(resolved.graph.metadata.name, canonical);
+            assert_eq!(resolved.provenance, ArchetypeProvenance::Bundled);
+        }
     }
 }

--- a/crates/surge-orchestrator/src/engine/hooks/mod.rs
+++ b/crates/surge-orchestrator/src/engine/hooks/mod.rs
@@ -11,6 +11,7 @@
 //! Process spawning is hidden behind [`HookCommandSpawner`] so tests can
 //! substitute an in-memory recorder. Production wiring uses
 //! [`ProcessSpawner`], which spawns `tokio::process::Command` with the
+//! run worktree as cwd, portable `SURGE_*` environment variables, and the
 //! per-hook `timeout_seconds`.
 //!
 //! ## Outcome semantics
@@ -63,6 +64,8 @@ pub struct HookContext<'a> {
     pub last_error: Option<&'a str>,
     /// File path used by `MatcherSpec::file_glob`.
     pub file_path: Option<&'a Path>,
+    /// Worktree root used as the hook process working directory.
+    pub worktree_path: Option<&'a Path>,
 }
 
 impl<'a> HookContext<'a> {
@@ -79,6 +82,7 @@ impl<'a> HookContext<'a> {
             outcome: None,
             last_error: None,
             file_path: None,
+            worktree_path: None,
         }
     }
 
@@ -115,6 +119,13 @@ impl<'a> HookContext<'a> {
     #[must_use]
     pub fn with_file_path(mut self, path: &'a Path) -> Self {
         self.file_path = Some(path);
+        self
+    }
+
+    /// Attach the run worktree root used as the hook process working directory.
+    #[must_use]
+    pub fn with_worktree_path(mut self, path: &'a Path) -> Self {
+        self.worktree_path = Some(path);
         self
     }
 
@@ -218,7 +229,7 @@ pub trait HookCommandSpawner: Send + Sync {
     /// Run the hook's command and return the captured outcome. Implementations
     /// must surface timeouts as `exit_status: 124, timed_out: true` rather than
     /// returning an error so the executor can apply `HookFailureMode` mapping.
-    async fn spawn(&self, hook: &Hook) -> HookCommandResult;
+    async fn spawn(&self, hook: &Hook, ctx: &HookContext<'_>) -> HookCommandResult;
 }
 
 /// Production [`HookCommandSpawner`] backed by `tokio::process::Command`.
@@ -227,16 +238,29 @@ pub struct ProcessSpawner;
 
 #[async_trait]
 impl HookCommandSpawner for ProcessSpawner {
-    async fn spawn(&self, hook: &Hook) -> HookCommandResult {
+    async fn spawn(&self, hook: &Hook, ctx: &HookContext<'_>) -> HookCommandResult {
         let timeout = hook
             .timeout_seconds
             .map(|s| Duration::from_secs(u64::from(s)));
-        match spawn_via_shell(&hook.command, timeout).await {
+        let surge_bin = resolve_surge_bin();
+        let command = render_portable_hook_command(&hook.command, surge_bin.as_deref());
+        let working_dir = resolve_hook_worktree(hook, ctx);
+        let env = hook_environment(ctx, working_dir.as_deref(), surge_bin.as_deref());
+        tracing::debug!(
+            target: "engine::hooks",
+            hook_id = %hook.id,
+            node = %ctx.node,
+            cwd = working_dir.as_ref().map(|path| path.display().to_string()).as_deref(),
+            env_keys = "SURGE_WORKTREE,SURGE_NODE,SURGE_OUTCOME,SURGE_SESSION,SURGE_BIN",
+            "hook process context prepared"
+        );
+        match spawn_via_shell(&command, timeout, working_dir.as_deref(), &env).await {
             Ok(res) => res,
             Err(err) => {
                 tracing::error!(
                     target: "engine::hooks",
                     hook_id = %hook.id,
+                    node = %ctx.node,
                     err = %err,
                     "hook command spawn failed"
                 );
@@ -254,6 +278,8 @@ impl HookCommandSpawner for ProcessSpawner {
 async fn spawn_via_shell(
     command: &str,
     timeout: Option<Duration>,
+    working_dir: Option<&Path>,
+    env: &[(&'static str, String)],
 ) -> Result<HookCommandResult, std::io::Error> {
     use tokio::process::Command;
 
@@ -281,6 +307,13 @@ async fn spawn_via_shell(
         // (Unix) / TerminateProcess (Windows) so the timeout path
         // genuinely stops the hook.
         .kill_on_drop(true);
+
+    if let Some(working_dir) = working_dir {
+        cmd.current_dir(working_dir);
+    }
+    for (key, value) in env {
+        cmd.env(key, value);
+    }
 
     let child = cmd.spawn()?;
 
@@ -322,6 +355,98 @@ async fn spawn_via_shell(
         stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
         timed_out: false,
     })
+}
+
+fn resolve_hook_worktree(hook: &Hook, ctx: &HookContext<'_>) -> Option<std::path::PathBuf> {
+    let Some(worktree_path) = ctx.worktree_path else {
+        tracing::error!(
+            target: "engine::hooks",
+            hook_id = %hook.id,
+            node = %ctx.node,
+            "hook worktree path missing; running hook in inherited cwd"
+        );
+        return None;
+    };
+
+    match std::fs::canonicalize(worktree_path) {
+        Ok(path) => Some(path),
+        Err(err) => {
+            tracing::error!(
+                target: "engine::hooks",
+                hook_id = %hook.id,
+                node = %ctx.node,
+                worktree = %worktree_path.display(),
+                err = %err,
+                "failed to canonicalize hook worktree; using original path"
+            );
+            Some(worktree_path.to_path_buf())
+        },
+    }
+}
+
+fn hook_environment(
+    ctx: &HookContext<'_>,
+    worktree_path: Option<&Path>,
+    surge_bin: Option<&Path>,
+) -> Vec<(&'static str, String)> {
+    let mut env = vec![("SURGE_NODE", ctx.node.to_string())];
+    if let Some(worktree_path) = worktree_path {
+        env.push(("SURGE_WORKTREE", worktree_path.display().to_string()));
+    }
+    if let Some(outcome) = ctx.outcome {
+        env.push(("SURGE_OUTCOME", outcome.to_string()));
+    }
+    if let Some(session) = ctx.session {
+        env.push(("SURGE_SESSION", session.to_string()));
+    }
+    if let Some(surge_bin) = surge_bin {
+        env.push(("SURGE_BIN", surge_bin.display().to_string()));
+    }
+    env
+}
+
+fn resolve_surge_bin() -> Option<std::path::PathBuf> {
+    if let Some(path) = std::env::var_os("SURGE_BIN").map(std::path::PathBuf::from) {
+        return Some(path);
+    }
+
+    let current = std::env::current_exe().ok()?;
+    if current
+        .file_stem()
+        .and_then(|stem| stem.to_str())
+        .is_some_and(|stem| stem.eq_ignore_ascii_case("surge"))
+    {
+        return Some(current);
+    }
+
+    let sibling = current.with_file_name(surge_executable_name());
+    if sibling.exists() {
+        return Some(sibling);
+    }
+
+    Some(current)
+}
+
+fn surge_executable_name() -> &'static str {
+    if cfg!(target_os = "windows") {
+        "surge.exe"
+    } else {
+        "surge"
+    }
+}
+
+fn render_portable_hook_command(command: &str, surge_bin: Option<&Path>) -> String {
+    if !command.contains("{surge}") {
+        return command.to_owned();
+    }
+    let Some(surge_bin) = surge_bin else {
+        return command.to_owned();
+    };
+    command.replace("{surge}", &quote_shell_path(surge_bin))
+}
+
+fn quote_shell_path(path: &Path) -> String {
+    format!("\"{}\"", path.display().to_string().replace('"', "\\\""))
 }
 
 /// Hook execution facade. The default spawner runs a real shell; tests use
@@ -381,7 +506,7 @@ impl<S: HookCommandSpawner> HookExecutor<S> {
                 node = %ctx.node,
                 "hook.start"
             );
-            let res = self.spawner.spawn(hook).await;
+            let res = self.spawner.spawn(hook, ctx).await;
             tracing::debug!(
                 target: "engine::hooks",
                 hook_id = %hook.id,
@@ -518,6 +643,7 @@ mod tests {
     #[derive(Default)]
     struct RecordingSpawner {
         calls: Mutex<Vec<String>>,
+        worktrees: Mutex<Vec<Option<String>>>,
         scripted: Mutex<Vec<HookCommandResult>>,
     }
 
@@ -525,6 +651,7 @@ mod tests {
         fn with(results: Vec<HookCommandResult>) -> Arc<Self> {
             Arc::new(Self {
                 calls: Mutex::new(Vec::new()),
+                worktrees: Mutex::new(Vec::new()),
                 scripted: Mutex::new(results),
             })
         }
@@ -532,12 +659,20 @@ mod tests {
         fn calls(&self) -> Vec<String> {
             self.calls.lock().unwrap().clone()
         }
+
+        fn worktrees(&self) -> Vec<Option<String>> {
+            self.worktrees.lock().unwrap().clone()
+        }
     }
 
     #[async_trait]
     impl HookCommandSpawner for Arc<RecordingSpawner> {
-        async fn spawn(&self, hook: &Hook) -> HookCommandResult {
+        async fn spawn(&self, hook: &Hook, ctx: &HookContext<'_>) -> HookCommandResult {
             self.calls.lock().unwrap().push(hook.id.clone());
+            self.worktrees
+                .lock()
+                .unwrap()
+                .push(ctx.worktree_path.map(|path| path.display().to_string()));
             self.scripted.lock().unwrap().remove(0)
         }
     }
@@ -690,6 +825,57 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn hook_context_carries_worktree_to_spawner() {
+        let spawner = RecordingSpawner::with(vec![ok_result()]);
+        let exec = HookExecutor::with_spawner(spawner.clone());
+        let hooks = vec![hook(
+            "worktree-aware",
+            HookTrigger::PreToolUse,
+            HookFailureMode::Reject,
+        )];
+        let node = NodeKey::try_from("agent_1").unwrap();
+        let worktree = Path::new("workspace-root");
+        let ctx = HookContext::for_node(&node).with_worktree_path(worktree);
+
+        let outcome = exec.run_hooks(&hooks, HookTrigger::PreToolUse, &ctx).await;
+
+        assert!(outcome.is_proceed());
+        assert_eq!(
+            spawner.worktrees(),
+            vec![Some("workspace-root".to_string())]
+        );
+    }
+
+    #[test]
+    fn surge_placeholder_renders_to_current_binary_path() {
+        let rendered = render_portable_hook_command(
+            "{surge} artifact validate --kind flow flow.toml",
+            resolve_surge_bin().as_deref(),
+        );
+
+        assert!(!rendered.contains("{surge}"));
+        assert!(rendered.contains("artifact validate --kind flow flow.toml"));
+    }
+
+    #[test]
+    fn hook_environment_contains_portable_context() {
+        let node = NodeKey::try_from("agent_1").unwrap();
+        let outcome = OutcomeKey::try_from("drafted").unwrap();
+        let worktree = Path::new("workspace-root");
+        let surge_bin = Path::new("surge-bin");
+        let ctx = HookContext::for_node(&node)
+            .with_worktree_path(worktree)
+            .with_outcome(&outcome);
+
+        let env = hook_environment(&ctx, Some(worktree), Some(surge_bin));
+
+        assert!(env.contains(&("SURGE_NODE", "agent_1".to_string())));
+        assert!(env.contains(&("SURGE_WORKTREE", "workspace-root".to_string())));
+        assert!(env.contains(&("SURGE_OUTCOME", "drafted".to_string())));
+        assert!(env.contains(&("SURGE_BIN", "surge-bin".to_string())));
+    }
+
+    #[tokio::test]
     async fn trigger_mismatch_skips_hook() {
         let spawner = RecordingSpawner::with(vec![]);
         let exec = HookExecutor::with_spawner(spawner.clone());
@@ -769,7 +955,8 @@ mod tests {
         };
 
         let node = NodeKey::try_from("agent_1").unwrap();
-        let ctx = HookContext::for_node(&node);
+        let cwd = std::env::current_dir().unwrap();
+        let ctx = HookContext::for_node(&node).with_worktree_path(&cwd);
 
         let outcome = exec.run_hooks(&[h], HookTrigger::PostToolUse, &ctx).await;
         assert!(outcome.is_proceed(), "got {outcome:?}");

--- a/crates/surge-orchestrator/src/engine/run_task.rs
+++ b/crates/surge-orchestrator/src/engine/run_task.rs
@@ -5,7 +5,7 @@ use crate::engine::config::EngineRunConfig;
 use crate::engine::handle::{EngineRunEvent, RunOutcome};
 use crate::engine::hooks::{HookContext, HookExecutor, HookOutcome};
 use crate::engine::stage::StageError;
-use crate::engine::stage::agent::{AgentStageParams, execute_agent_stage};
+use crate::engine::stage::agent::{AgentStageParams, effective_agent_hooks, execute_agent_stage};
 use crate::engine::stage::branch::{BranchStageParams, execute_branch_stage};
 use crate::engine::stage::human_gate::{HumanGateStageParams, execute_human_gate_stage};
 use crate::engine::stage::notify::{NotifyStageParams, execute_notify_stage};
@@ -470,8 +470,15 @@ pub(crate) async fn execute(params: RunTaskParams) -> RunOutcome {
 
                 // on_error hooks may suppress the failure into an outcome the
                 // node already declares.
-                let on_error_resolution =
-                    run_on_error_hooks(&hook_executor, &node, &cursor.node, &raw_reason).await;
+                let on_error_resolution = run_on_error_hooks(
+                    &hook_executor,
+                    &node,
+                    &cursor.node,
+                    &raw_reason,
+                    &params.worktree_path,
+                    params.profile_registry.as_deref(),
+                )
+                .await;
                 // Persist a HookExecuted event for every hook invoked on
                 // the on_error chain so the audit trail matches the
                 // pre/post_tool_use and on_outcome paths.
@@ -708,6 +715,8 @@ pub(crate) async fn run_on_error_hooks(
     node: &surge_core::node::Node,
     cursor_node: &surge_core::keys::NodeKey,
     raw_reason: &str,
+    worktree_path: &std::path::Path,
+    profile_registry: Option<&crate::profile_loader::ProfileRegistry>,
 ) -> OnErrorResolution {
     let NodeConfig::Agent(agent_cfg) = &node.config else {
         return OnErrorResolution {
@@ -715,16 +724,20 @@ pub(crate) async fn run_on_error_hooks(
             records: Vec::new(),
         };
     };
-    if agent_cfg.hooks.is_empty() {
+    let resolved_profile = resolve_profile_for_hooks(agent_cfg, profile_registry);
+    let effective_hooks = effective_agent_hooks(agent_cfg, resolved_profile.as_ref());
+    if effective_hooks.is_empty() {
         return OnErrorResolution {
             outcome: None,
             records: Vec::new(),
         };
     }
 
-    let ctx = HookContext::for_node(cursor_node).with_error(raw_reason);
+    let ctx = HookContext::for_node(cursor_node)
+        .with_worktree_path(worktree_path)
+        .with_error(raw_reason);
     let hook_outcome = executor
-        .run_hooks(&agent_cfg.hooks, HookTrigger::OnError, &ctx)
+        .run_hooks(&effective_hooks, HookTrigger::OnError, &ctx)
         .await;
     let records = hook_outcome.executed().to_vec();
     let outcome = match hook_outcome {
@@ -746,6 +759,39 @@ pub(crate) async fn run_on_error_hooks(
         HookOutcome::Reject { .. } | HookOutcome::Proceed { .. } => None,
     };
     OnErrorResolution { outcome, records }
+}
+
+fn resolve_profile_for_hooks(
+    agent_cfg: &surge_core::agent_config::AgentConfig,
+    profile_registry: Option<&crate::profile_loader::ProfileRegistry>,
+) -> Option<surge_core::profile::registry::ResolvedProfile> {
+    let registry = profile_registry?;
+    let profile_str = agent_cfg.profile.as_ref();
+    let key_ref = match surge_core::profile::keyref::parse_key_ref(profile_str) {
+        Ok(key_ref) => key_ref,
+        Err(error) => {
+            tracing::warn!(
+                target: "engine::stage::error",
+                profile = profile_str,
+                err = %error,
+                "invalid profile reference while resolving on_error hooks; using node hooks only"
+            );
+            return None;
+        },
+    };
+
+    match registry.resolve(&key_ref) {
+        Ok(profile) => Some(profile),
+        Err(error) => {
+            tracing::warn!(
+                target: "engine::stage::error",
+                profile = profile_str,
+                err = %error,
+                "profile resolution failed while resolving on_error hooks; using node hooks only"
+            );
+            None
+        },
+    }
 }
 
 async fn load_existing_memory(
@@ -872,7 +918,15 @@ mod tests {
             vec!["done", "retry_later"],
         );
         let cursor = node.id.clone();
-        let resolution = run_on_error_hooks(&executor, &node, &cursor, "boom").await;
+        let resolution = run_on_error_hooks(
+            &executor,
+            &node,
+            &cursor,
+            "boom",
+            std::path::Path::new("."),
+            None,
+        )
+        .await;
         // Audit trail invariant: on every hook invocation the resolution
         // must carry a corresponding HookExecutionRecord. The shell may
         // mangle the JSON on some Windows configurations, but the hook
@@ -898,7 +952,15 @@ mod tests {
             vec!["done"],
         );
         let cursor = node.id.clone();
-        let resolution = run_on_error_hooks(&executor, &node, &cursor, "boom").await;
+        let resolution = run_on_error_hooks(
+            &executor,
+            &node,
+            &cursor,
+            "boom",
+            std::path::Path::new("."),
+            None,
+        )
+        .await;
         assert!(
             resolution.outcome.is_none(),
             "undeclared outcome must not suppress"
@@ -916,7 +978,15 @@ mod tests {
         let executor = HookExecutor::new();
         let node = agent_node(vec![], vec!["done"]);
         let cursor = node.id.clone();
-        let resolution = run_on_error_hooks(&executor, &node, &cursor, "boom").await;
+        let resolution = run_on_error_hooks(
+            &executor,
+            &node,
+            &cursor,
+            "boom",
+            std::path::Path::new("."),
+            None,
+        )
+        .await;
         assert!(resolution.outcome.is_none());
         assert!(
             resolution.records.is_empty(),
@@ -938,7 +1008,15 @@ mod tests {
         };
         let executor = HookExecutor::new();
         let cursor = node.id.clone();
-        let resolution = run_on_error_hooks(&executor, &node, &cursor, "boom").await;
+        let resolution = run_on_error_hooks(
+            &executor,
+            &node,
+            &cursor,
+            "boom",
+            std::path::Path::new("."),
+            None,
+        )
+        .await;
         assert!(resolution.outcome.is_none());
         assert!(
             resolution.records.is_empty(),

--- a/crates/surge-orchestrator/src/engine/stage/agent.rs
+++ b/crates/surge-orchestrator/src/engine/stage/agent.rs
@@ -958,10 +958,7 @@ async fn validate_profile_artifact_contracts(
         if matching_paths.is_empty() {
             return Ok(Some(artifact_contract_rejection(
                 declaration.contract.kind,
-                format!(
-                    "outcome '{outcome}' must produce artifact '{}'",
-                    declaration.path
-                ),
+                missing_declared_artifact_reason(outcome, declaration),
             )));
         }
 
@@ -1011,19 +1008,66 @@ async fn read_produced_artifact(
     relative_path: &Path,
 ) -> Result<Option<ProducedArtifactInput>, StageError> {
     let absolute = worktree_path.join(relative_path);
-    let Ok(canonical_path) = tokio::fs::canonicalize(&absolute).await else {
-        return Ok(None);
+    let canonical_path = match tokio::fs::canonicalize(&absolute).await {
+        Ok(path) => path,
+        Err(error) => {
+            tracing::warn!(
+                target: "engine::stage::agent",
+                relative_path = %normalize_artifact_path(relative_path),
+                absolute_path = %absolute.display(),
+                err = %error,
+                "reported artifact could not be canonicalized"
+            );
+            return Ok(None);
+        },
     };
     if !canonical_path.starts_with(canonical_worktree) {
+        tracing::warn!(
+            target: "engine::stage::agent",
+            relative_path = %normalize_artifact_path(relative_path),
+            canonical_path = %canonical_path.display(),
+            canonical_worktree = %canonical_worktree.display(),
+            "reported artifact canonical path escaped the worktree"
+        );
         return Ok(None);
     }
-    let Ok(bytes) = tokio::fs::read(&canonical_path).await else {
-        return Ok(None);
+    let bytes = match tokio::fs::read(&canonical_path).await {
+        Ok(bytes) => bytes,
+        Err(error) => {
+            tracing::warn!(
+                target: "engine::stage::agent",
+                relative_path = %normalize_artifact_path(relative_path),
+                canonical_path = %canonical_path.display(),
+                err = %error,
+                "reported artifact could not be read"
+            );
+            return Ok(None);
+        },
     };
     Ok(Some(ProducedArtifactInput {
         relative_path: relative_path.to_path_buf(),
         bytes,
     }))
+}
+
+fn missing_declared_artifact_reason(
+    outcome: &OutcomeKey,
+    declaration: &ProfileArtifactDeclaration,
+) -> String {
+    let kind = declaration.contract.kind;
+    match kind {
+        ArtifactKind::Adr | ArtifactKind::Story => {
+            let contract = kind.contract();
+            format!(
+                "outcome '{outcome}' must produce a {kind} artifact matching declared path '{}' (contract pattern '{}')",
+                declaration.path, contract.canonical_path
+            )
+        },
+        _ => format!(
+            "outcome '{outcome}' must produce artifact '{}'",
+            declaration.path
+        ),
+    }
 }
 
 fn artifact_contract_rejection(kind: ArtifactKind, reason: String) -> ArtifactContractRejection {

--- a/crates/surge-orchestrator/src/engine/stage/agent.rs
+++ b/crates/surge-orchestrator/src/engine/stage/agent.rs
@@ -16,10 +16,13 @@ use surge_acp::bridge::facade::BridgeFacade;
 use surge_acp::bridge::session::{AgentKind, MessageContent, SessionConfig};
 use surge_acp::client::PermissionPolicy;
 use surge_core::agent_config::AgentConfig;
+use surge_core::artifact_contract::{ArtifactDiagnosticSeverity, validate_artifact};
 use surge_core::content_hash::ContentHash;
 use surge_core::keys::{NodeKey, OutcomeKey};
 use surge_core::node::OutcomeDecl;
+use surge_core::profile::registry::ResolvedProfile;
 use surge_core::run_event::{EventPayload, SessionDisposition, VersionedEventPayload};
+use surge_core::{ArtifactKind, ProfileArtifactDeclaration};
 use surge_persistence::artifacts::ArtifactStore;
 use surge_persistence::runs::run_writer::RunWriter;
 
@@ -410,46 +413,47 @@ pub async fn execute_agent_stage(p: AgentStageParams<'_>) -> StageResult {
                     reason, hook_id, ..
                 } = &outcome_chain
                 {
-                    p.writer
-                        .append_event(VersionedEventPayload::new(
-                            EventPayload::OutcomeRejectedByHook {
-                                node: p.node.clone(),
-                                outcome: outcome.clone(),
-                                hook_id: hook_id.clone(),
-                            },
-                        ))
-                        .await
-                        .map_err(|e| StageError::Storage(e.to_string()))?;
+                    record_outcome_rejection(
+                        RejectionRecordParams {
+                            writer: p.writer,
+                            bridge: p.bridge,
+                            node: p.node,
+                            session_id,
+                            outcome: &outcome,
+                            hook_id,
+                            reason,
+                            source: "on_outcome hook",
+                            max_rejections: max_outcome_rejections,
+                        },
+                        &mut outcome_rejection_attempts,
+                    )
+                    .await?;
+                    continue;
+                }
 
-                    outcome_rejection_attempts += 1;
-                    tracing::info!(
-                        target: "engine::stage::agent",
-                        node = %p.node,
-                        outcome = %outcome,
-                        hook_id = %hook_id,
-                        attempt = outcome_rejection_attempts,
-                        max = max_outcome_rejections,
-                        reason = %reason,
-                        "on_outcome hook rejected outcome; awaiting agent retry"
-                    );
-
-                    if outcome_rejection_attempts > max_outcome_rejections {
-                        let exhausted_reason = format!(
-                            "on_outcome rejection budget exhausted (last reject from '{hook_id}')"
-                        );
-                        p.writer
-                            .append_event(VersionedEventPayload::new(EventPayload::StageFailed {
-                                node: p.node.clone(),
-                                reason: exhausted_reason.clone(),
-                                retry_available: false,
-                            }))
-                            .await
-                            .map_err(|e| StageError::Storage(e.to_string()))?;
-                        // Close the session before bailing — the agent isn't
-                        // going to recover at this point.
-                        let _ = p.bridge.close_session(session_id).await;
-                        return Err(StageError::AgentCrashed(exhausted_reason));
-                    }
+                if let Some(rejection) = validate_profile_artifact_contracts(
+                    resolved_profile.as_ref(),
+                    &outcome,
+                    &artifacts_produced,
+                    p.worktree_path,
+                )
+                .await?
+                {
+                    record_outcome_rejection(
+                        RejectionRecordParams {
+                            writer: p.writer,
+                            bridge: p.bridge,
+                            node: p.node,
+                            session_id,
+                            outcome: &outcome,
+                            hook_id: &rejection.hook_id,
+                            reason: &rejection.reason,
+                            source: "profile artifact contract",
+                            max_rejections: max_outcome_rejections,
+                        },
+                        &mut outcome_rejection_attempts,
+                    )
+                    .await?;
                     continue;
                 }
 
@@ -462,6 +466,7 @@ pub async fn execute_agent_stage(p: AgentStageParams<'_>) -> StageResult {
                     let canonical_worktree = tokio::fs::canonicalize(p.worktree_path)
                         .await
                         .map_err(|e| StageError::Storage(e.to_string()))?;
+                    let stem_counts = artifact_stem_counts(&artifacts_produced);
                     let mut emitted_names = BTreeSet::new();
                     for declared_path in &artifacts_produced {
                         let Some(relative_path) = safe_declared_artifact_path(declared_path) else {
@@ -510,10 +515,8 @@ pub async fn execute_agent_stage(p: AgentStageParams<'_>) -> StageResult {
                                 continue;
                             },
                         };
-                        let name = relative_path
-                            .file_stem()
-                            .and_then(|s| s.to_str())
-                            .map_or_else(|| declared_path.clone(), str::to_owned);
+                        let name =
+                            logical_artifact_name(&relative_path, declared_path, &stem_counts);
                         if !emitted_names.insert(name.clone()) {
                             return Err(StageError::Internal(format!(
                                 "duplicate artifact logical name '{name}' from declared path '{declared_path}'"
@@ -846,6 +849,309 @@ pub async fn execute_agent_stage(p: AgentStageParams<'_>) -> StageResult {
         .map_err(|e| StageError::Storage(e.to_string()))?;
 
     Ok(outcome)
+}
+
+struct RejectionRecordParams<'a> {
+    writer: &'a RunWriter,
+    bridge: &'a Arc<dyn BridgeFacade>,
+    node: &'a NodeKey,
+    session_id: surge_core::id::SessionId,
+    outcome: &'a OutcomeKey,
+    hook_id: &'a str,
+    reason: &'a str,
+    source: &'a str,
+    max_rejections: u32,
+}
+
+async fn record_outcome_rejection(
+    params: RejectionRecordParams<'_>,
+    attempts: &mut u32,
+) -> Result<(), StageError> {
+    params
+        .writer
+        .append_event(VersionedEventPayload::new(
+            EventPayload::OutcomeRejectedByHook {
+                node: params.node.clone(),
+                outcome: params.outcome.clone(),
+                hook_id: params.hook_id.to_owned(),
+            },
+        ))
+        .await
+        .map_err(|e| StageError::Storage(e.to_string()))?;
+
+    *attempts += 1;
+    tracing::info!(
+        target: "engine::stage::agent",
+        node = %params.node,
+        outcome = %params.outcome,
+        hook_id = %params.hook_id,
+        attempt = *attempts,
+        max = params.max_rejections,
+        reason = %params.reason,
+        source = %params.source,
+        "outcome rejected; awaiting agent retry"
+    );
+
+    if *attempts > params.max_rejections {
+        let exhausted_reason = format!(
+            "on_outcome rejection budget exhausted (last reject from '{}')",
+            params.hook_id
+        );
+        params
+            .writer
+            .append_event(VersionedEventPayload::new(EventPayload::StageFailed {
+                node: params.node.clone(),
+                reason: exhausted_reason.clone(),
+                retry_available: false,
+            }))
+            .await
+            .map_err(|e| StageError::Storage(e.to_string()))?;
+        // Close the session before bailing — the agent isn't going to recover
+        // at this point.
+        let _ = params.bridge.close_session(params.session_id).await;
+        return Err(StageError::AgentCrashed(exhausted_reason));
+    }
+
+    Ok(())
+}
+
+#[derive(Debug, Clone)]
+struct ArtifactContractRejection {
+    hook_id: String,
+    reason: String,
+}
+
+async fn validate_profile_artifact_contracts(
+    resolved_profile: Option<&ResolvedProfile>,
+    outcome: &OutcomeKey,
+    artifacts_produced: &[String],
+    worktree_path: &Path,
+) -> Result<Option<ArtifactContractRejection>, StageError> {
+    let Some(profile) = resolved_profile else {
+        return Ok(None);
+    };
+    let Some(profile_outcome) = profile
+        .profile
+        .outcomes
+        .iter()
+        .find(|candidate| candidate.id == *outcome)
+    else {
+        return Ok(None);
+    };
+    if profile_outcome.produced_artifacts.is_empty() {
+        return Ok(None);
+    }
+
+    let canonical_worktree = tokio::fs::canonicalize(worktree_path)
+        .await
+        .map_err(|e| StageError::Storage(e.to_string()))?;
+    let produced_paths: Vec<PathBuf> = artifacts_produced
+        .iter()
+        .filter_map(|declared_path| safe_declared_artifact_path(declared_path))
+        .collect();
+
+    for declaration in &profile_outcome.produced_artifacts {
+        let matching_paths: Vec<&PathBuf> = produced_paths
+            .iter()
+            .filter(|path| artifact_declaration_matches_path(declaration, path))
+            .collect();
+        if matching_paths.is_empty() {
+            return Ok(Some(artifact_contract_rejection(
+                declaration.contract.kind,
+                format!(
+                    "outcome '{outcome}' must produce artifact '{}'",
+                    declaration.path
+                ),
+            )));
+        }
+
+        for relative_path in matching_paths {
+            let Some(validation_input) =
+                read_produced_artifact(worktree_path, &canonical_worktree, relative_path).await?
+            else {
+                return Ok(Some(artifact_contract_rejection(
+                    declaration.contract.kind,
+                    format!(
+                        "artifact '{}' was reported but could not be read from the worktree",
+                        normalize_artifact_path(relative_path)
+                    ),
+                )));
+            };
+            let content = String::from_utf8_lossy(&validation_input.bytes);
+            let report = validate_artifact(
+                declaration.contract.kind,
+                Some(validation_input.relative_path.as_path()),
+                &content,
+            );
+            if report.is_valid() {
+                continue;
+            }
+            return Ok(Some(artifact_contract_rejection(
+                declaration.contract.kind,
+                format_artifact_validation_reason(
+                    declaration.contract.kind,
+                    validation_input.relative_path.as_path(),
+                    &report.diagnostics,
+                ),
+            )));
+        }
+    }
+
+    Ok(None)
+}
+
+struct ProducedArtifactInput {
+    relative_path: PathBuf,
+    bytes: Vec<u8>,
+}
+
+async fn read_produced_artifact(
+    worktree_path: &Path,
+    canonical_worktree: &Path,
+    relative_path: &Path,
+) -> Result<Option<ProducedArtifactInput>, StageError> {
+    let absolute = worktree_path.join(relative_path);
+    let Ok(canonical_path) = tokio::fs::canonicalize(&absolute).await else {
+        return Ok(None);
+    };
+    if !canonical_path.starts_with(canonical_worktree) {
+        return Ok(None);
+    }
+    let Ok(bytes) = tokio::fs::read(&canonical_path).await else {
+        return Ok(None);
+    };
+    Ok(Some(ProducedArtifactInput {
+        relative_path: relative_path.to_path_buf(),
+        bytes,
+    }))
+}
+
+fn artifact_contract_rejection(kind: ArtifactKind, reason: String) -> ArtifactContractRejection {
+    ArtifactContractRejection {
+        hook_id: format!("profile-artifact-contract:{kind}"),
+        reason,
+    }
+}
+
+fn format_artifact_validation_reason(
+    kind: ArtifactKind,
+    path: &Path,
+    diagnostics: &[surge_core::ArtifactValidationDiagnostic],
+) -> String {
+    let errors = diagnostics
+        .iter()
+        .filter(|diagnostic| diagnostic.severity == ArtifactDiagnosticSeverity::Error)
+        .take(3)
+        .map(|diagnostic| {
+            let location = diagnostic
+                .location
+                .as_ref()
+                .map(|location| format!(" at {location}"))
+                .unwrap_or_default();
+            format!("{}{}: {}", diagnostic.code, location, diagnostic.message)
+        })
+        .collect::<Vec<_>>()
+        .join("; ");
+    format!(
+        "{kind} artifact '{}' failed contract validation: {errors}",
+        normalize_artifact_path(path)
+    )
+}
+
+fn artifact_declaration_matches_path(
+    declaration: &ProfileArtifactDeclaration,
+    relative_path: &Path,
+) -> bool {
+    let declared = normalize_profile_declared_path(&declaration.path);
+    let actual = normalize_artifact_path(relative_path);
+    if declared == actual {
+        return true;
+    }
+
+    match declaration.contract.kind {
+        ArtifactKind::Adr | ArtifactKind::Story => {
+            declared == declaration.contract.kind.contract().canonical_path
+                && declaration
+                    .contract
+                    .kind
+                    .contract()
+                    .accepts_path(relative_path)
+        },
+        _ => false,
+    }
+}
+
+fn artifact_stem_counts(paths: &[String]) -> BTreeMap<String, usize> {
+    let mut counts = BTreeMap::new();
+    for declared_path in paths {
+        let Some(relative_path) = safe_declared_artifact_path(declared_path) else {
+            continue;
+        };
+        let Some(stem) = artifact_stem(&relative_path) else {
+            continue;
+        };
+        *counts.entry(stem).or_insert(0) += 1;
+    }
+    counts
+}
+
+fn logical_artifact_name(
+    relative_path: &Path,
+    declared_path: &str,
+    stem_counts: &BTreeMap<String, usize>,
+) -> String {
+    let Some(stem) = artifact_stem(relative_path) else {
+        return sanitize_artifact_name(declared_path);
+    };
+    if stem_counts.get(&stem).copied().unwrap_or_default() <= 1 {
+        return stem;
+    }
+    path_based_artifact_name(relative_path).unwrap_or(stem)
+}
+
+fn artifact_stem(path: &Path) -> Option<String> {
+    path.file_stem()
+        .and_then(|stem| stem.to_str())
+        .filter(|stem| !stem.is_empty())
+        .map(ToOwned::to_owned)
+}
+
+fn path_based_artifact_name(path: &Path) -> Option<String> {
+    let normalized = normalize_artifact_path(path);
+    let name = sanitize_artifact_name(&normalized);
+    (!name.is_empty()).then_some(name)
+}
+
+fn sanitize_artifact_name(input: &str) -> String {
+    let mut name = String::with_capacity(input.len());
+    let mut last_was_separator = false;
+    for ch in input.chars() {
+        if ch.is_ascii_alphanumeric() || ch == '-' {
+            name.push(ch);
+            last_was_separator = false;
+        } else if !last_was_separator {
+            name.push('_');
+            last_was_separator = true;
+        }
+    }
+    name.trim_matches('_').to_string()
+}
+
+fn normalize_profile_declared_path(path: &str) -> String {
+    safe_declared_artifact_path(path).map_or_else(
+        || path.replace('\\', "/"),
+        |path| normalize_artifact_path(&path),
+    )
+}
+
+fn normalize_artifact_path(path: &Path) -> String {
+    path.components()
+        .filter_map(|component| match component {
+            Component::Normal(part) => Some(part.to_string_lossy()),
+            _ => None,
+        })
+        .collect::<Vec<_>>()
+        .join("/")
 }
 
 fn safe_declared_artifact_path(declared_path: &str) -> Option<PathBuf> {

--- a/crates/surge-orchestrator/src/engine/stage/agent.rs
+++ b/crates/surge-orchestrator/src/engine/stage/agent.rs
@@ -23,7 +23,7 @@ use surge_core::run_event::{EventPayload, SessionDisposition, VersionedEventPayl
 use surge_persistence::artifacts::ArtifactStore;
 use surge_persistence::runs::run_writer::RunWriter;
 
-use surge_core::hooks::HookTrigger;
+use surge_core::hooks::{Hook, HookTrigger};
 
 use crate::engine::hooks::{HookContext, HookExecutor, HookOutcome, record_hook_executed};
 use crate::engine::sandbox_factory::build_sandbox;
@@ -82,6 +82,31 @@ pub struct AgentStageParams<'a> {
     pub hook_executor: &'a HookExecutor,
 }
 
+/// Merge profile-level hooks with node-level hooks for one effective agent run.
+///
+/// Profile hooks run first. A node hook with the same `id` replaces the
+/// profile hook in-place, giving per-node config the final say without losing
+/// deterministic ordering.
+#[must_use]
+pub(crate) fn effective_agent_hooks(
+    agent_config: &AgentConfig,
+    resolved_profile: Option<&surge_core::profile::registry::ResolvedProfile>,
+) -> Vec<Hook> {
+    let mut hooks = resolved_profile
+        .map(|profile| profile.profile.hooks.entries.clone())
+        .unwrap_or_default();
+
+    for node_hook in &agent_config.hooks {
+        if let Some(existing) = hooks.iter_mut().find(|hook| hook.id == node_hook.id) {
+            *existing = node_hook.clone();
+        } else {
+            hooks.push(node_hook.clone());
+        }
+    }
+
+    hooks
+}
+
 /// Execute a single agent stage.
 ///
 /// Phase 6.2: opens a session, sends an empty placeholder message, then drives
@@ -135,6 +160,7 @@ pub async fn execute_agent_stage(p: AgentStageParams<'_>) -> StageResult {
     } else {
         None
     };
+    let effective_hooks = effective_agent_hooks(p.agent_config, resolved_profile.as_ref());
 
     // Prompt selection: explicit prompt_overrides.system wins; then
     // prompt_overrides.append_system; then the resolved profile's
@@ -369,11 +395,12 @@ pub async fn execute_agent_stage(p: AgentStageParams<'_>) -> StageResult {
                 // A rejecting hook lets the agent attempt a different outcome
                 // until `limits.max_retries` is exhausted.
                 let hook_ctx = HookContext::for_node(p.node)
+                    .with_worktree_path(p.worktree_path)
                     .with_session(session_id)
                     .with_outcome(&outcome);
                 let outcome_chain = p
                     .hook_executor
-                    .run_hooks(&p.agent_config.hooks, HookTrigger::OnOutcome, &hook_ctx)
+                    .run_hooks(&effective_hooks, HookTrigger::OnOutcome, &hook_ctx)
                     .await;
                 for record in outcome_chain.executed() {
                     record_hook_executed(p.writer, record).await;
@@ -582,11 +609,12 @@ pub async fn execute_agent_stage(p: AgentStageParams<'_>) -> StageResult {
                 // the call: we send a synthetic tool-error reply and continue
                 // the agent loop without invoking the dispatcher.
                 let hook_ctx = HookContext::for_node(p.node)
+                    .with_worktree_path(p.worktree_path)
                     .with_session(session_id)
                     .with_tool(tool.as_str(), Some(args_redacted_json.as_str()));
                 let pre_outcome = p
                     .hook_executor
-                    .run_hooks(&p.agent_config.hooks, HookTrigger::PreToolUse, &hook_ctx)
+                    .run_hooks(&effective_hooks, HookTrigger::PreToolUse, &hook_ctx)
                     .await;
                 for record in pre_outcome.executed() {
                     record_hook_executed(p.writer, record).await;
@@ -676,7 +704,7 @@ pub async fn execute_agent_stage(p: AgentStageParams<'_>) -> StageResult {
                 // result above.
                 let post_outcome = p
                     .hook_executor
-                    .run_hooks(&p.agent_config.hooks, HookTrigger::PostToolUse, &hook_ctx)
+                    .run_hooks(&effective_hooks, HookTrigger::PostToolUse, &hook_ctx)
                     .await;
                 for record in post_outcome.executed() {
                     record_hook_executed(p.writer, record).await;
@@ -967,5 +995,117 @@ fn sandbox_allows_mcp_tool(
         | SandboxMode::WorkspaceNetwork
         | SandboxMode::FullAccess
         | SandboxMode::Custom => true,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use surge_core::approvals::ApprovalConfig;
+    use surge_core::edge::EdgeKind;
+    use surge_core::hooks::{HookFailureMode, HookInheritance, MatcherSpec};
+    use surge_core::profile::registry::{Provenance, ResolvedProfile};
+    use surge_core::profile::{
+        InspectorUi, Profile, ProfileBindings, ProfileHooks, ProfileOutcome, PromptTemplate, Role,
+        RoleCategory, RuntimeCfg, ToolsCfg,
+    };
+    use surge_core::sandbox::SandboxConfig;
+
+    fn hook(id: &str, command: &str) -> Hook {
+        Hook {
+            id: id.to_string(),
+            trigger: HookTrigger::PreToolUse,
+            matcher: MatcherSpec::default(),
+            command: command.to_string(),
+            on_failure: HookFailureMode::Warn,
+            timeout_seconds: None,
+            inherit: HookInheritance::default(),
+        }
+    }
+
+    fn agent_config(hooks: Vec<Hook>) -> AgentConfig {
+        AgentConfig {
+            profile: surge_core::keys::ProfileKey::try_from("implementer@1.0").unwrap(),
+            prompt_overrides: None,
+            tool_overrides: None,
+            sandbox_override: None,
+            approvals_override: None,
+            bindings: Vec::new(),
+            rules_overrides: None,
+            limits: surge_core::agent_config::NodeLimits::default(),
+            hooks,
+            custom_fields: BTreeMap::new(),
+        }
+    }
+
+    fn resolved_profile(hooks: Vec<Hook>) -> ResolvedProfile {
+        let profile_key = surge_core::keys::ProfileKey::try_from("implementer").unwrap();
+        ResolvedProfile {
+            profile: Profile {
+                schema_version: 1,
+                role: Role {
+                    id: profile_key.clone(),
+                    version: semver::Version::new(1, 0, 0),
+                    display_name: "Implementer".into(),
+                    icon: None,
+                    category: RoleCategory::Agents,
+                    description: "Implements".into(),
+                    when_to_use: "Tests".into(),
+                    extends: None,
+                },
+                runtime: RuntimeCfg {
+                    recommended_model: "claude-opus-4-7".into(),
+                    default_temperature: 0.2,
+                    default_max_tokens: 200_000,
+                    load_rules_lazily: None,
+                    agent_id: "claude-code".into(),
+                },
+                sandbox: SandboxConfig::default(),
+                tools: ToolsCfg::default(),
+                approvals: ApprovalConfig::default(),
+                outcomes: vec![ProfileOutcome {
+                    id: OutcomeKey::try_from("done").unwrap(),
+                    description: "Done".into(),
+                    edge_kind_hint: EdgeKind::Forward,
+                    required_artifacts: Vec::new(),
+                    produced_artifacts: Vec::new(),
+                }],
+                bindings: ProfileBindings::default(),
+                hooks: ProfileHooks { entries: hooks },
+                prompt: PromptTemplate {
+                    system: "Implement".into(),
+                },
+                inspector_ui: InspectorUi::default(),
+            },
+            provenance: Provenance::Bundled,
+            chain: vec![profile_key],
+        }
+    }
+
+    #[test]
+    fn effective_hooks_append_node_hooks_after_profile_hooks() {
+        let profile = resolved_profile(vec![hook("profile", "profile-cmd")]);
+        let agent = agent_config(vec![hook("node", "node-cmd")]);
+
+        let effective = effective_agent_hooks(&agent, Some(&profile));
+
+        assert_eq!(
+            effective
+                .iter()
+                .map(|hook| hook.id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["profile", "node"]
+        );
+    }
+
+    #[test]
+    fn node_hooks_override_profile_hooks_by_id() {
+        let profile = resolved_profile(vec![hook("validate", "profile-cmd")]);
+        let agent = agent_config(vec![hook("validate", "node-cmd")]);
+
+        let effective = effective_agent_hooks(&agent, Some(&profile));
+
+        assert_eq!(effective.len(), 1);
+        assert_eq!(effective[0].command, "node-cmd");
     }
 }

--- a/crates/surge-orchestrator/src/profile_loader/registry.rs
+++ b/crates/surge-orchestrator/src/profile_loader/registry.rs
@@ -136,6 +136,7 @@ impl ProfileRegistry {
             chain_len = chain_keys.len(),
             "profile resolved"
         );
+        log_profile_artifact_contracts(&merged);
 
         Ok(ResolvedProfile {
             profile: merged,
@@ -272,6 +273,22 @@ impl ProfileRegistry {
     #[must_use]
     pub fn bundled(&self) -> &[Profile] {
         &self.bundled
+    }
+}
+
+fn log_profile_artifact_contracts(profile: &Profile) {
+    for outcome in &profile.outcomes {
+        for artifact in &outcome.produced_artifacts {
+            tracing::debug!(
+                target: "profile::registry",
+                profile = profile.role.id.as_str(),
+                outcome = outcome.id.as_ref(),
+                artifact = artifact.path.as_str(),
+                artifact_kind = artifact.contract.kind.as_str(),
+                schema_version = artifact.contract.schema_version,
+                "profile artifact contract resolved"
+            );
+        }
     }
 }
 

--- a/crates/surge-orchestrator/src/snapshots/surge_orchestrator__prompt__tests__description_author_bootstrap_prompt.snap
+++ b/crates/surge-orchestrator/src/snapshots/surge_orchestrator__prompt__tests__description_author_bootstrap_prompt.snap
@@ -21,11 +21,11 @@ Tighten the scope and make the terminal outcome explicit.
 
 # Mission
 
-Turn the user request into one artifact: `description.md`. This artifact is the
+Turn the user request into the Description contract artifact: `description.md`. This artifact is the
 source of truth for the Roadmap Planner and Flow Generator, so write it as if the
 next agent will not see the original conversation.
 
-Output schema (Markdown sections in this order):
+Description contract (Markdown; no schema_version field):
 - `## Goal` — one paragraph; the *what* and the *why*.
 - `## Context` — what already exists in the project that this work touches.
 - `## Requirements` — bulleted, testable, prioritized.

--- a/crates/surge-orchestrator/src/snapshots/surge_orchestrator__prompt__tests__flow_generator_bootstrap_prompt.snap
+++ b/crates/surge-orchestrator/src/snapshots/surge_orchestrator__prompt__tests__flow_generator_bootstrap_prompt.snap
@@ -17,7 +17,7 @@ Create a bootstrap flow for adaptive project execution.
 - Produce description.md
 - Produce roadmap.md
 
-Approved or edited `roadmap.md`:
+Approved or edited Roadmap contract artifact (`roadmap.toml`, with `roadmap.md` as compatibility context when present):
 ## Milestones
 1. Bootstrap graph asset
 2. CLI entrypoint
@@ -30,15 +30,21 @@ Tighten the scope and make the terminal outcome explicit.
 
 # Mission
 
-Emit one valid `flow.toml` graph. Use typed nodes, declared outcomes, and profile
+Emit one valid Flow contract artifact: `flow.toml` with `schema_version = 1`.
+Use typed nodes, declared outcomes, and profile
 references; do not write free-form execution instructions into graph nodes.
 
 Pick exactly one archetype and include it in `[metadata.archetype]`:
+- `feature` — design/plan -> implement core -> integration/tests for standard feature work.
 - `linear-3` — single small task: Spec Author -> Implementer -> Verifier -> Terminal.
 - `linear-with-review` — one milestone with 5-7 tasks and an explicit Review node.
 - `multi-milestone` — outer Loop over `roadmap.milestones` wrapping per-milestone task Loops.
 - `bug-fix` — starts with reproduction / failing-case characterization before implementation.
 - `refactor` — starts with behavior characterization before implementation.
+- `performance` — baseline/profile -> optimize -> benchmark/validate.
+- `security` — security audit -> fixes -> security regression tests.
+- `docs` — outline -> write -> review/publish documentation.
+- `migration` — migration plan -> implementation -> rollback validation.
 - `spike` — bounded research/prototype path; may skip Architect and Reviewer when appropriate.
 - `single-task` — one focused Agent node plus Terminal for tiny, low-risk work.
 

--- a/crates/surge-orchestrator/src/snapshots/surge_orchestrator__prompt__tests__roadmap_planner_bootstrap_prompt.snap
+++ b/crates/surge-orchestrator/src/snapshots/surge_orchestrator__prompt__tests__roadmap_planner_bootstrap_prompt.snap
@@ -22,11 +22,18 @@ Tighten the scope and make the terminal outcome explicit.
 
 # Mission
 
-Turn `description.md` into one artifact: `roadmap.md`. The roadmap must be
-milestoned, dependency-aware, and specific enough for the Flow Generator to
-compile into a `flow.toml` graph without inventing scope.
+Turn `description.md` into Roadmap contract artifacts:
+- Primary machine-readable artifact: `roadmap.toml` with `schema_version = 1`.
+- Human compatibility artifact: `roadmap.md`.
 
-Output schema:
+`roadmap.toml` schema:
+- Top-level `schema_version = 1`.
+- `[[milestones]]` with `id`, `title`, and nested `[[milestones.tasks]]`.
+- Each task has `id`, `title`, optional `description`, and optional `acceptance_criteria = [...]`.
+- `[[dependencies]]` uses `from`, `to`, and optional `reason`.
+- `[[risks]]` uses `description` and optional `mitigation`.
+
+`roadmap.md` compatibility sections:
 - `## Milestones` — ordered list. Each milestone has a heading and 3-15 task bullets sized to scope.
 - `## Dependencies` — explicit edges between milestones when one must finish before another can start.
 - `## Risks` — short bulleted list of what could break the plan.
@@ -36,8 +43,8 @@ Rules:
 - Milestones are deliverable-focused, not phase-focused (no "Planning" / "Implementation" / "Testing" milestones).
 - Calibrate task sizes against the existing project: a "2-day" task is roughly 8 plan-tasks.
 - If the description is missing requirements you need to plan, report `needs_clarification` with the gaps.
-- No code in this artifact. Roadmap describes what ships, not how.
+- No code in these artifacts. Roadmap describes what ships, not how.
 
 When finished:
-1. Write the markdown artifact to `roadmap.md`.
-2. Call `report_stage_outcome` with outcome `drafted` and `artifacts_produced = ["roadmap.md"]`.
+1. Write `roadmap.toml` and `roadmap.md`.
+2. Call `report_stage_outcome` with outcome `drafted` and `artifacts_produced = ["roadmap.toml", "roadmap.md"]`.

--- a/crates/surge-orchestrator/tests/artifact_contract_golden_test.rs
+++ b/crates/surge-orchestrator/tests/artifact_contract_golden_test.rs
@@ -1,0 +1,160 @@
+//! Golden checks for Surge artifact contracts.
+//!
+//! These fixtures are synthetic and safe to print by name on failure. The tests
+//! intentionally assert stable diagnostic codes rather than prose so agent
+//! wording can vary without breaking contract equivalence.
+
+use std::path::PathBuf;
+
+use surge_core::{
+    ArtifactDiagnosticCode, ArtifactKind, ArtifactValidationReport, validate_artifact,
+};
+
+fn artifacts_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/artifacts")
+}
+
+fn load_fixture(relative: &str) -> (PathBuf, String) {
+    let path = artifacts_root().join(relative);
+    let content =
+        std::fs::read_to_string(&path).unwrap_or_else(|err| panic!("read {relative}: {err}"));
+    (path, content)
+}
+
+fn validate_fixture(kind: ArtifactKind, relative: &str) -> ArtifactValidationReport {
+    let (path, content) = load_fixture(relative);
+    let artifact_path = path
+        .strip_prefix(artifacts_root().join("valid"))
+        .or_else(|_| path.strip_prefix(artifacts_root().join("invalid")))
+        .unwrap_or(path.as_path());
+    validate_artifact(kind, Some(artifact_path), &content)
+}
+
+fn diagnostic_codes(report: &ArtifactValidationReport) -> Vec<ArtifactDiagnosticCode> {
+    report
+        .diagnostics
+        .iter()
+        .map(|diagnostic| diagnostic.code)
+        .collect()
+}
+
+#[test]
+fn valid_fixtures_pass_all_artifact_contracts() {
+    let cases = [
+        (ArtifactKind::Description, "valid/description.md"),
+        (ArtifactKind::Requirements, "valid/requirements.md"),
+        (ArtifactKind::Roadmap, "valid/roadmap.toml"),
+        (ArtifactKind::Roadmap, "valid/roadmap.md"),
+        (ArtifactKind::Spec, "valid/spec.toml"),
+        (ArtifactKind::Spec, "valid/spec.md"),
+        (
+            ArtifactKind::Adr,
+            "valid/docs/adr/0001-validate-artifacts.md",
+        ),
+        (ArtifactKind::Story, "valid/stories/story-001.md"),
+        (ArtifactKind::Plan, "valid/plan.md"),
+        (ArtifactKind::Flow, "valid/flow.toml"),
+    ];
+
+    for (kind, relative) in cases {
+        let report = validate_fixture(kind, relative);
+        assert!(
+            report.is_valid(),
+            "{relative} should be valid, got {report:#?}"
+        );
+    }
+}
+
+#[test]
+fn invalid_fixtures_emit_stable_diagnostic_codes() {
+    let cases: &[(ArtifactKind, &str, &[ArtifactDiagnosticCode])] = &[
+        (
+            ArtifactKind::Description,
+            "invalid/description.md",
+            &[
+                ArtifactDiagnosticCode::MissingSection,
+                ArtifactDiagnosticCode::MissingSection,
+                ArtifactDiagnosticCode::MissingSection,
+            ],
+        ),
+        (
+            ArtifactKind::Requirements,
+            "invalid/requirements.md",
+            &[
+                ArtifactDiagnosticCode::MissingSection,
+                ArtifactDiagnosticCode::MissingSection,
+                ArtifactDiagnosticCode::MissingSection,
+                ArtifactDiagnosticCode::MissingSection,
+            ],
+        ),
+        (
+            ArtifactKind::Roadmap,
+            "invalid/roadmap.toml",
+            &[ArtifactDiagnosticCode::UnsupportedSchemaVersion],
+        ),
+        (
+            ArtifactKind::Spec,
+            "invalid/spec.toml",
+            &[ArtifactDiagnosticCode::MissingAcceptanceCriteria],
+        ),
+        (
+            ArtifactKind::Adr,
+            "invalid/docs/adr/0001-missing-frontmatter.md",
+            &[ArtifactDiagnosticCode::InvalidFrontmatter],
+        ),
+        (
+            ArtifactKind::Story,
+            "invalid/stories/story-1.md",
+            &[ArtifactDiagnosticCode::InvalidArtifactPath],
+        ),
+        (
+            ArtifactKind::Plan,
+            "invalid/plan.md",
+            &[ArtifactDiagnosticCode::MissingSection],
+        ),
+        (
+            ArtifactKind::Flow,
+            "invalid/flow.toml",
+            &[ArtifactDiagnosticCode::UnsupportedSchemaVersion],
+        ),
+    ];
+
+    for (kind, relative, expected_codes) in cases {
+        let report = validate_fixture(*kind, relative);
+        assert!(!report.is_valid(), "{relative} should be invalid");
+        assert_eq!(
+            diagnostic_codes(&report),
+            *expected_codes,
+            "{relative} diagnostic codes drifted"
+        );
+    }
+}
+
+#[test]
+fn toml_and_markdown_compatibility_reports_are_contract_equivalent() {
+    let roadmap_toml = validate_fixture(ArtifactKind::Roadmap, "valid/roadmap.toml");
+    let roadmap_md = validate_fixture(ArtifactKind::Roadmap, "valid/roadmap.md");
+    let spec_toml = validate_fixture(ArtifactKind::Spec, "valid/spec.toml");
+    let spec_md = validate_fixture(ArtifactKind::Spec, "valid/spec.md");
+
+    assert_contract_equivalent("roadmap", &roadmap_toml, &roadmap_md);
+    assert_contract_equivalent("spec", &spec_toml, &spec_md);
+}
+
+fn assert_contract_equivalent(
+    label: &str,
+    left: &ArtifactValidationReport,
+    right: &ArtifactValidationReport,
+) {
+    assert_eq!(left.kind, right.kind, "{label} kind differs");
+    assert_eq!(
+        left.is_valid(),
+        right.is_valid(),
+        "{label} validity differs"
+    );
+    assert_eq!(
+        diagnostic_codes(left),
+        diagnostic_codes(right),
+        "{label} diagnostic codes differ"
+    );
+}

--- a/crates/surge-orchestrator/tests/engine_agent_artifact_emission_test.rs
+++ b/crates/surge-orchestrator/tests/engine_agent_artifact_emission_test.rs
@@ -20,11 +20,11 @@ use surge_core::id::SessionId;
 use surge_core::keys::{NodeKey, OutcomeKey, ProfileKey};
 use surge_core::run_event::EventPayload;
 use surge_orchestrator::engine::hooks::HookExecutor;
-use surge_orchestrator::engine::stage::StageError;
 use surge_orchestrator::engine::stage::agent::{AgentStageParams, execute_agent_stage};
 use surge_orchestrator::engine::tools::{
     ToolCall, ToolDispatchContext, ToolDispatcher, ToolResultPayload,
 };
+use surge_orchestrator::profile_loader::{DiskProfileSet, ProfileRegistry};
 use surge_persistence::runs::{EventSeq, Storage};
 
 struct UnusedDispatcher;
@@ -39,8 +39,12 @@ impl ToolDispatcher for UnusedDispatcher {
 }
 
 fn agent_cfg() -> AgentConfig {
+    agent_cfg_with_profile("implementer@1.0")
+}
+
+fn agent_cfg_with_profile(profile: &str) -> AgentConfig {
     AgentConfig {
-        profile: ProfileKey::try_from("implementer@1.0").unwrap(),
+        profile: ProfileKey::try_from(profile).unwrap(),
         prompt_overrides: None,
         tool_overrides: None,
         sandbox_override: None,
@@ -284,18 +288,30 @@ async fn missing_artifact_path_logs_warning_and_skips_event() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn duplicate_artifact_logical_names_fail_before_overwrite() {
+async fn compatible_artifacts_with_the_same_stem_get_distinct_names() {
     let dir = tempfile::tempdir().unwrap();
+    tokio::fs::write(
+        dir.path().join("spec.toml"),
+        br#"schema_version = 1
+
+[spec]
+subtasks = [
+  { id = "one", acceptance_criteria = ["first check passes"] },
+]
+"#,
+    )
+    .await
+    .unwrap();
+    tokio::fs::write(
+        dir.path().join("spec.md"),
+        b"# Spec\n\n## Goal\nShip it.\n\n## Subtasks\n- one\n\n## Acceptance Criteria\n- [ ] passes\n",
+    )
+    .await
+    .unwrap();
     tokio::fs::create_dir_all(dir.path().join("docs"))
         .await
         .unwrap();
-    tokio::fs::create_dir_all(dir.path().join("src"))
-        .await
-        .unwrap();
     tokio::fs::write(dir.path().join("docs").join("spec.md"), b"docs spec")
-        .await
-        .unwrap();
-    tokio::fs::write(dir.path().join("src").join("spec.md"), b"src spec")
         .await
         .unwrap();
 
@@ -313,7 +329,7 @@ async fn duplicate_artifact_logical_names_fail_before_overwrite() {
         session: session_id,
         outcome: OutcomeKey::from_str("done").unwrap(),
         summary: "colliding artifacts".into(),
-        artifacts_produced: vec!["docs/spec.md".into(), "src/spec.md".into()],
+        artifacts_produced: vec!["spec.toml".into(), "spec.md".into(), "docs/spec.md".into()],
     })
     .await;
 
@@ -348,12 +364,33 @@ async fn duplicate_artifact_logical_names_fail_before_overwrite() {
         profile_registry: None,
         hook_executor: &hook_executor,
     })
-    .await;
+    .await
+    .unwrap();
     pump.await.unwrap();
 
-    assert!(
-        matches!(result, Err(StageError::Internal(message)) if message.contains("duplicate artifact logical name")),
-        "duplicate file stems must fail instead of overwriting the per-run artifact index",
+    assert_eq!(result.as_ref(), "done");
+
+    let reader = storage.open_run_reader(run_id).await.expect("reader");
+    let events = reader
+        .read_events(EventSeq(0)..EventSeq(64))
+        .await
+        .expect("read_events");
+    let artifact_names: Vec<String> = events
+        .iter()
+        .filter_map(|ev| match &ev.payload.payload {
+            EventPayload::ArtifactProduced { name, .. } => Some(name.clone()),
+            _ => None,
+        })
+        .collect();
+
+    assert_eq!(
+        artifact_names,
+        vec![
+            "spec_toml".to_string(),
+            "spec_md".to_string(),
+            "docs_spec_md".to_string()
+        ],
+        "colliding stems should be disambiguated without dropping valid artifacts",
     );
 }
 
@@ -458,5 +495,126 @@ async fn artifact_paths_that_escape_worktree_are_skipped() {
     assert!(
         saw_outcome,
         "OutcomeReported must still be appended when unsafe artifact paths are skipped"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn profile_artifact_contract_rejects_invalid_adr_without_shell_hook() {
+    let dir = tempfile::tempdir().unwrap();
+    tokio::fs::create_dir_all(dir.path().join("docs").join("adr"))
+        .await
+        .unwrap();
+    tokio::fs::write(
+        dir.path()
+            .join("docs")
+            .join("adr")
+            .join("0001-contracts.md"),
+        b"# ADR 0001\n\n## Status\nDrafted without the required frontmatter.\n",
+    )
+    .await
+    .unwrap();
+
+    let storage = Storage::open(dir.path()).await.unwrap();
+    let run_id = surge_core::id::RunId::new();
+    let writer = storage.create_run(run_id, dir.path(), None).await.unwrap();
+    let artifact_store = surge_persistence::artifacts::ArtifactStore::new(dir.path().join("runs"));
+    let registry = Arc::new(ProfileRegistry::new(DiskProfileSet::empty()));
+
+    let mock = Arc::new(fixtures::mock_bridge::MockBridge::new());
+    let bridge: Arc<dyn BridgeFacade> = mock.clone();
+
+    let session_id = SessionId::new();
+    mock.pin_next_session_id(session_id).await;
+    mock.enqueue_event(BridgeEvent::OutcomeReported {
+        session: session_id,
+        outcome: OutcomeKey::from_str("drafted").unwrap(),
+        summary: "invalid adr".into(),
+        artifacts_produced: vec!["docs/adr/0001-contracts.md".into()],
+    })
+    .await;
+    mock.enqueue_event(BridgeEvent::OutcomeReported {
+        session: session_id,
+        outcome: OutcomeKey::from_str("no_decision_needed").unwrap(),
+        summary: "fallback".into(),
+        artifacts_produced: vec![],
+    })
+    .await;
+
+    let mock_for_pump = mock.clone();
+    let pump = tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        mock_for_pump.pump_scripted_events().await;
+    });
+
+    let dispatcher: Arc<dyn ToolDispatcher> = Arc::new(UnusedDispatcher);
+    let memory = surge_core::run_state::RunMemory::default();
+    let cfg = agent_cfg_with_profile("architect@1.0");
+    let node = NodeKey::try_from("architect").unwrap();
+    let tool_resolutions =
+        std::sync::Arc::new(tokio::sync::Mutex::new(std::collections::HashMap::new()));
+    let hook_executor = HookExecutor::new();
+    let result = execute_agent_stage(AgentStageParams {
+        node: &node,
+        agent_config: &cfg,
+        declared_outcomes: &[],
+        bridge: &bridge,
+        writer: &writer,
+        artifact_store: &artifact_store,
+        worktree_path: dir.path(),
+        tool_dispatcher: &dispatcher,
+        run_memory: &memory,
+        run_id,
+        tool_resolutions: &tool_resolutions,
+        human_input_timeout: Duration::from_secs(5),
+        mcp_registry: None,
+        mcp_servers: Vec::new(),
+        profile_registry: Some(registry),
+        hook_executor: &hook_executor,
+    })
+    .await
+    .expect("stage should retry after invalid ADR contract rejection");
+    pump.await.unwrap();
+    assert_eq!(result.as_ref(), "no_decision_needed");
+
+    let reader = storage.open_run_reader(run_id).await.expect("reader");
+    let events = reader
+        .read_events(EventSeq(0)..EventSeq(64))
+        .await
+        .expect("read_events");
+
+    let mut saw_contract_rejection = false;
+    let mut outcome_names = Vec::new();
+    let artifact_count = events
+        .iter()
+        .filter(|ev| matches!(ev.payload.payload, EventPayload::ArtifactProduced { .. }))
+        .count();
+    for ev in events {
+        match ev.payload.payload {
+            EventPayload::OutcomeRejectedByHook {
+                outcome, hook_id, ..
+            } => {
+                assert_eq!(outcome.as_ref(), "drafted");
+                assert_eq!(hook_id, "profile-artifact-contract:adr");
+                saw_contract_rejection = true;
+            },
+            EventPayload::OutcomeReported { outcome, .. } => {
+                outcome_names.push(outcome.to_string());
+            },
+            _ => {},
+        }
+    }
+
+    assert!(
+        saw_contract_rejection,
+        "invalid ADR should be rejected by the profile artifact contract"
+    );
+    assert_eq!(
+        outcome_names,
+        vec!["no_decision_needed".to_string()],
+        "the rejected drafted outcome must not be persisted"
+    );
+    assert_eq!(
+        artifact_count, 0,
+        "invalid artifacts must not be emitted before contract validation passes"
     );
 }

--- a/crates/surge-orchestrator/tests/fixtures/artifacts/invalid/description.md
+++ b/crates/surge-orchestrator/tests/fixtures/artifacts/invalid/description.md
@@ -1,0 +1,4 @@
+# Description
+
+## Goal
+Validate artifacts.

--- a/crates/surge-orchestrator/tests/fixtures/artifacts/invalid/docs/adr/0001-missing-frontmatter.md
+++ b/crates/surge-orchestrator/tests/fixtures/artifacts/invalid/docs/adr/0001-missing-frontmatter.md
@@ -1,0 +1,16 @@
+# ADR 0001: Missing Frontmatter
+
+## Status
+Accepted.
+
+## Context
+The frontmatter is absent.
+
+## Decision
+This should fail validation.
+
+## Alternatives considered
+- None.
+
+## Consequences
+- The validator rejects it.

--- a/crates/surge-orchestrator/tests/fixtures/artifacts/invalid/flow.toml
+++ b/crates/surge-orchestrator/tests/fixtures/artifacts/invalid/flow.toml
@@ -1,0 +1,21 @@
+schema_version = 2
+start = "end"
+edges = []
+
+[metadata]
+name = "bad-flow"
+created_at = "2026-05-11T00:00:00Z"
+
+[nodes.end]
+id = "end"
+declared_outcomes = []
+
+[nodes.end.position]
+x = 0.0
+y = 0.0
+
+[nodes.end.config]
+node_kind = "terminal"
+
+[nodes.end.config.kind]
+type = "success"

--- a/crates/surge-orchestrator/tests/fixtures/artifacts/invalid/plan.md
+++ b/crates/surge-orchestrator/tests/fixtures/artifacts/invalid/plan.md
@@ -1,0 +1,4 @@
+# Implementation Plan
+
+## Settings
+- Testing: yes

--- a/crates/surge-orchestrator/tests/fixtures/artifacts/invalid/requirements.md
+++ b/crates/surge-orchestrator/tests/fixtures/artifacts/invalid/requirements.md
@@ -1,0 +1,4 @@
+# Requirements
+
+## Overview
+Missing most required sections.

--- a/crates/surge-orchestrator/tests/fixtures/artifacts/invalid/roadmap.toml
+++ b/crates/surge-orchestrator/tests/fixtures/artifacts/invalid/roadmap.toml
@@ -1,0 +1,5 @@
+schema_version = 2
+
+[[milestones]]
+id = "artifact-validation"
+title = "Artifact validation"

--- a/crates/surge-orchestrator/tests/fixtures/artifacts/invalid/spec.toml
+++ b/crates/surge-orchestrator/tests/fixtures/artifacts/invalid/spec.toml
@@ -1,0 +1,13 @@
+schema_version = 1
+
+[spec]
+id = "artifact-validation"
+title = "Artifact validation"
+description = "Missing acceptance criteria."
+complexity = "small"
+
+[[spec.subtasks]]
+id = "missing-criteria"
+title = "Missing criteria"
+description = "This subtask is not testable."
+complexity = "small"

--- a/crates/surge-orchestrator/tests/fixtures/artifacts/invalid/stories/story-1.md
+++ b/crates/surge-orchestrator/tests/fixtures/artifacts/invalid/stories/story-1.md
@@ -1,0 +1,19 @@
+# Story 1
+
+## Context
+The path is not canonical.
+
+## What needs to be done
+Use a three-digit story number.
+
+## Architecture decisions
+None.
+
+## Files to modify
+- `stories/story-001.md`
+
+## Acceptance criteria
+- The invalid path is rejected.
+
+## Out of scope
+- Content validation failures.

--- a/crates/surge-orchestrator/tests/fixtures/artifacts/valid/description.md
+++ b/crates/surge-orchestrator/tests/fixtures/artifacts/valid/description.md
@@ -1,0 +1,14 @@
+# Description
+
+## Goal
+Add artifact validation before downstream stages consume generated outputs.
+
+## Context
+Surge already has bundled profiles, hooks, and graph validation.
+
+## Requirements
+- Validate canonical artifacts with stable diagnostics.
+- Reject malformed outputs before persistence.
+
+## Out of Scope
+- Removing the legacy spec pipeline.

--- a/crates/surge-orchestrator/tests/fixtures/artifacts/valid/docs/adr/0001-validate-artifacts.md
+++ b/crates/surge-orchestrator/tests/fixtures/artifacts/valid/docs/adr/0001-validate-artifacts.md
@@ -1,0 +1,23 @@
++++
+status = "accepted"
+deciders = ["core maintainers"]
+date = "2026-05-11"
++++
+
+# ADR 0001: Validate Generated Artifacts
+
+## Status
+Accepted.
+
+## Context
+Agent outputs need stable shapes before downstream stages consume them.
+
+## Decision
+Use Surge-owned artifact contracts with pure validators and hook enforcement.
+
+## Alternatives considered
+- Keep conventions in prompts only.
+- Validate only in CI.
+
+## Consequences
+Generated artifacts can be rejected before persistence.

--- a/crates/surge-orchestrator/tests/fixtures/artifacts/valid/flow.toml
+++ b/crates/surge-orchestrator/tests/fixtures/artifacts/valid/flow.toml
@@ -1,0 +1,21 @@
+schema_version = 1
+start = "end"
+edges = []
+
+[metadata]
+name = "single-terminal"
+created_at = "2026-05-11T00:00:00Z"
+
+[nodes.end]
+id = "end"
+declared_outcomes = []
+
+[nodes.end.position]
+x = 0.0
+y = 0.0
+
+[nodes.end.config]
+node_kind = "terminal"
+
+[nodes.end.config.kind]
+type = "success"

--- a/crates/surge-orchestrator/tests/fixtures/artifacts/valid/plan.md
+++ b/crates/surge-orchestrator/tests/fixtures/artifacts/valid/plan.md
@@ -1,0 +1,9 @@
+# Implementation Plan
+
+## Settings
+- Testing: yes
+- Docs: yes
+
+## Tasks
+- [ ] Task 1: Add fixtures.
+- [ ] Task 2: Run focused tests.

--- a/crates/surge-orchestrator/tests/fixtures/artifacts/valid/requirements.md
+++ b/crates/surge-orchestrator/tests/fixtures/artifacts/valid/requirements.md
@@ -1,0 +1,16 @@
+# Requirements
+
+## Overview
+Operators need generated artifacts to be validated before a run advances.
+
+## User Stories
+- As an operator, I can see why an artifact was rejected.
+
+## Functional Requirements
+- The CLI validates canonical paths and contents.
+
+## Success Criteria
+- Invalid schema versions fail validation.
+
+## Out of Scope
+- Live agent quality scoring.

--- a/crates/surge-orchestrator/tests/fixtures/artifacts/valid/roadmap.md
+++ b/crates/surge-orchestrator/tests/fixtures/artifacts/valid/roadmap.md
@@ -1,0 +1,10 @@
+# Roadmap
+
+## Milestones
+- Artifact validation
+
+## Dependencies
+- Artifact validation before hook enforcement.
+
+## Risks
+- Validators may reject legacy output.

--- a/crates/surge-orchestrator/tests/fixtures/artifacts/valid/roadmap.toml
+++ b/crates/surge-orchestrator/tests/fixtures/artifacts/valid/roadmap.toml
@@ -1,0 +1,20 @@
+schema_version = 1
+
+[[milestones]]
+id = "artifact-validation"
+title = "Artifact validation"
+
+[[milestones.tasks]]
+id = "validators"
+title = "Add validators"
+description = "Validate canonical generated artifacts."
+acceptance_criteria = ["Invalid schema versions fail", "Valid fixtures pass"]
+
+[[dependencies]]
+from = "artifact-validation"
+to = "hook-enforcement"
+reason = "Hooks need validators to call."
+
+[[risks]]
+description = "Validators drift from prompts."
+mitigation = "Keep profile prompts linked to conventions."

--- a/crates/surge-orchestrator/tests/fixtures/artifacts/valid/spec.md
+++ b/crates/surge-orchestrator/tests/fixtures/artifacts/valid/spec.md
@@ -1,0 +1,14 @@
+# Spec
+
+## Goal
+Enforce artifact contracts before downstream stages consume outputs.
+
+## Subtasks
+1. Add pure validators.
+   - Acceptance criteria: valid fixtures pass.
+
+## Acceptance Criteria
+- [ ] Invalid schema versions fail with stable diagnostics.
+
+## Constraints
+- Core validators stay pure and do not read files.

--- a/crates/surge-orchestrator/tests/fixtures/artifacts/valid/spec.toml
+++ b/crates/surge-orchestrator/tests/fixtures/artifacts/valid/spec.toml
@@ -1,0 +1,17 @@
+schema_version = 1
+
+[spec]
+id = "artifact-validation"
+title = "Artifact validation"
+description = "Define and enforce generated artifact contracts."
+complexity = "medium"
+
+[[spec.subtasks]]
+id = "core-contracts"
+title = "Core contracts"
+description = "Add pure contract metadata and diagnostics."
+complexity = "small"
+files = ["crates/surge-core/src/artifact_contract.rs"]
+
+[[spec.subtasks.acceptance_criteria]]
+description = "Valid minimal artifacts pass validation."

--- a/crates/surge-orchestrator/tests/fixtures/artifacts/valid/stories/story-001.md
+++ b/crates/surge-orchestrator/tests/fixtures/artifacts/valid/stories/story-001.md
@@ -1,0 +1,19 @@
+# Story 001
+
+## Context
+The CLI validator needs examples that cover invalid graph shapes.
+
+## What needs to be done
+Add fixture-driven validation tests.
+
+## Architecture decisions
+Keep pure validation in `surge-core`.
+
+## Files to modify
+- `crates/surge-core/src/artifact_contract.rs`
+
+## Acceptance criteria
+- Invalid fixtures emit stable diagnostic codes.
+
+## Out of scope
+- Live agent comparison tests.

--- a/crates/surge-orchestrator/tests/on_outcome_retry_test.rs
+++ b/crates/surge-orchestrator/tests/on_outcome_retry_test.rs
@@ -23,6 +23,7 @@ use surge_orchestrator::engine::stage::agent::{AgentStageParams, execute_agent_s
 use surge_orchestrator::engine::tools::{
     ToolCall, ToolDispatchContext, ToolDispatcher, ToolResultPayload as EngineResultPayload,
 };
+use surge_orchestrator::profile_loader::{DiskProfileSet, ProfileRegistry};
 use surge_persistence::runs::Storage;
 use surge_persistence::runs::seq::EventSeq;
 
@@ -44,8 +45,12 @@ impl ToolDispatcher for UnusedDispatcher {
 }
 
 fn agent_cfg(hooks: Vec<Hook>, max_retries: u32) -> AgentConfig {
+    agent_cfg_with_profile("implementer@1.0", hooks, max_retries)
+}
+
+fn agent_cfg_with_profile(profile: &str, hooks: Vec<Hook>, max_retries: u32) -> AgentConfig {
     AgentConfig {
-        profile: ProfileKey::try_from("implementer@1.0").unwrap(),
+        profile: ProfileKey::try_from(profile).unwrap(),
         prompt_overrides: None,
         tool_overrides: None,
         sandbox_override: None,
@@ -74,6 +79,50 @@ fn outcome_reject_hook(id: &str, target_outcome: &str) -> Hook {
         timeout_seconds: Some(5),
         inherit: HookInheritance::Extend,
     }
+}
+
+fn drop_profile_with_on_outcome_hook(profiles_dir: &std::path::Path) {
+    std::fs::create_dir_all(profiles_dir).unwrap();
+    std::fs::write(
+        profiles_dir.join("validator-1.0.toml"),
+        r#"
+schema_version = 1
+
+[role]
+id = "validator"
+version = "1.0.0"
+display_name = "Validator"
+category = "agents"
+description = "Test profile with an on_outcome validator hook"
+when_to_use = "Tests"
+
+[runtime]
+recommended_model = "test-model"
+agent_id = "mock"
+
+[[outcomes]]
+id = "pass"
+description = "Rejected by profile hook"
+edge_kind_hint = "forward"
+
+[[outcomes]]
+id = "fixes_needed"
+description = "Accepted fallback"
+edge_kind_hint = "forward"
+
+[[hooks.entries]]
+id = "profile-validator"
+trigger = "on_outcome"
+matcher = { outcome = "pass" }
+command = "exit 1"
+on_failure = "reject"
+timeout_seconds = 5
+
+[prompt]
+system = "test"
+"#,
+    )
+    .unwrap();
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -171,6 +220,97 @@ async fn rejected_outcome_lets_agent_retry_with_different_outcome() {
     }
     assert!(saw_rejection, "missing OutcomeRejectedByHook for 'pass'");
     assert!(saw_outcome, "missing OutcomeReported for 'fixes_needed'");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn profile_on_outcome_hook_rejects_and_retries() {
+    let profiles_dir = tempfile::tempdir().unwrap();
+    drop_profile_with_on_outcome_hook(profiles_dir.path());
+    let disk = DiskProfileSet::scan(profiles_dir.path()).unwrap();
+    let registry = Arc::new(ProfileRegistry::new(disk));
+
+    let dir = tempfile::tempdir().unwrap();
+    let storage = Storage::open(dir.path()).await.unwrap();
+    let run_id = surge_core::id::RunId::new();
+    let writer = storage.create_run(run_id, dir.path(), None).await.unwrap();
+    let artifact_store = surge_persistence::artifacts::ArtifactStore::new(dir.path().join("runs"));
+
+    let mock = Arc::new(MockBridge::new());
+    let bridge: Arc<dyn BridgeFacade> = mock.clone();
+
+    let session_id = SessionId::new();
+    mock.pin_next_session_id(session_id).await;
+    mock.enqueue_event(BridgeEvent::OutcomeReported {
+        session: session_id,
+        outcome: OutcomeKey::from_str("pass").unwrap(),
+        summary: "profile hook rejects this".into(),
+        artifacts_produced: vec![],
+    })
+    .await;
+    mock.enqueue_event(BridgeEvent::OutcomeReported {
+        session: session_id,
+        outcome: OutcomeKey::from_str("fixes_needed").unwrap(),
+        summary: "fallback".into(),
+        artifacts_produced: vec![],
+    })
+    .await;
+
+    let mock_for_pump = mock.clone();
+    let pump = tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        mock_for_pump.pump_scripted_events().await;
+    });
+
+    let dispatcher: Arc<dyn ToolDispatcher> = Arc::new(UnusedDispatcher);
+    let memory = surge_core::run_state::RunMemory::default();
+    let cfg = agent_cfg_with_profile("validator@1.0", vec![], 3);
+    let node = NodeKey::try_from("agent_1").unwrap();
+    let tool_resolutions = Arc::new(tokio::sync::Mutex::new(std::collections::HashMap::new()));
+    let hook_executor = HookExecutor::new();
+
+    let result = execute_agent_stage(AgentStageParams {
+        node: &node,
+        agent_config: &cfg,
+        declared_outcomes: &[],
+        bridge: &bridge,
+        writer: &writer,
+        artifact_store: &artifact_store,
+        worktree_path: dir.path(),
+        tool_dispatcher: &dispatcher,
+        run_memory: &memory,
+        run_id,
+        tool_resolutions: &tool_resolutions,
+        human_input_timeout: Duration::from_secs(5),
+        mcp_registry: None,
+        mcp_servers: Vec::new(),
+        profile_registry: Some(registry),
+        hook_executor: &hook_executor,
+    })
+    .await
+    .expect("stage should complete after profile hook rejection retry");
+
+    pump.await.unwrap();
+    assert_eq!(result.as_str(), "fixes_needed");
+
+    drop(writer);
+
+    let reader = storage.open_run_reader(run_id).await.unwrap();
+    let last = reader.current_seq().await.unwrap();
+    let events = reader
+        .read_events(EventSeq(0)..EventSeq(last.0 + 1))
+        .await
+        .unwrap();
+
+    let saw_profile_rejection = events.into_iter().any(|ev| {
+        matches!(
+            ev.payload.payload,
+            EventPayload::OutcomeRejectedByHook { ref hook_id, .. } if hook_id == "profile-validator"
+        )
+    });
+    assert!(
+        saw_profile_rejection,
+        "profile on_outcome hook should reject the first outcome"
+    );
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/surge-orchestrator/tests/profile_registry_e2e.rs
+++ b/crates/surge-orchestrator/tests/profile_registry_e2e.rs
@@ -22,8 +22,10 @@ use surge_acp::bridge::event::BridgeEvent;
 use surge_acp::bridge::facade::BridgeFacade;
 use surge_core::SessionId;
 use surge_core::agent_config::AgentConfig;
+use surge_core::hooks::{HookFailureMode, HookTrigger};
 use surge_core::id::RunId;
 use surge_core::keys::{NodeKey, OutcomeKey, ProfileKey};
+use surge_core::profile::bundled::BundledRegistry;
 use surge_core::profile::keyref::parse_key_ref;
 use surge_core::profile::registry::Provenance;
 use surge_orchestrator::engine::hooks::HookExecutor;
@@ -112,6 +114,39 @@ fn project_context_author_runtime_id_normalizes_against_acp_registry() {
     assert_eq!(
         acp_registry.normalize_agent_id(&resolved.profile.runtime.agent_id),
         Some("claude-acp".to_string()),
+    );
+}
+
+#[test]
+fn all_bundled_profiles_resolve_and_validator_hooks_are_portable() {
+    let registry = ProfileRegistry::new(DiskProfileSet::empty());
+    let mut validator_hook_count = 0;
+
+    for bundled in BundledRegistry::all() {
+        let profile_ref = format!("{}@{}", bundled.role.id.as_str(), bundled.role.version);
+        let key_ref = parse_key_ref(&profile_ref).unwrap();
+        let resolved = registry
+            .resolve(&key_ref)
+            .unwrap_or_else(|error| panic!("resolve {profile_ref}: {error}"));
+
+        for hook in &resolved.profile.hooks.entries {
+            if !hook.id.starts_with("validate-") {
+                continue;
+            }
+            validator_hook_count += 1;
+            assert_eq!(hook.trigger, HookTrigger::OnOutcome, "{profile_ref}");
+            assert_eq!(hook.on_failure, HookFailureMode::Reject, "{profile_ref}");
+            assert!(
+                hook.command.starts_with("{surge} artifact validate"),
+                "{profile_ref} validator hook should use portable {{surge}} placeholder: {}",
+                hook.command
+            );
+        }
+    }
+
+    assert_eq!(
+        validator_hook_count, 5,
+        "description, roadmap, and spec profiles should register artifact validators"
     );
 }
 

--- a/crates/surge-ui/tests/gate_approval_ui_e2e.rs
+++ b/crates/surge-ui/tests/gate_approval_ui_e2e.rs
@@ -10,6 +10,20 @@
 use std::fs;
 use std::path::PathBuf;
 
+fn unique_test_dir(test_name: &str) -> PathBuf {
+    let nonce = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let temp_dir = std::env::temp_dir().join(format!(
+        "surge-ui-test-{}-{}-{nonce}",
+        std::process::id(),
+        test_name
+    ));
+    fs::create_dir_all(&temp_dir).expect("Failed to create temp dir");
+    temp_dir
+}
+
 /// Test helper to simulate UI gate decision writing.
 ///
 /// This mimics what happens when the user clicks approve/reject in the UI.
@@ -94,10 +108,7 @@ fn verify_ui_decision_file(
 
 #[test]
 fn test_ui_gate_decision_approval_write() {
-    // Create temp directory for test
-    let temp_dir = std::env::temp_dir().join(format!("surge-ui-test-{}", std::process::id()));
-    let _ = fs::remove_dir_all(&temp_dir); // Clean up any previous test
-    fs::create_dir_all(&temp_dir).expect("Failed to create temp dir");
+    let temp_dir = unique_test_dir("approval");
 
     // Simulate UI approval decision
     let task_id = "test-task-001";
@@ -112,10 +123,7 @@ fn test_ui_gate_decision_approval_write() {
 
 #[test]
 fn test_ui_gate_decision_rejection_write() {
-    // Create temp directory for test
-    let temp_dir = std::env::temp_dir().join(format!("surge-ui-test-{}", std::process::id()));
-    let _ = fs::remove_dir_all(&temp_dir); // Clean up any previous test
-    fs::create_dir_all(&temp_dir).expect("Failed to create temp dir");
+    let temp_dir = unique_test_dir("rejection");
 
     // Simulate UI rejection decision
     let task_id = "test-task-002";
@@ -130,10 +138,7 @@ fn test_ui_gate_decision_rejection_write() {
 
 #[test]
 fn test_ui_gate_decision_file_format() {
-    // Create temp directory for test
-    let temp_dir = std::env::temp_dir().join(format!("surge-ui-test-{}", std::process::id()));
-    let _ = fs::remove_dir_all(&temp_dir); // Clean up any previous test
-    fs::create_dir_all(&temp_dir).expect("Failed to create temp dir");
+    let temp_dir = unique_test_dir("file-format");
 
     // Write decision
     let task_id = "test-task-003";
@@ -169,10 +174,7 @@ fn test_ui_gate_decision_file_format() {
 
 #[test]
 fn test_ui_rejection_feedback_file() {
-    // Create temp directory for test
-    let temp_dir = std::env::temp_dir().join(format!("surge-ui-test-{}", std::process::id()));
-    let _ = fs::remove_dir_all(&temp_dir); // Clean up any previous test
-    fs::create_dir_all(&temp_dir).expect("Failed to create temp dir");
+    let temp_dir = unique_test_dir("feedback");
 
     // Simulate writing HUMAN_INPUT.md (as done by gate_approval.rs)
     let task_id = "test-task-004";
@@ -213,9 +215,8 @@ fn test_ui_rejection_feedback_file() {
 
 #[test]
 fn test_ui_gate_decision_directory_creation() {
-    // Create temp directory for test
-    let temp_dir = std::env::temp_dir().join(format!("surge-ui-test-{}", std::process::id()));
-    let _ = fs::remove_dir_all(&temp_dir); // Clean up any previous test
+    let temp_dir = unique_test_dir("directory-creation");
+    fs::remove_dir_all(&temp_dir).expect("Failed to remove temp dir before directory test");
     // Note: Don't create temp_dir initially - test should create it
 
     // Write decision to non-existent directory
@@ -244,10 +245,7 @@ fn test_ui_gate_decision_directory_creation() {
 fn test_ui_decision_orchestrator_compatibility() {
     use serde_json;
 
-    // Create temp directory for test
-    let temp_dir = std::env::temp_dir().join(format!("surge-ui-test-{}", std::process::id()));
-    let _ = fs::remove_dir_all(&temp_dir); // Clean up any previous test
-    fs::create_dir_all(&temp_dir).expect("Failed to create temp dir");
+    let temp_dir = unique_test_dir("orchestrator-compatibility");
 
     // Write UI decision
     let task_id = "test-task-006";

--- a/crates/surge-ui/tests/gate_approval_ui_e2e.rs
+++ b/crates/surge-ui/tests/gate_approval_ui_e2e.rs
@@ -9,14 +9,18 @@
 
 use std::fs;
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+static TEST_DIR_SEQ: AtomicU64 = AtomicU64::new(0);
 
 fn unique_test_dir(test_name: &str) -> PathBuf {
     let nonce = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap()
         .as_nanos();
+    let seq = TEST_DIR_SEQ.fetch_add(1, Ordering::Relaxed);
     let temp_dir = std::env::temp_dir().join(format!(
-        "surge-ui-test-{}-{}-{nonce}",
+        "surge-ui-test-{}-{}-{nonce}-{seq}",
         std::process::id(),
         test_name
     ));

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,7 @@ Detailed docs for the Surge workspace. The project landing page is [`README.md`]
 | [Workflow](workflow.md) | AFK workflow, flow model, intake sources, run lifecycle |
 | [Architecture](ARCHITECTURE.md) | Canonical architecture: positioning, principles, engine, ACP bridge, storage |
 | [Hooks](hooks.md) | `pre_tool_use` / `post_tool_use` / `on_outcome` / `on_error` lifecycle, matcher, failure modes |
+| [Artifact Conventions](conventions/README.md) | Canonical generated artifact names, schemas, validators, and examples |
 | [Archetypes](archetypes.md) | Bundled `flow.toml` archetypes with mermaid diagrams |
 | [Development](development.md) | `cargo` checks, ignored long-running tests, local runtime state |
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -17,6 +17,7 @@ surge spec ...          manage legacy specs
 surge run ...           execute the legacy spec pipeline
 surge bootstrap ...     generate an adaptive flow from a free-form prompt
 surge engine ...        execute flow.toml graphs
+surge artifact ...      validate generated artifacts against Surge contracts
 surge daemon ...        manage the long-running local engine host
 surge clean             clean up orphaned worktrees and merged branches
 surge worktrees         list active worktrees
@@ -63,6 +64,22 @@ The product model in [`docs/ARCHITECTURE.md`](ARCHITECTURE.md) describes a riche
 
 Bundled templates live in the binary; user templates under `${SURGE_HOME}/templates/*.toml` shadow bundled templates by filename stem or `metadata.name`.
 
+## Artifact Validation
+
+Generated role artifacts can be validated directly:
+
+```text
+surge artifact validate --kind description description.md
+surge artifact validate --kind roadmap roadmap.toml
+surge artifact validate --kind spec spec.toml
+surge artifact validate --kind flow flow.toml
+```
+
+Use `--format json` for structured diagnostics. The same validator surface is
+used by bundled profile `on_outcome` hooks for description, roadmap, and spec
+artifacts. See [Artifact Conventions](conventions/README.md) for every
+canonical path and minimal example.
+
 ## Project Initialization And Context
 
 `surge init --default` is the non-interactive setup path. It writes a complete validated `surge.toml`, chooses the best detected ACP registry agent when possible, and keeps an existing config unchanged. `surge init` without flags enters the wizard and can update onboarding sections in an existing config while preserving unrelated TOML content.
@@ -93,5 +110,6 @@ surge feature ...       amend roadmap with a new feature
 ## See Also
 
 - [Getting Started](getting-started.md) — install Surge and run the first flow
+- [Artifact Conventions](conventions/README.md) — generated artifact contracts and validator examples
 - [Workflow](workflow.md) — how runs are bootstrapped, executed, and logged
 - [Architecture](ARCHITECTURE.md) — the canonical architecture document

--- a/docs/conventions/README.md
+++ b/docs/conventions/README.md
@@ -1,0 +1,34 @@
+# Artifact Conventions
+
+Surge owns the shape of role artifacts so agents can reason freely while the
+engine, validators, hooks, and future UI surfaces can treat outputs
+consistently. The source of truth in code is `surge_core::artifact_contract`.
+
+Validate any artifact with:
+
+```bash
+surge artifact validate --kind <kind> <path>
+```
+
+Validator hooks run from the run worktree. Successful validation is logged at
+DEBUG by hook/CLI callers; failures are surfaced as short diagnostics and
+profile-level `on_outcome` hooks reject the outcome before it is persisted.
+
+| Kind | Canonical artifact | Primary format | Compatibility artifact | Guide |
+|---|---|---|---|---|
+| Description | `description.md` | Markdown | none | [Description](description.md) |
+| Requirements | `requirements.md` | Markdown | none | [Requirements](requirements.md) |
+| Roadmap | `roadmap.toml` | TOML | `roadmap.md` | [Roadmap](roadmap.md) |
+| Spec | `spec.toml` | TOML | `spec.md` | [Spec](spec.md) |
+| ADR | `docs/adr/<NNNN>-<slug>.md` | Markdown | none | [ADR](adr.md) |
+| Story | `stories/story-NNN.md` | Markdown | none | [Story](story.md) |
+| Plan | `plan.md` | Markdown | none | [Plan](plan.md) |
+| Flow | `flow.toml` | TOML graph | none | [Flow](flow.md) |
+
+## Authoring Rules
+
+- Use schema version `1` for TOML artifacts owned by the artifact contract.
+- Use `schema_version = 1` for `flow.toml`; that version is owned by the graph schema.
+- Keep Markdown headings stable. Validators match required section headings.
+- Keep artifact paths relative to the run worktree.
+- Do not include secrets or full logs in validation diagnostics.

--- a/docs/conventions/adr.md
+++ b/docs/conventions/adr.md
@@ -1,0 +1,48 @@
+# ADR Artifact
+
+Architect writes ADRs for decisions that affect multiple modules, public
+contracts, or future work.
+
+Path pattern: `docs/adr/<NNNN>-<slug>.md`  
+Validator kind: `adr`  
+Schema version: none; TOML frontmatter plus Markdown body.
+
+## Minimal Valid Example
+
+```markdown
++++
+status = "accepted"
+deciders = ["core maintainers"]
+date = "2026-05-11"
++++
+
+# ADR 0001: Validate Generated Artifacts
+
+## Status
+Accepted.
+
+## Context
+Agent outputs need stable shapes before downstream stages consume them.
+
+## Decision
+Use Surge-owned artifact contracts with pure validators and hook enforcement.
+
+## Alternatives considered
+- Keep conventions in prompts only; rejected because prompts drift.
+- Validate only in CI; rejected because bad outputs would already affect runs.
+
+## Consequences
+Generated artifacts can be rejected before persistence, but profile authors must keep hooks current.
+```
+
+## Checklist
+
+- Path starts with `docs/adr/` and uses a four-digit number.
+- TOML frontmatter is delimited by `+++`.
+- Frontmatter includes `status`, `deciders`, and `date`.
+- Body has `## Status`, `## Context`, `## Decision`, `## Alternatives considered`, and `## Consequences`.
+
+## Profile Guidance
+
+Architect should report `drafted` only when it writes an ADR. If no durable
+decision is needed, report `no_decision_needed` and do not create a placeholder.

--- a/docs/conventions/adr.md
+++ b/docs/conventions/adr.md
@@ -3,8 +3,8 @@
 Architect writes ADRs for decisions that affect multiple modules, public
 contracts, or future work.
 
-Path pattern: `docs/adr/<NNNN>-<slug>.md`  
-Validator kind: `adr`  
+Path pattern: `docs/adr/<NNNN>-<slug>.md`
+Validator kind: `adr`
 Schema version: none; TOML frontmatter plus Markdown body.
 
 ## Minimal Valid Example

--- a/docs/conventions/description.md
+++ b/docs/conventions/description.md
@@ -1,0 +1,40 @@
+# Description Artifact
+
+`description.md` is the first bootstrap artifact. It turns the user's request
+into stable context for planners and generators.
+
+Path: `description.md`  
+Validator kind: `description`  
+Schema version: none; human-readable Markdown contract.
+
+## Minimal Valid Example
+
+```markdown
+# Description
+
+## Goal
+Add artifact validators so generated role outputs can be checked before the run advances.
+
+## Context
+Surge already has bundled profiles, hooks, and graph validation.
+
+## Requirements
+- Validate malformed outputs before downstream stages consume them.
+- Keep diagnostics short and safe to show in operator surfaces.
+
+## Out of Scope
+- Removing legacy `surge-spec`.
+```
+
+## Checklist
+
+- `## Goal` explains the what and why in one short paragraph.
+- `## Context` names the existing project surface touched by the request.
+- `## Requirements` uses testable bullets.
+- `## Out of Scope` states what will not be done.
+
+## Profile Guidance
+
+Description Author should write only `description.md` and report
+`artifacts_produced = ["description.md"]`. Its bundled `on_outcome` hook rejects
+`drafted` when this contract fails.

--- a/docs/conventions/description.md
+++ b/docs/conventions/description.md
@@ -3,8 +3,8 @@
 `description.md` is the first bootstrap artifact. It turns the user's request
 into stable context for planners and generators.
 
-Path: `description.md`  
-Validator kind: `description`  
+Path: `description.md`
+Validator kind: `description`
 Schema version: none; human-readable Markdown contract.
 
 ## Minimal Valid Example

--- a/docs/conventions/flow.md
+++ b/docs/conventions/flow.md
@@ -1,0 +1,47 @@
+# Flow Artifact
+
+`flow.toml` is the executable workflow graph consumed by the engine.
+
+Path: `flow.toml`  
+Validator kind: `flow`  
+Schema version: `schema_version = 1`, owned by the graph schema.
+
+## Minimal Valid Example
+
+```toml
+schema_version = 1
+start = "end"
+edges = []
+
+[metadata]
+name = "single-terminal"
+created_at = "2026-05-11T00:00:00Z"
+
+[nodes.end]
+id = "end"
+declared_outcomes = []
+
+[nodes.end.position]
+x = 0.0
+y = 0.0
+
+[nodes.end.config]
+node_kind = "terminal"
+
+[nodes.end.config.kind]
+type = "success"
+```
+
+## Checklist
+
+- Top-level `schema_version = 1` is present.
+- `[metadata]`, `start`, `[nodes]`, and `edges` are present.
+- Every non-terminal node has declared outcomes and reaches a terminal node.
+- Agent nodes reference profiles like `implementer@1.0`, not free-form prompts.
+- Bundled archetypes include `feature`, `bug-fix`, `refactor`, `performance`, `security`, `docs`, and `migration`.
+
+## Profile Guidance
+
+Flow Generator writes only `flow.toml`. Its validation uses the specialized
+bootstrap retry path so invalid graphs produce `BootstrapEditRequested` feedback
+instead of a second generic `on_outcome` rejection path.

--- a/docs/conventions/flow.md
+++ b/docs/conventions/flow.md
@@ -2,8 +2,8 @@
 
 `flow.toml` is the executable workflow graph consumed by the engine.
 
-Path: `flow.toml`  
-Validator kind: `flow`  
+Path: `flow.toml`
+Validator kind: `flow`
 Schema version: `schema_version = 1`, owned by the graph schema.
 
 ## Minimal Valid Example

--- a/docs/conventions/plan.md
+++ b/docs/conventions/plan.md
@@ -3,8 +3,8 @@
 Plan artifacts break a bounded implementation into executable tasks. AI Factory
 plans live under `.ai-factory/plans/`; generic role plans may use `plan.md`.
 
-Path: `plan.md`  
-Validator kind: `plan`  
+Path: `plan.md`
+Validator kind: `plan`
 Schema version: none; human-readable Markdown contract.
 
 ## Minimal Valid Example

--- a/docs/conventions/plan.md
+++ b/docs/conventions/plan.md
@@ -1,0 +1,34 @@
+# Plan Artifact
+
+Plan artifacts break a bounded implementation into executable tasks. AI Factory
+plans live under `.ai-factory/plans/`; generic role plans may use `plan.md`.
+
+Path: `plan.md`  
+Validator kind: `plan`  
+Schema version: none; human-readable Markdown contract.
+
+## Minimal Valid Example
+
+```markdown
+# Implementation Plan
+
+## Settings
+- Testing: yes
+- Docs: yes
+
+## Tasks
+- [ ] Task 1: Add validator fixtures.
+- [ ] Task 2: Run focused tests.
+```
+
+## Checklist
+
+- `## Settings` names relevant execution policy.
+- `## Tasks` contains checkboxes that can be updated as work progresses.
+- Tasks are ordered by dependency and small enough to verify.
+- Do not use a plan as a substitute for `spec.toml` acceptance criteria.
+
+## Profile Guidance
+
+Use plans for execution control and progress tracking. Use Spec artifacts for
+the durable contract of what must be true when work is done.

--- a/docs/conventions/requirements.md
+++ b/docs/conventions/requirements.md
@@ -1,0 +1,44 @@
+# Requirements Artifact
+
+`requirements.md` captures product requirements when a run needs a more formal
+requirements surface than the bootstrap description.
+
+Path: `requirements.md`  
+Validator kind: `requirements`  
+Schema version: none; human-readable Markdown contract.
+
+## Minimal Valid Example
+
+```markdown
+# Requirements
+
+## Overview
+Operators need artifact validation before accepting generated plans.
+
+## User Stories
+- As an operator, I can see why a generated artifact was rejected.
+
+## Functional Requirements
+- The CLI validates canonical artifact paths.
+- The hook stderr contains stable diagnostic codes.
+
+## Success Criteria
+- Invalid schema versions fail validation.
+- Valid minimal artifacts pass validation.
+
+## Out of Scope
+- Live agent quality scoring.
+```
+
+## Checklist
+
+- `## Overview` summarizes the need.
+- `## User Stories` frames user value.
+- `## Functional Requirements` lists concrete behavior.
+- `## Success Criteria` lists measurable pass/fail checks.
+- `## Out of Scope` limits the work.
+
+## Profile Guidance
+
+Use this artifact when the run needs product-level requirements before roadmap
+planning. Keep implementation details for Spec artifacts.

--- a/docs/conventions/requirements.md
+++ b/docs/conventions/requirements.md
@@ -3,8 +3,8 @@
 `requirements.md` captures product requirements when a run needs a more formal
 requirements surface than the bootstrap description.
 
-Path: `requirements.md`  
-Validator kind: `requirements`  
+Path: `requirements.md`
+Validator kind: `requirements`
 Schema version: none; human-readable Markdown contract.
 
 ## Minimal Valid Example

--- a/docs/conventions/roadmap.md
+++ b/docs/conventions/roadmap.md
@@ -1,0 +1,61 @@
+# Roadmap Artifacts
+
+Roadmap Planner emits a machine-readable `roadmap.toml` plus human-compatible
+`roadmap.md`.
+
+Primary path: `roadmap.toml`  
+Compatibility path: `roadmap.md`  
+Validator kind: `roadmap`  
+Schema version: `schema_version = 1`, owned by the artifact contract.
+
+## Minimal Valid TOML
+
+```toml
+schema_version = 1
+
+[[milestones]]
+id = "artifact-validation"
+title = "Artifact validation"
+
+[[milestones.tasks]]
+id = "validators"
+title = "Add validators"
+description = "Validate canonical generated artifacts."
+acceptance_criteria = ["Invalid schema versions fail", "Valid fixtures pass"]
+
+[[dependencies]]
+from = "artifact-validation"
+to = "hook-enforcement"
+reason = "Hooks need validators to call."
+
+[[risks]]
+description = "Validators drift from prompts."
+mitigation = "Keep profile prompts linked to this convention."
+```
+
+## Minimal Valid Markdown
+
+```markdown
+# Roadmap
+
+## Milestones
+- Artifact validation
+
+## Dependencies
+- Artifact validation before hook enforcement.
+
+## Risks
+- Validators may reject legacy output.
+```
+
+## Checklist
+
+- TOML has top-level `schema_version = 1`.
+- TOML has one or more `[[milestones]]`.
+- Tasks include clear titles and testable acceptance criteria when known.
+- Markdown compatibility view has `## Milestones`, `## Dependencies`, and `## Risks`.
+
+## Profile Guidance
+
+Roadmap Planner should report both `roadmap.toml` and `roadmap.md`. The bundled
+profile validates both artifacts on `drafted`.

--- a/docs/conventions/roadmap.md
+++ b/docs/conventions/roadmap.md
@@ -3,9 +3,9 @@
 Roadmap Planner emits a machine-readable `roadmap.toml` plus human-compatible
 `roadmap.md`.
 
-Primary path: `roadmap.toml`  
-Compatibility path: `roadmap.md`  
-Validator kind: `roadmap`  
+Primary path: `roadmap.toml`
+Compatibility path: `roadmap.md`
+Validator kind: `roadmap`
 Schema version: `schema_version = 1`, owned by the artifact contract.
 
 ## Minimal Valid TOML

--- a/docs/conventions/spec.md
+++ b/docs/conventions/spec.md
@@ -3,9 +3,9 @@
 Spec Author emits a typed `spec.toml` plus a human-compatible `spec.md` for a
 single milestone or bounded task set.
 
-Primary path: `spec.toml`  
-Compatibility path: `spec.md`  
-Validator kind: `spec`  
+Primary path: `spec.toml`
+Compatibility path: `spec.md`
+Validator kind: `spec`
 Schema version: `schema_version = 1`, owned by the artifact contract.
 
 ## Minimal Valid TOML

--- a/docs/conventions/spec.md
+++ b/docs/conventions/spec.md
@@ -1,0 +1,63 @@
+# Spec Artifacts
+
+Spec Author emits a typed `spec.toml` plus a human-compatible `spec.md` for a
+single milestone or bounded task set.
+
+Primary path: `spec.toml`  
+Compatibility path: `spec.md`  
+Validator kind: `spec`  
+Schema version: `schema_version = 1`, owned by the artifact contract.
+
+## Minimal Valid TOML
+
+```toml
+schema_version = 1
+
+[spec]
+id = "artifact-validation"
+title = "Artifact validation"
+description = "Define and enforce generated artifact contracts."
+complexity = "medium"
+
+[[spec.subtasks]]
+id = "core-contracts"
+title = "Core contracts"
+description = "Add pure contract metadata and diagnostics."
+complexity = "small"
+files = ["crates/surge-core/src/artifact_contract.rs"]
+
+[[spec.subtasks.acceptance_criteria]]
+description = "Valid minimal artifacts pass validation."
+```
+
+## Minimal Valid Markdown
+
+```markdown
+# Spec
+
+## Goal
+Enforce artifact contracts before downstream stages consume outputs.
+
+## Subtasks
+1. Add pure validators.
+   - Acceptance criteria: valid fixtures pass.
+
+## Acceptance Criteria
+- [ ] Invalid schema versions fail with stable diagnostics.
+
+## Constraints
+- Core validators stay pure and do not read files.
+```
+
+## Checklist
+
+- TOML has top-level `schema_version = 1`.
+- `[spec]` contains identity, title, description, complexity, and subtasks.
+- Each subtask has machine-readable acceptance criteria.
+- Markdown has `## Goal`, `## Subtasks`, and `## Acceptance Criteria`.
+- Long context belongs in `stories/story-NNN.md`.
+
+## Profile Guidance
+
+Spec Author should report `artifacts_produced = ["spec.toml", "spec.md"]`.
+The bundled profile validates both artifacts on `drafted`.

--- a/docs/conventions/story.md
+++ b/docs/conventions/story.md
@@ -1,0 +1,44 @@
+# Story Artifact
+
+Story files carry long-form subtask context that would make `spec.toml` too
+large or prose-heavy.
+
+Path pattern: `stories/story-NNN.md`  
+Validator kind: `story`  
+Schema version: none; human-readable Markdown contract.
+
+## Minimal Valid Example
+
+```markdown
+# Story 001
+
+## Context
+The CLI validator needs examples that cover invalid graph shapes.
+
+## What needs to be done
+Add fixture-driven validation tests.
+
+## Architecture decisions
+Keep pure validation in `surge-core`; compose graph checks in the CLI.
+
+## Files to modify
+- `crates/surge-core/src/artifact_contract.rs`
+
+## Acceptance criteria
+- Invalid fixtures emit stable diagnostic codes.
+
+## Out of scope
+- Live agent comparison tests.
+```
+
+## Checklist
+
+- Filename uses three digits, for example `stories/story-001.md`.
+- All six required sections are present.
+- Acceptance criteria are concrete and testable.
+- The story references files or modules without duplicating implementation code.
+
+## Profile Guidance
+
+Spec Author may create story files and reference them from `spec.toml` through
+`story_file = "stories/story-NNN.md"`.

--- a/docs/conventions/story.md
+++ b/docs/conventions/story.md
@@ -3,8 +3,8 @@
 Story files carry long-form subtask context that would make `spec.toml` too
 large or prose-heavy.
 
-Path pattern: `stories/story-NNN.md`  
-Validator kind: `story`  
+Path pattern: `stories/story-NNN.md`
+Validator kind: `story`
 Schema version: none; human-readable Markdown contract.
 
 ## Minimal Valid Example

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -83,9 +83,18 @@ The canonical first useful run is bootstrap:
 cargo run -p surge-cli --bin surge -- bootstrap "add a small health-check command to this project"
 ```
 
-Bootstrap generates `description.md`, `roadmap.md`, and `flow.toml`, asks for
-console approval after each artifact, then starts the generated follow-up graph.
+Bootstrap generates `description.md`, `roadmap.toml`, `roadmap.md`, and
+`flow.toml`, asks for console approval after each artifact, then starts the
+generated follow-up graph.
 See [Bootstrap](bootstrap.md) for the edit loop, archetypes, and resume path.
+
+You can validate generated artifacts directly while debugging a run:
+
+```bash
+cargo run -p surge-cli --bin surge -- artifact validate --kind description description.md
+cargo run -p surge-cli --bin surge -- artifact validate --kind roadmap roadmap.toml
+cargo run -p surge-cli --bin surge -- artifact validate --kind flow flow.toml
+```
 
 ## Run the Minimal Agent Graph
 
@@ -110,6 +119,7 @@ For setup troubleshooting, run commands with `RUST_LOG=surge=debug` to see agent
 ## See Also
 
 - [CLI](cli.md) — full `surge` command surface and current-to-target mapping
+- [Artifact Conventions](conventions/README.md) — generated artifact names, schemas, and validator examples
 - [Bootstrap](bootstrap.md) — adaptive flow generation from a free-form prompt
 - [Workflow](workflow.md) — how a run flows through bootstrap, the engine, and the event log
 - [Development](development.md) — running tests, lints, and ignored long-running checks


### PR DESCRIPTION
## Summary

Adds the artifact format and convention library milestone:

- defines canonical artifact contracts, typed roadmap/spec wrappers, and pure validators in `surge-core`
- adds `surge artifact validate` with flow graph validation composed in the CLI layer
- registers new bundled convention flow templates and legacy aliases
- wires profile-level produced artifact declarations and portable `on_outcome` validation hooks
- documents artifact conventions and adds golden fixtures/regression coverage

## Validation

- `cargo test --workspace --exclude surge-ui`
- `cargo clippy --workspace --all-targets --all-features`
- `cargo fmt --check`
- `git diff --check`

## Notes

Flow Generator keeps its specialized bootstrap validation retry path; generic profile validator hooks are applied to Description, Roadmap, and Spec artifacts to avoid duplicate flow retry behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `surge artifact validate` CLI command with human-readable and JSON output formats for validating artifact contents and paths.
  * Added five new bundled workflow templates (feature, performance, security, docs, migration) with legacy alias support.
  * Integrated artifact contract validation into profile-driven hooks to reject invalid outputs before persistence.

* **Documentation**
  * Added comprehensive artifact conventions guide covering canonical paths, formats, and validation rules.
  * Updated CLI documentation with artifact validation examples.
  * Enhanced getting-started guide with artifact validation troubleshooting.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vanyastaff/surge/pull/53)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->