### PR TITLE
[codex] add roadmap amendment workflow

### DIFF
--- a/.ai-factory/ROADMAP.md
+++ b/.ai-factory/ROADMAP.md
@@ -265,3 +265,4 @@
 | Bootstrap & adaptive flow generation | 2026-05-09 |
 | Project initialization & stable context | 2026-05-10 |
 | Artifact format & convention library | 2026-05-11 |
+| Roadmap amendments via `surge feature` | 2026-05-11 |

--- a/.ai-factory/ROADMAP.md
+++ b/.ai-factory/ROADMAP.md
@@ -99,23 +99,22 @@
   - Artifact authoring guide for new role types in `docs/`
   - Validator failure UX: schema-rejected outputs surface a concise diff in Telegram cards so the user sees *what failed*
 
-- [ ] **Roadmap amendments via `surge feature`** — live mutation of an active roadmap or follow-up runs from a completed one (touches `surge-cli`, `surge-orchestrator`, `surge-core`, `surge-persistence`, `surge-notify`)
-  - `surge feature describe <prompt>` opens a chat session with Feature Planner profile to clarify scope before patch generation
-  - Feature Planner produces a `RoadmapPatch`: insertion point (which milestone, which position), new milestone / task items, dependencies, rationale
-  - `RoadmapPatch` is a typed structure in `surge-core` with `schema_version`
-  - HumanGate on patch before apply: approve / edit / reject with redo loop
-  - Approved patch applied to `roadmap.md`: versioned suffix (`vNext`) or commit-based history; original preserved for replay
-  - Approved patch applied to active `flow.toml`: new milestone / task nodes inserted, edges rewired, validation re-run, rollback on validation failure
-  - New `RoadmapUpdated` event in `surge-core` event types (joins `RunStarted`, `StageEntered`, etc.)
-  - Active runner detection: daemon checks if a run is currently executing this roadmap via run-status query
-  - If active and roadmap-flow execution enabled: emit `RoadmapUpdated`; runner picks up new pending work in next outer milestone Loop iteration
-  - If terminal or roadmap-flow disabled: spawn follow-up run from the appended portion only — completed history is never mutated
-  - Idempotency: re-applying the same `RoadmapPatch` is a no-op (content-hash dedup)
-  - Conflict detection: patch referencing a milestone that's already running surfaces a clear conflict to user with options (defer to next milestone, abort current, follow-up run)
-  - Telegram surface: notification card on patch approval, runner pickup, or follow-up run creation
-  - CLI mirrors: `surge feature list` (pending patches), `surge feature show <id>`, `surge feature reject <id>`
-  - Integration tests: amendment during running roadmap, amendment after terminal roadmap, malformed patch rejection, conflicting patch on running milestone
-  - Documentation: amendment lifecycle diagram in `docs/workflow.md`-aligned format
+- [x] **Roadmap amendments via `surge feature`** — live mutation of an active roadmap or follow-up runs from a completed one (touches `surge-cli`, `surge-orchestrator`, `surge-core`, `surge-persistence`, `surge-notify`)
+  - `surge feature describe <prompt>` runs the Feature Planner profile against a project or run roadmap target and stores a normalized `roadmap-patch.toml`
+  - Feature Planner produces a typed `RoadmapPatch`: insertion point, new milestone/task items, dependencies, rationale, conflicts, and lifecycle status
+  - `RoadmapPatch` is a typed structure in `surge-core` with `schema_version`, validation, content hashing, and pure apply semantics
+  - Patch approval loop records approve / edit / reject decisions with optional conflict choices and an edit-loop cap
+  - Approved typed project-roadmap patches apply to the selected roadmap artifact/file and preserve replay through content-addressed artifacts and events
+  - Approved active-flow patches can produce graph revisions with new milestone/task nodes, rewired edges, validation, and rollback-on-failure semantics
+  - `RoadmapPatchDrafted`, `RoadmapPatchApprovalRequested`, `RoadmapPatchApprovalDecided`, `RoadmapPatchApplied`, `RoadmapUpdated`, and `GraphRevisionAccepted` events live in `surge-core`
+  - Target resolver detects project, active-run, deferred, and terminal-run amendment points from registry/run status and artifact views
+  - Active runners observe accepted graph revisions at safe boundaries; terminal or follow-up-only targets create follow-up run requests from appended work
+  - Idempotency: registry-level content-hash dedup keeps duplicate `RoadmapPatch` rows stable
+  - Conflict detection: running/completed roadmap conflicts surface stable codes and operator choices: defer to next milestone, abort current run, create follow-up run, or reject patch
+  - Notification payloads cover patch approval, apply, runner pickup, follow-up run creation, conflicts, and rejection; Telegram can render richer cards from the same schema later
+  - CLI mirrors: `surge feature list`, `surge feature show <id>`, `surge feature reject <id>`, plus `--conflict-choice` on describe/reject
+  - Regression tests cover malformed patch rejection, duplicate idempotency, running conflicts, follow-up request creation, CLI mirrors, replay/snapshot views, and notification rendering
+  - Documentation: amendment lifecycle and command reference live in `docs/workflow.md`, `docs/cli.md`, and `docs/conventions/roadmap.md`
 
 - [ ] **Legacy pipeline retirement** — remove `surge-spec` crate and the parallel-execution path in `surge-orchestrator` (touches `surge-spec`, `surge-orchestrator`, `surge-cli`, workspace root)
   - **Parity checklist** completed before any deletion: every behavior of the legacy pipeline has a verified equivalent in the graph executor

--- a/.ai-factory/plans/roadmap-amendments-surge-feature.md
+++ b/.ai-factory/plans/roadmap-amendments-surge-feature.md
@@ -1,0 +1,218 @@
+# Implementation Plan: Roadmap Amendments via `surge feature`
+
+Branch: feature/roadmap-amendments-surge-feature
+Created: 2026-05-11
+Refined: 2026-05-11
+
+## Settings
+- Testing: yes
+- Logging: verbose
+- Docs: yes
+
+## Roadmap Linkage
+Milestone: "Roadmap amendments via `surge feature`"
+Rationale: This is the next unchecked roadmap milestone after the artifact convention library and depends on the newly merged profile artifact contracts.
+
+## Scope
+Add a typed amendment lifecycle for follow-up feature requests: `surge feature describe <prompt>` runs the bundled Feature Planner profile, produces and validates a `roadmap-patch.toml`, routes it through human approval, applies approved changes to the active or completed roadmap, and either updates an active roadmap-flow run or starts a follow-up run from the appended work.
+
+Non-goals:
+- Do not add new `NodeKind` variants; use existing Agent, HumanGate, Loop, Subgraph, Notify, and Terminal semantics.
+- Do not mutate completed run history. Completed artifacts stay replayable; approved amendments are appended as new events and/or follow-up run inputs.
+- Do not make tracker status changes part of this milestone; tracker automation tiers remain a later milestone.
+- Do not build the final Telegram cockpit UX here; add structured notification payloads and minimal delivery hooks that the later Telegram milestone can render richly.
+- Do not retire `surge-spec`; legacy cleanup remains a separate roadmap milestone.
+
+## Commit Plan
+- **Commit 1** (after tasks 1-5): "feat(core): define roadmap patch contracts"
+- **Commit 2** (after tasks 6-9): "feat(feature): draft and store roadmap patches"
+- **Commit 3** (after tasks 10-15): "feat(engine): apply roadmap amendments"
+- **Commit 4** (after tasks 16-19): "feat(cli): expose feature amendment workflow"
+- **Commit 5** (after tasks 20-22): "docs: document roadmap amendment lifecycle"
+
+## Tasks
+
+### Phase 1: Core Contract And Validation
+- [x] Task 1: Define typed `RoadmapPatch` structures in `surge-core`.
+  Deliverable: add a pure domain model for `RoadmapPatch`, `RoadmapPatchId`, `RoadmapPatchTarget`, `InsertionPoint`, patch operations, dependencies, rationale, conflict metadata, patch status, and schema version.
+  Expected behavior: the model can represent inserting new milestones, inserting tasks into existing milestones, replacing draft-only items, dependency edges, conflict metadata, operator conflict choices, and a stable content hash for idempotency.
+  Files: `crates/surge-core/src/roadmap_patch.rs`, `crates/surge-core/src/lib.rs`, `crates/surge-core/src/roadmap.rs`.
+  Logging requirements: no runtime logging in `surge-core`; expose stable IDs, content hashes, and validation codes so callers can log patch lifecycle at DEBUG/INFO/WARN without parsing prose.
+  Dependency notes: foundational for all later tasks; keep `surge-core` pure with no filesystem, `tokio`, `tracing`, or database access.
+
+- [x] Task 2: Register RoadmapPatch as a first-class artifact contract.
+  Deliverable: extend `ArtifactKind`, parser aliases, the contract matrix, diagnostics, and CLI kind handling so `roadmap-patch.toml` is a first-class artifact rather than an ad hoc TOML file.
+  Expected behavior: `surge artifact validate --kind roadmap-patch roadmap-patch.toml` accepts minimal valid patches and rejects malformed TOML, missing insertion point, empty item sets, unsupported schema versions, and dependency references that cannot be resolved against a supplied roadmap context when context is available.
+  Files: `crates/surge-core/src/artifact_contract.rs`, `crates/surge-cli/src/commands/artifact.rs`, `crates/surge-core/tests/` or inline tests, `crates/surge-orchestrator/tests/fixtures/artifacts/`.
+  Logging requirements: CLI/orchestrator callers log validation start/end at DEBUG, invalid patch summaries at WARN, and never log the full patch body unless it is a synthetic test fixture.
+  Dependency notes: depends on task 1; reuse existing artifact validation style from the artifact convention milestone.
+
+- [x] Task 3: Wire Feature Planner profile output declarations and sandbox mode.
+  Deliverable: update `feature-planner-1.0.toml` so `patched` declares `roadmap-patch.toml` as a produced artifact with the RoadmapPatch contract, plus a reject-mode validator hook where applicable. Change the profile sandbox from `read-only` to the narrowest write-capable mode required to create the patch artifact.
+  Expected behavior: the engine rejects malformed Feature Planner output before treating the outcome as usable, `out_of_scope` remains a non-patch outcome, and the profile can actually write its declared artifact inside the worktree.
+  Files: `crates/surge-core/bundled/profiles/feature-planner-1.0.toml`, `crates/surge-core/src/profile/bundled.rs`, `crates/surge-orchestrator/tests/profile_registry_e2e.rs`.
+  Logging requirements: resolved profile artifact contracts log at DEBUG with profile id, outcome id, artifact kind, path, and schema version; rejection logs stay concise.
+  Dependency notes: depends on task 2 and the existing profile artifact validation infrastructure.
+
+- [x] Task 4: Add roadmap amendment event types.
+  Deliverable: extend `EventPayload` with `RoadmapPatchDrafted`, `RoadmapPatchApprovalRequested`, `RoadmapPatchApprovalDecided`, `RoadmapPatchApplied`, and `RoadmapUpdated` or an equivalent compact event set that captures the same lifecycle.
+  Expected behavior: event payloads round-trip through the existing JSON/bincode facade, expose stable discriminants, keep replay deterministic, and do not embed full patch text when a content hash/reference is enough.
+  Files: `crates/surge-core/src/run_event.rs`, `crates/surge-core/src/run_state.rs`, migration tests if needed.
+  Logging requirements: event writers log patch id, run id, target, decision, and hash at INFO; validation/conflict failures log at WARN with stable reason codes.
+  Dependency notes: depends on task 1. Preserve backward compatibility for old event logs.
+
+- [x] Task 5: Update event fold, materialized views, and replay readers for amendment events.
+  Deliverable: decide which new roadmap amendment events are fold-visible, which update materialized SQL views, and which are explicit replay no-ops. Add reader/view APIs where CLI and notifications need patch lifecycle queries.
+  Expected behavior: `RunMemory` captures patch/applied roadmap state only when needed for deterministic execution; `views::maintain` handles or explicitly ignores each new event; event-log rebuilds reproduce the same patch registry/read model after restart.
+  Files: `crates/surge-core/src/run_state.rs`, `crates/surge-persistence/src/runs/views.rs`, `crates/surge-persistence/src/runs/reader_views.rs`, `crates/surge-persistence/src/runs/types.rs`, `crates/surge-persistence/src/runs/mod.rs`, persistence tests.
+  Logging requirements: storage layer logs migrations/view rebuild failures at ERROR through existing surfaces; amendment-specific writers log patch id and lifecycle transition at DEBUG/INFO above the persistence layer.
+  Dependency notes: depends on task 4 and blocks CLI `list/show/reject` reliability.
+
+### Phase 2: Patch Drafting And Approval Flow
+- [x] Task 6: Build a reusable Feature Planner execution driver through existing agent-stage semantics.
+  Deliverable: add an orchestrator helper that runs the Feature Planner as an agent stage or ephemeral graph so produced artifact declarations, profile hooks, sandbox intent, and outcome validation are reused rather than reimplemented.
+  Expected behavior: the driver works with the mock ACP bridge in tests, binds `request` and `roadmap`, collects `roadmap-patch.toml`, validates it through the same artifact contract path as normal agent stages, retries on validator rejection, and returns a typed patch or `out_of_scope`.
+  Files: `crates/surge-orchestrator/src/feature_driver.rs` or `crates/surge-orchestrator/src/roadmap_amendment.rs`, `crates/surge-orchestrator/src/lib.rs`, `crates/surge-orchestrator/tests/feature_planner_driver_test.rs`.
+  Logging requirements: DEBUG for profile resolution, session open/close, binding paths, and artifact discovery; INFO for drafted patch id/hash; WARN for out-of-scope or invalid output; ERROR for ACP/session failures.
+  Dependency notes: depends on tasks 1-3; follow patterns from `project_context.rs`, `bootstrap_driver.rs`, and agent-stage artifact reading.
+
+- [x] Task 7: Store patch artifacts and amended artifacts through the artifact store.
+  Deliverable: persist `roadmap-patch.toml`, amended `roadmap.toml`/`roadmap.md`, and amended or follow-up `flow.toml` via the existing content-addressed artifact store and emit hash/path references in events.
+  Expected behavior: patch lifecycle events refer to stable content hashes; replay and follow-up runs can recover patch and amended artifacts without reading mutable worktree files; no event embeds large artifact bodies.
+  Files: `crates/surge-orchestrator/src/roadmap_amendment.rs`, `crates/surge-persistence/src/artifacts.rs`, `crates/surge-orchestrator/tests/roadmap_amendment_artifacts_test.rs`.
+  Logging requirements: DEBUG for artifact store paths and content hashes; INFO for stored patch/amended artifact refs; ERROR for store failures with path/hash context but without full artifact contents.
+  Dependency notes: depends on tasks 1, 4, and 6; blocks robust restart/replay behavior.
+
+- [x] Task 8: Add a human approval loop for roadmap patches.
+  Deliverable: introduce an approval helper that presents patch summary, insertion point, dependencies, and rationale with approve/edit/reject decisions and a bounded redo loop.
+  Expected behavior: approve proceeds to apply, edit feeds operator feedback back into the Feature Planner, reject records a terminal rejected patch state, and repeated invalid/edit cycles escalate cleanly.
+  Files: `crates/surge-orchestrator/src/roadmap_amendment.rs`, `crates/surge-orchestrator/src/engine/stage/human_gate.rs` if reusable helpers are needed, tests under `crates/surge-orchestrator/tests/`.
+  Logging requirements: INFO for approval requested/decided with patch id and decision; DEBUG for redo iteration count; WARN when edit-loop cap is reached or approval times out.
+  Dependency notes: depends on tasks 4, 6, and 7; reuse existing `HumanInputRequested` / `resolve_human_input` patterns instead of creating a parallel approval mechanism.
+
+- [x] Task 9: Persist pending patch metadata for list/show/reject commands.
+  Deliverable: add a project-level or run-indexed persistence surface for patch records keyed by patch id/content hash with status, target run/project, created time, decision, and content hash. Prefer event-derived read models when the patch belongs to a run; use a project-level SQLite table only for patches that are not yet attached to a run.
+  Expected behavior: pending patches survive process restarts, `list` can filter by pending/applied/rejected, duplicate content hashes resolve to the existing patch record, and `reject` works without scanning every run event log.
+  Files: `crates/surge-persistence/src/roadmap_patches.rs` if a project-level store is needed, `crates/surge-persistence/src/runs/reader_views.rs`, `crates/surge-persistence/src/lib.rs`, migration files if schema changes are required, persistence tests.
+  Logging requirements: DEBUG for store open/query paths, INFO for status transitions, WARN for duplicate/replay conflicts, ERROR for migration or serialization failures.
+  Dependency notes: depends on tasks 1, 5, and 7; supports CLI tasks 16-17.
+
+- [x] Task 10: Normalize roadmap target discovery.
+  Deliverable: implement a target resolver that can identify whether a prompt should amend a project roadmap file, an active run's roadmap artifact, or a completed bootstrap/follow-up run.
+  Expected behavior: resolver returns a typed target with roadmap artifact hash/path, current flow hash/path when available, run status, run worktree when available, last safe amendment point, and whether active pickup is allowed. Ambiguous targets require an explicit CLI selector.
+  Files: `crates/surge-orchestrator/src/roadmap_target.rs`, `crates/surge-persistence/src/runs/`, `crates/surge-cli/src/commands/feature.rs`.
+  Logging requirements: DEBUG for candidate target scan and selected target; INFO for chosen active/completed/project target; WARN when no roadmap is found or multiple ambiguous targets require explicit CLI selection.
+  Dependency notes: depends on tasks 5 and 9 for persisted patch context; use event-log reads and existing project config paths rather than ad hoc global state.
+
+### Phase 3: Applying Patches To Roadmaps And Flows
+- [x] Task 11: Implement pure roadmap patch application.
+  Deliverable: add pure functions that apply a `RoadmapPatch` to a `RoadmapArtifact` and markdown `roadmap.md` representation while preserving completed history and producing a patch result summary.
+  Expected behavior: approved patches append or insert only where allowed, keep original completed items intact, produce deterministic ordering, and reject references to missing or currently-running milestones with typed conflict errors.
+  Files: `crates/surge-core/src/roadmap_patch.rs`, `crates/surge-core/src/roadmap.rs`, core tests and fixtures.
+  Logging requirements: core remains log-free; callers log apply result with inserted milestone/task ids and conflict codes.
+  Dependency notes: depends on tasks 1 and 10. Prefer typed parsing and `toml_edit`/structured helpers over ad hoc string replacement.
+
+- [x] Task 12: Implement flow amendment generation and validation.
+  Deliverable: add an orchestrator helper that translates approved roadmap patch results into changes for the active `flow.toml`, inserting new milestone/task nodes and rewiring edges through existing graph primitives.
+  Expected behavior: generated graphs pass `validate_for_m6`; rollback leaves the previous graph untouched on validation failure; follow-up-only targets can produce a minimal appended flow instead of mutating active flow.
+  Files: `crates/surge-orchestrator/src/flow_amendment.rs`, `crates/surge-core/src/graph.rs` if helper APIs are needed, `crates/surge-orchestrator/tests/flow_amendment_test.rs`.
+  Logging requirements: DEBUG for graph node/edge insertions and validation start/end; INFO for successful graph amendment with old/new graph hash; WARN for validation rollback with diagnostic summary.
+  Dependency notes: depends on task 11. Do not add a new `NodeKind`.
+
+- [x] Task 13: Define graph revision and replay semantics for active amendments.
+  Deliverable: decide how an amended graph is represented after the original `PipelineMaterialized` frozen graph: either append a new graph-revision event, treat `RoadmapUpdated` as a deferred loop-input event, or explicitly constrain active amendments to pending loop items without mutating `RunState::Pipeline.graph`.
+  Expected behavior: replay from the event log reconstructs the same graph/loop state after an amendment; snapshots can serialize and restore the new state; old runs without amendments replay unchanged.
+  Files: `crates/surge-core/src/run_event.rs`, `crates/surge-core/src/run_state.rs`, `crates/surge-orchestrator/src/engine/replay.rs`, `crates/surge-orchestrator/src/engine/snapshot.rs`, engine replay/snapshot tests.
+  Logging requirements: INFO when a new graph revision or deferred update is accepted; DEBUG for replay/snapshot reconstruction details; WARN when an attempted active mutation cannot be represented safely.
+  Dependency notes: depends on tasks 4, 5, and 12; blocks active-run pickup.
+
+- [x] Task 14: Add active-run pickup semantics at safe loop boundaries.
+  Deliverable: teach the engine/daemon-side runner to observe `RoadmapUpdated` for eligible active roadmap-loop runs and include new pending items only at a safe outer milestone loop boundary.
+  Expected behavior: if the current milestone is already running, the update is deferred to the next safe loop boundary; already-resolved `LoopFrame.items` are not silently mutated mid-iteration; if the target is terminal or active pickup is disabled, a follow-up run path is selected instead.
+  Files: `crates/surge-orchestrator/src/engine/run_task.rs`, `crates/surge-orchestrator/src/engine/routing.rs`, `crates/surge-orchestrator/src/engine/stage/loop_stage.rs`, `crates/surge-daemon/src/`, engine tests for active and terminal run cases.
+  Logging requirements: INFO for update observed/picked-up/deferred/follow-up-created; DEBUG for loop-boundary checks; WARN for conflicts that require operator choice.
+  Dependency notes: depends on tasks 10, 12, and 13; this is the riskiest part, so land only after pure apply, graph revision, and flow validation tests pass.
+
+- [x] Task 15: Implement follow-up run creation from appended work.
+  Deliverable: add helper logic that materializes a follow-up graph from the approved patch when a completed roadmap or non-pickup target is amended.
+  Expected behavior: completed history is never mutated; the follow-up run receives the current project context and appended roadmap portion as seed artifacts; CLI output prints the new run id.
+  Files: `crates/surge-orchestrator/src/roadmap_amendment.rs`, `crates/surge-cli/src/commands/feature.rs`, tests under `crates/surge-orchestrator/tests/`.
+  Logging requirements: INFO for follow-up run creation with parent target, patch id, and run id; DEBUG for artifact seeding; ERROR for failure to materialize or start the follow-up run.
+  Dependency notes: depends on tasks 7, 10, 11, and 12 and reuses `bootstrap_driver` materialization patterns where possible.
+
+### Phase 4: CLI And Notification Surfaces
+- [x] Task 16: Add `surge feature describe <prompt>`.
+  Deliverable: introduce a `Feature` CLI command group with `describe`, target selection flags, worktree options, JSON output, and human-readable progress output.
+  Expected behavior: command resolves a roadmap target, runs Feature Planner, records pending patch metadata, prompts for approval when configured for console mode, and applies or stores the patch according to user decision.
+  Files: `crates/surge-cli/src/main.rs`, `crates/surge-cli/src/commands/feature.rs`, `crates/surge-cli/src/commands/mod.rs`, CLI tests.
+  Logging requirements: DEBUG for args/target resolution and driver steps; INFO for patch drafted/applied/follow-up started; WARN for out-of-scope, ambiguous target, or rejected patch; avoid logging full prompt text when it may contain secrets.
+  Dependency notes: depends on tasks 6-10 and tasks 11-15 for apply/start behavior.
+
+- [x] Task 17: Add CLI mirrors for pending patches.
+  Deliverable: implement `surge feature list`, `surge feature show <id>`, and `surge feature reject <id>` using the patch metadata persistence surface from task 9.
+  Expected behavior: `list` shows patch id, status, target, created time, and short rationale; `show` can emit human or JSON details; `reject` is idempotent and records the decision.
+  Files: `crates/surge-cli/src/commands/feature.rs`, `crates/surge-persistence/src/roadmap_patches.rs`, CLI integration tests.
+  Logging requirements: DEBUG for query filters; INFO for reject status transition; WARN when a patch id is missing, already applied, or already rejected.
+  Dependency notes: depends on task 9 and should work even before active-run pickup is enabled.
+
+- [x] Task 18: Add notification payloads for amendment lifecycle.
+  Deliverable: add structured notification messages for patch approval requested, patch applied, runner pickup, follow-up run created, conflict detected, and rejection.
+  Expected behavior: notification channels can render useful text today, while Telegram can later upgrade them into rich cards without changing the event schema.
+  Files: `crates/surge-notify/src/messages.rs`, `crates/surge-notify/src/multiplexer.rs`, `crates/surge-orchestrator/src/roadmap_amendment.rs`, notification tests.
+  Logging requirements: INFO for notification dispatch attempts and outcomes; DEBUG for channel selection; WARN for non-blocking delivery failures unless policy makes them blocking.
+  Dependency notes: depends on tasks 4, 8, 11, 14, and 15.
+
+- [x] Task 19: Add conflict resolution options.
+  Deliverable: model operator choices for conflicts: defer to next milestone, abort current run, create follow-up run, or reject patch.
+  Expected behavior: conflicts referencing an already-running milestone surface clear choices; selected choices are persisted and reflected in the eventual apply/follow-up path.
+  Files: `crates/surge-core/src/roadmap_patch.rs`, `crates/surge-orchestrator/src/roadmap_amendment.rs`, `crates/surge-cli/src/commands/feature.rs`, tests.
+  Logging requirements: WARN for conflict detection with stable conflict code; INFO for chosen resolution; DEBUG for recalculated target after resolution.
+  Dependency notes: depends on tasks 8, 10, 14, and 15.
+
+### Phase 5: Regression Coverage And Documentation
+- [x] Task 20: Add end-to-end amendment tests.
+  Deliverable: cover malformed patch rejection, duplicate patch idempotency, amendment during a running roadmap, amendment after a terminal roadmap, conflict on running milestone, CLI list/show/reject, and follow-up run creation.
+  Expected behavior: default CI uses mock agents and synthetic fixtures only; real-agent amendment tests are ignored or feature-gated. Tests cover replay/snapshot behavior for amended runs and event-view rebuild behavior for patch lifecycle queries.
+  Files: `crates/surge-orchestrator/tests/roadmap_amendment_e2e.rs`, `crates/surge-cli/tests/feature_cli_test.rs`, `crates/surge-core/tests/` or inline core tests, fixtures under `crates/surge-orchestrator/tests/fixtures/`.
+  Logging requirements: tests assert important lifecycle logs or event discriminants where practical; fixture failures print patch ids and diagnostic codes, not full private prompts.
+  Dependency notes: depends on tasks 1-19 and should be expanded as each phase lands.
+
+- [x] Task 21: Document the amendment lifecycle.
+  Deliverable: update workflow/docs with a lifecycle diagram and command reference for `surge feature describe/list/show/reject`, including active-run vs follow-up behavior.
+  Expected behavior: docs explain which artifacts are mutated, which events are appended, how conflict choices work, and how completed history remains replay-safe.
+  Files: `docs/workflow.md`, `docs/cli.md`, `docs/conventions/roadmap.md`, `docs/README.md`, `README.md` if command overview needs a short mention.
+  Logging requirements: docs mention where users can find INFO/WARN lifecycle logs and how to enable verbose `RUST_LOG` while debugging amendments.
+  Dependency notes: docs checkpoint is mandatory because `Docs: yes`.
+
+- [x] Task 22: Final verification and roadmap closeout.
+  Deliverable: run focused tests, full workspace verification, update `.ai-factory/ROADMAP.md` only after implementation is actually complete, and prepare PR summary.
+  Expected behavior: `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` pass; no roadmap checkbox is marked complete until implemented and verified.
+  Files: `.ai-factory/ROADMAP.md`, implementation plan status updates, PR description.
+  Logging requirements: no new runtime logging; record verification commands and noteworthy failures in the PR summary.
+  Dependency notes: final task; do not treat docs-only or CLI-only work as milestone completion.
+
+## Verification Plan
+- Run `cargo fmt --check`.
+- Run `cargo test -p surge-core roadmap_patch`.
+- Run `cargo test -p surge-core artifact_contract`.
+- Run `cargo test -p surge-persistence roadmap_patch`.
+- Run `cargo test -p surge-orchestrator --test feature_planner_driver_test`.
+- Run `cargo test -p surge-orchestrator --test roadmap_amendment_artifacts_test`.
+- Run `cargo test -p surge-orchestrator --test flow_amendment_test`.
+- Run `cargo test -p surge-orchestrator --test engine_roadmap_update_replay_test`.
+- Run `cargo test -p surge-orchestrator --test roadmap_amendment_e2e`.
+- Run `cargo test -p surge-cli --test feature_cli_test`.
+- Run `cargo test -p surge-notify`.
+- Run `cargo clippy --workspace --all-targets -- -D warnings`.
+- Run `cargo test --workspace`.
+- Run `git diff --check`.
+
+## Implementation Notes
+- Keep `RoadmapPatch` and pure application logic in `surge-core`; filesystem, ACP, persistence, and notification wiring belong above it.
+- Use structured TOML parsing and `toml_edit`/typed serializers where possible; avoid regex-based roadmap mutation.
+- Make patch IDs/content hashes deterministic so idempotency survives restarts and replays.
+- Apply active-run amendments only at explicit safe points; defer or create follow-up runs when the current milestone is already executing.
+- Keep notification payloads structured now so Telegram cards can become richer later without schema churn.
+- Preserve existing bootstrap and graph-engine behavior; amendments should compose with the event log rather than bypass it.
+- The Feature Planner driver should reuse agent-stage outcome/artifact validation; avoid introducing a second ACP invocation path with divergent validation behavior.
+- Treat active-run amendments as explicit event-log graph/input revisions with replay and snapshot tests before enabling pickup.

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,106 @@
+# Surge local environment template.
+#
+# Copy to `.env` and uncomment only the values you want to use locally.
+# `just` loads this project's `.env` automatically via `set dotenv-load`.
+# Keep real secrets out of git.
+
+# -----------------------------------------------------------------------------
+# Surge config overrides
+# -----------------------------------------------------------------------------
+
+# Overrides `default_agent` from surge.toml.
+# SURGE_DEFAULT_AGENT=codex-acp
+
+# Optional pipeline overrides.
+# SURGE_MAX_QA_ITERATIONS=10
+# SURGE_MAX_PARALLEL=3
+# SURGE_GATE_AFTER_SPEC=true
+# SURGE_GATE_AFTER_PLAN=true
+# SURGE_GATE_AFTER_EACH_SUBTASK=false
+# SURGE_GATE_AFTER_QA=true
+
+# Optional runtime home override. Leave unset to use the default `~/.surge`.
+# SURGE_HOME=C:/Users/vanya/.surge
+
+# -----------------------------------------------------------------------------
+# ACP client discovery
+# -----------------------------------------------------------------------------
+
+# Set one of these when the binary is not discoverable on PATH.
+# CLAUDE_ACP_PATH=C:/path/to/claude.exe
+# CLAUDE_PATH=C:/path/to/claude.exe
+# CLAUDE_BIN=C:/path/to/claude.exe
+
+# CODEX_ACP_PATH=C:/path/to/codex.exe
+# CODEX_PATH=C:/path/to/codex.exe
+# CODEX_BIN=C:/path/to/codex.exe
+
+# GEMINI_PATH=C:/path/to/gemini.exe
+# GEMINI_BIN=C:/path/to/gemini.exe
+
+# GITHUB_COPILOT_CLI_PATH=C:/path/to/gh.exe
+# GH_PATH=C:/path/to/gh.exe
+
+# Triage LLM helper uses this Claude-specific override.
+# SURGE_CLAUDE_BINARY=C:/path/to/claude.exe
+
+# Provider credentials used by the underlying agent CLIs, if they need env auth.
+# ANTHROPIC_API_KEY=
+# OPENAI_API_KEY=
+# GEMINI_API_KEY=
+
+# -----------------------------------------------------------------------------
+# Real ACP smoke test
+# -----------------------------------------------------------------------------
+
+# Required for:
+# cargo test -p surge-orchestrator --test real_acp_smoke -- --ignored --nocapture
+# SURGE_REAL_ACP_BIN=C:/path/to/codex.exe
+SURGE_REAL_ACP_PROFILE=implementer@1.0
+
+# Optional: claude-code | codex | gemini-cli | custom.
+# SURGE_REAL_ACP_KIND=codex
+
+# Optional extra process args, split on whitespace by the test harness.
+# SURGE_REAL_ACP_ARGS=
+
+# Optional ignored triage LLM test.
+# ANTHROPIC_TEST_KEY=
+
+# -----------------------------------------------------------------------------
+# Telegram approvals / inbox bot
+# -----------------------------------------------------------------------------
+
+# These names match [telegram] in surge.example.toml and surge init defaults.
+# Do not commit the real bot token.
+# SURGE_TELEGRAM_CHAT_ID=
+# SURGE_TELEGRAM_BOT_TOKEN=
+
+# -----------------------------------------------------------------------------
+# GitHub / Linear real integration tests and intake sources
+# -----------------------------------------------------------------------------
+
+# Real test harnesses:
+# GITHUB_TEST_PAT=
+# GITHUB_TEST_OWNER=
+# GITHUB_TEST_REPO=
+# LINEAR_TEST_API_TOKEN=
+# LINEAR_TEST_WORKSPACE_ID=
+
+# Common names to reference from [[task_sources]] in surge.toml:
+# GITHUB_TOKEN=
+# LINEAR_API_TOKEN=
+
+# -----------------------------------------------------------------------------
+# Optional notification integrations
+# -----------------------------------------------------------------------------
+
+# Use these only if your local surge.toml or future notification config points
+# at them. The current code reads provider-specific env var names from config.
+# SLACK_TOKEN=
+# WEBHOOK_URL=
+# SMTP_HOST=
+# SMTP_USERNAME=
+# SMTP_PASSWORD=
+# SMTP_FROM=
+# SMTP_TO=

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,11 @@
 /target/
 **/*.rs.bk
 
+# Local environment / secrets
+.env
+.env.local
+.env.*.local
+
 # Surge runtime
 .surge/
 *.pid

--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ Full setup, agent configuration, and daemon usage are in [`docs/getting-started.
 | Guide | Description |
 |---|---|
 | [Getting Started](docs/getting-started.md) | Requirements, build, run examples, agent configuration, smoke tests |
-| [CLI](docs/cli.md) | Command surface, two execution paths, current → target mapping |
-| [Workflow](docs/workflow.md) | AFK workflow, flow model, intake sources, run lifecycle |
+| [CLI](docs/cli.md) | Command surface, execution paths, project context, roadmap amendments |
+| [Workflow](docs/workflow.md) | AFK workflow, flow model, intake sources, roadmap amendments, run lifecycle |
 | [Architecture](docs/ARCHITECTURE.md) | Positioning, principles, engine, ACP bridge, storage, crate layout |
 | [Hooks](docs/hooks.md) | `pre_tool_use` / `post_tool_use` / `on_outcome` / `on_error` lifecycle, matcher, failure modes |
 | [Archetypes](docs/archetypes.md) | Bundled `flow.toml` archetypes with mermaid diagrams |

--- a/crates/surge-cli/src/commands/bootstrap.rs
+++ b/crates/surge-cli/src/commands/bootstrap.rs
@@ -162,11 +162,11 @@ async fn drive_run_handle(
                 print_bootstrap_event(seq, &payload);
                 if let EventPayload::HumanInputRequested {
                     call_id, prompt, ..
-                } = payload
+                } = payload.as_ref()
                 {
-                    let response = prompt_for_gate_decision(None, &prompt)?;
+                    let response = prompt_for_gate_decision(None, prompt)?;
                     engine
-                        .resolve_human_input(run_id, call_id, response)
+                        .resolve_human_input(run_id, call_id.clone(), response)
                         .await?;
                 }
             },

--- a/crates/surge-cli/src/commands/engine.rs
+++ b/crates/surge-cli/src/commands/engine.rs
@@ -463,7 +463,7 @@ fn print_event(event: &surge_orchestrator::engine::handle::EngineRunEvent) {
             let prefix = format!("[{seq}]")
                 .if_supports_color(Stream::Stderr, |s| s.dimmed())
                 .to_string();
-            match payload {
+            match payload.as_ref() {
                 EventPayload::StageEntered { node, attempt } => {
                     eprintln!(
                         "{prefix} [{}] StageEntered (attempt {})",
@@ -514,7 +514,7 @@ fn print_event(event: &surge_orchestrator::engine::handle::EngineRunEvent) {
 
 /// If `--daemon` is requested but no daemon is running, auto-spawn
 /// one. Idempotent if a daemon is already alive.
-async fn ensure_daemon_running() -> Result<()> {
+pub(crate) async fn ensure_daemon_running() -> Result<()> {
     use surge_daemon::pidfile;
     if let Some(p) = pidfile::read_pid(&pidfile::pid_path()?)? {
         if pidfile::is_alive(p) {

--- a/crates/surge-cli/src/commands/feature.rs
+++ b/crates/surge-cli/src/commands/feature.rs
@@ -32,7 +32,7 @@ use surge_orchestrator::feature_driver::{
 };
 use surge_orchestrator::roadmap_amendment::{
     RoadmapPatchApprovalLoop, RoadmapPatchApprovalResolution, record_roadmap_updated,
-    start_follow_up_run, store_applied_artifacts, store_patch_draft,
+    request_patch_approval, start_follow_up_run, store_applied_artifacts, store_patch_draft,
 };
 use surge_orchestrator::roadmap_document::{
     parse_roadmap_document, render_amended_roadmap_document, roadmap_identifiers_prompt,
@@ -267,6 +267,29 @@ async fn reject_command(args: FeatureRejectArgs) -> Result<()> {
         .await
         .context("open storage")?;
     let patch_id = parse_patch_id(&args.patch_id)?;
+    let Some(existing) = storage.roadmap_patch_store().get(&patch_id)? else {
+        return Err(anyhow!("roadmap patch not found: {patch_id}"));
+    };
+    if existing.status != RoadmapPatchStatus::Applied {
+        let owner_run_id = existing
+            .run_id
+            .ok_or_else(|| anyhow!("roadmap patch {patch_id} has no owning run event log"))?;
+        let writer = storage
+            .open_run_writer(owner_run_id)
+            .await
+            .with_context(|| format!("open owning run writer {owner_run_id}"))?;
+        append_reject_decision_event(
+            &writer,
+            &patch_id,
+            args.reason.clone(),
+            args.conflict_choice.map(Into::into),
+        )
+        .await?;
+        writer
+            .close()
+            .await
+            .context("close owning run writer after patch rejection")?;
+    }
     let Some(record) = storage.roadmap_patch_store().reject(
         &patch_id,
         args.reason.as_deref(),
@@ -289,6 +312,32 @@ async fn reject_command(args: FeatureRejectArgs) -> Result<()> {
             println!("conflict_choice={}", conflict_choice_label(choice));
         }
     }
+    Ok(())
+}
+
+async fn append_reject_decision_event(
+    writer: &surge_persistence::runs::RunWriter,
+    patch_id: &RoadmapPatchId,
+    comment: Option<String>,
+    conflict_choice: Option<OperatorConflictChoice>,
+) -> Result<()> {
+    tracing::info!(
+        target: "feature_cli",
+        patch_id = %patch_id,
+        conflict_choice = conflict_choice.map(conflict_choice_label),
+        "roadmap_patch_reject_decision_event"
+    );
+    writer
+        .append_event(VersionedEventPayload::new(
+            EventPayload::RoadmapPatchApprovalDecided {
+                patch_id: patch_id.clone(),
+                decision: RoadmapPatchApprovalDecision::Reject,
+                channel_used: ApprovalChannelKind::Desktop,
+                comment,
+                conflict_choice,
+            },
+        ))
+        .await?;
     Ok(())
 }
 
@@ -404,7 +453,12 @@ async fn run_describe_flow(flow: DescribeFlow<'_>) -> Result<()> {
         FeaturePlannerResult::Patched { patch, patch_path } => {
             let mut patch = *patch;
             normalize_patch_target(&mut patch, &flow.target);
-            attach_apply_conflicts(&mut patch, &flow.roadmap_text, flow.args.json);
+            attach_apply_conflicts(
+                &mut patch,
+                &flow.target.roadmap_path,
+                &flow.roadmap_text,
+                flow.args.json,
+            );
             let patch_toml = toml::to_string_pretty(&patch).context("serialize roadmap patch")?;
             tokio::fs::write(&patch_path, patch_toml.as_bytes())
                 .await
@@ -422,6 +476,7 @@ async fn run_describe_flow(flow: DescribeFlow<'_>) -> Result<()> {
                 &flow.storage,
                 &flow.target,
                 &patch,
+                flow.planner_run_id,
                 PatchIndexUpdate {
                     content_hash: patch_hash,
                     status: RoadmapPatchStatus::Drafted,
@@ -444,17 +499,18 @@ async fn run_describe_flow(flow: DescribeFlow<'_>) -> Result<()> {
             let mut follow_up_run_id = None;
             let mut selected_conflict_choice = decision.conflict_choice();
             let status = match decision {
-                PatchDecision::Store => {
+                PatchDecision::Store { summary_hash } => {
                     record = upsert_patch_index(
                         &flow.storage,
                         &flow.target,
                         &patch,
+                        flow.planner_run_id,
                         PatchIndexUpdate {
                             content_hash: patch_hash,
                             status: RoadmapPatchStatus::PendingApproval,
                             patch_artifact: record.patch_artifact,
                             patch_path: record.patch_path.clone(),
-                            summary_hash: None,
+                            summary_hash: Some(summary_hash),
                             decision: None,
                             decision_comment: None,
                             conflict_choice: None,
@@ -471,6 +527,7 @@ async fn run_describe_flow(flow: DescribeFlow<'_>) -> Result<()> {
                         &flow.storage,
                         &flow.target,
                         &patch,
+                        flow.planner_run_id,
                         PatchIndexUpdate {
                             content_hash: patch_hash,
                             status: RoadmapPatchStatus::Rejected,
@@ -504,6 +561,7 @@ async fn run_describe_flow(flow: DescribeFlow<'_>) -> Result<()> {
                         &flow.storage,
                         &flow.target,
                         &patch,
+                        flow.planner_run_id,
                         PatchIndexUpdate {
                             content_hash: patch_hash,
                             status: apply.status,
@@ -790,7 +848,9 @@ async fn daemon_engine_facade() -> Result<DaemonEngineFacade> {
 }
 
 enum PatchDecision {
-    Store,
+    Store {
+        summary_hash: ContentHash,
+    },
     Approve {
         conflict_choice: Option<OperatorConflictChoice>,
     },
@@ -803,7 +863,7 @@ enum PatchDecision {
 impl PatchDecision {
     fn conflict_choice(&self) -> Option<OperatorConflictChoice> {
         match self {
-            Self::Store => None,
+            Self::Store { .. } => None,
             Self::Approve { conflict_choice }
             | Self::Reject {
                 conflict_choice, ..
@@ -820,7 +880,10 @@ async fn decide_patch(
 ) -> Result<PatchDecision> {
     validate_requested_conflict_choice(patch, conflict_choice)?;
     match mode {
-        FeatureApprovalMode::Store => Ok(PatchDecision::Store),
+        FeatureApprovalMode::Store => {
+            let summary_hash = record_cli_approval_request(writer, patch).await?;
+            Ok(PatchDecision::Store { summary_hash })
+        },
         FeatureApprovalMode::Approve => {
             require_conflict_choice_for_approval(patch, conflict_choice)?;
             if conflict_choice == Some(OperatorConflictChoice::RejectPatch) {
@@ -944,7 +1007,10 @@ async fn prompt_for_patch_decision(
                 conflict_choice,
             })
         },
-        "s" | "store" | "pending" => Ok(PatchDecision::Store),
+        "s" | "store" | "pending" => {
+            let summary_hash = record_cli_approval_request(writer, patch).await?;
+            Ok(PatchDecision::Store { summary_hash })
+        },
         other => Err(anyhow!("unknown approval choice: {other}")),
     }
 }
@@ -973,6 +1039,14 @@ async fn record_cli_decision(
         )
         .await?;
     Ok(())
+}
+
+async fn record_cli_approval_request(
+    writer: &surge_persistence::runs::RunWriter,
+    patch: &RoadmapPatch,
+) -> Result<ContentHash> {
+    let prompt = request_patch_approval(writer, patch, local_approval_channel()).await?;
+    Ok(prompt.summary_hash)
 }
 
 fn prompt_for_conflict_choice(patch: &RoadmapPatch) -> Result<Option<OperatorConflictChoice>> {
@@ -1083,6 +1157,7 @@ fn upsert_patch_index(
     storage: &Arc<Storage>,
     target: &RoadmapTargetCandidate,
     patch: &RoadmapPatch,
+    owner_run_id: RunId,
     update: PatchIndexUpdate,
 ) -> Result<surge_persistence::roadmap_patches::RoadmapPatchIndexRecord> {
     storage
@@ -1090,7 +1165,7 @@ fn upsert_patch_index(
         .upsert(&RoadmapPatchIndexUpsert {
             patch_id: patch.id.clone(),
             content_hash: update.content_hash,
-            run_id: target.run_id,
+            run_id: Some(owner_run_id),
             project_path: target.project_path.clone(),
             target: target.target.clone(),
             status: update.status,
@@ -1129,11 +1204,17 @@ fn normalize_patch_target(patch: &mut RoadmapPatch, target: &RoadmapTargetCandid
     }
 }
 
-fn attach_apply_conflicts(patch: &mut RoadmapPatch, roadmap_text: &str, json: bool) {
-    let Ok(roadmap) = toml::from_str::<RoadmapArtifact>(roadmap_text) else {
+fn attach_apply_conflicts(patch: &mut RoadmapPatch, path: &Path, roadmap_text: &str, json: bool) {
+    let Ok(parsed) = parse_roadmap_document(path, roadmap_text) else {
+        tracing::warn!(
+            target: "feature_cli",
+            patch_id = %patch.id,
+            roadmap_path = %path.display(),
+            "roadmap_patch_conflict_detection_parse_failed"
+        );
         return;
     };
-    match patch.apply_to_roadmap(&roadmap) {
+    match patch.apply_to_roadmap(&parsed.roadmap) {
         Ok(_) => {},
         Err(RoadmapPatchApplyError::InvalidShape { issues }) => {
             tracing::warn!(

--- a/crates/surge-cli/src/commands/feature.rs
+++ b/crates/surge-cli/src/commands/feature.rs
@@ -1,0 +1,1714 @@
+//! `surge feature` — roadmap amendment workflow.
+
+use std::collections::{BTreeSet, HashMap};
+use std::io::{self, Write as _};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::{Context, Result, anyhow};
+use clap::{Args, Subcommand, ValueEnum};
+use serde::Serialize;
+use surge_core::approvals::{
+    ApprovalChannel, ApprovalChannelKind, ApprovalDuration, ApprovalPolicy,
+};
+use surge_core::roadmap::RoadmapArtifact;
+use surge_core::roadmap_patch::{
+    ActivePickupPolicy, InsertionPoint, OperatorConflictChoice, RoadmapItemRef, RoadmapPatch,
+    RoadmapPatchApplyError, RoadmapPatchApplyResult, RoadmapPatchApprovalDecision,
+    RoadmapPatchConflict, RoadmapPatchConflictCode, RoadmapPatchId, RoadmapPatchItem,
+    RoadmapPatchOperation, RoadmapPatchStatus, RoadmapPatchTarget,
+};
+use surge_core::run_event::{EventPayload, RunConfig, VersionedEventPayload};
+use surge_core::sandbox::SandboxMode;
+use surge_core::{ContentHash, RoadmapMilestone, RoadmapStatus, RunId, SurgeConfig};
+use surge_git::GitManager;
+use surge_orchestrator::engine::hooks::HookExecutor;
+use surge_orchestrator::engine::tools::ToolDispatcher;
+use surge_orchestrator::engine::tools::worktree::WorktreeToolDispatcher;
+use surge_orchestrator::engine::{DaemonEngineFacade, EngineFacade as _};
+use surge_orchestrator::feature_driver::{
+    FeaturePlannerParams, FeaturePlannerResult, ToolResolutionMap, run_feature_planner,
+};
+use surge_orchestrator::roadmap_amendment::{
+    RoadmapPatchApprovalLoop, RoadmapPatchApprovalResolution, record_roadmap_updated,
+    start_follow_up_run, store_applied_artifacts, store_patch_draft,
+};
+use surge_orchestrator::roadmap_document::{
+    parse_roadmap_document, render_amended_roadmap_document, roadmap_identifiers_prompt,
+};
+use surge_orchestrator::roadmap_target::{
+    RoadmapAmendmentPoint, RoadmapTargetCandidate, RoadmapTargetResolver, RoadmapTargetSelector,
+};
+use surge_persistence::artifacts::ArtifactStore;
+use surge_persistence::roadmap_patches::{
+    RoadmapPatchIndexFilter, RoadmapPatchIndexRecord, RoadmapPatchIndexUpsert,
+};
+use surge_persistence::runs::Storage;
+
+const PROJECT_ROADMAP_PATH: &str = ".ai-factory/ROADMAP.md";
+const FEATURE_PLANNER_TERMINAL_NODE: &str = "feature_planner";
+
+/// Subcommands under `surge feature`.
+#[derive(Subcommand, Debug)]
+pub enum FeatureCommands {
+    /// Describe a follow-up feature and draft a roadmap patch.
+    Describe(FeatureDescribeArgs),
+    /// List roadmap patches known to this project.
+    List(FeatureListArgs),
+    /// Show one roadmap patch record.
+    Show(FeatureShowArgs),
+    /// Reject a pending roadmap patch.
+    Reject(FeatureRejectArgs),
+}
+
+/// Arguments for `surge feature describe`.
+#[derive(Args, Debug)]
+pub struct FeatureDescribeArgs {
+    /// Free-form feature request.
+    #[arg(required = true, num_args = 1..)]
+    pub prompt: Vec<String>,
+    /// Target a specific run roadmap.
+    #[arg(long = "run", value_name = "RUN_ID")]
+    pub run_id: Option<String>,
+    /// Force the project-level roadmap target.
+    #[arg(long)]
+    pub project: bool,
+    /// Worktree used by Feature Planner for generated artifacts.
+    #[arg(long)]
+    pub worktree: Option<PathBuf>,
+    /// Approval behavior after the patch is drafted.
+    #[arg(long, value_enum, default_value_t = FeatureApprovalMode::Prompt)]
+    pub approval: FeatureApprovalMode,
+    /// Conflict resolution to record when approving a conflicted patch.
+    #[arg(long, value_enum)]
+    pub conflict_choice: Option<FeatureConflictChoiceArg>,
+    /// Emit a single JSON object on stdout; progress stays on stderr.
+    #[arg(long)]
+    pub json: bool,
+}
+
+/// Console approval behavior for drafted patches.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum FeatureApprovalMode {
+    /// Ask on stdin/stdout.
+    Prompt,
+    /// Approve immediately and attempt apply.
+    Approve,
+    /// Reject immediately.
+    Reject,
+    /// Store the pending patch without a decision.
+    Store,
+}
+
+/// Conflict resolution choice for `surge feature describe`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum FeatureConflictChoiceArg {
+    /// Move new work to the next safe milestone.
+    #[value(alias = "defer_to_next_milestone")]
+    DeferToNextMilestone,
+    /// Stop the active run before a later apply.
+    #[value(alias = "abort_current_run")]
+    AbortCurrentRun,
+    /// Create a separate follow-up run for the new work.
+    #[value(alias = "create_follow_up_run")]
+    CreateFollowUpRun,
+    /// Reject the patch.
+    #[value(alias = "reject_patch")]
+    RejectPatch,
+}
+
+impl From<FeatureConflictChoiceArg> for OperatorConflictChoice {
+    fn from(value: FeatureConflictChoiceArg) -> Self {
+        match value {
+            FeatureConflictChoiceArg::DeferToNextMilestone => Self::DeferToNextMilestone,
+            FeatureConflictChoiceArg::AbortCurrentRun => Self::AbortCurrentRun,
+            FeatureConflictChoiceArg::CreateFollowUpRun => Self::CreateFollowUpRun,
+            FeatureConflictChoiceArg::RejectPatch => Self::RejectPatch,
+        }
+    }
+}
+
+/// Arguments for `surge feature list`.
+#[derive(Args, Debug)]
+pub struct FeatureListArgs {
+    /// Filter by lifecycle status.
+    #[arg(long, value_enum)]
+    pub status: Option<FeaturePatchStatusArg>,
+    /// Include patches from every project instead of only the current project.
+    #[arg(long)]
+    pub all_projects: bool,
+    /// Filter by owning run id.
+    #[arg(long = "run", value_name = "RUN_ID")]
+    pub run_id: Option<String>,
+    /// Maximum rows to print.
+    #[arg(long, default_value_t = 50)]
+    pub limit: usize,
+    /// Emit JSON.
+    #[arg(long)]
+    pub json: bool,
+}
+
+/// Arguments for `surge feature show`.
+#[derive(Args, Debug)]
+pub struct FeatureShowArgs {
+    /// Roadmap patch id.
+    pub patch_id: String,
+    /// Emit JSON.
+    #[arg(long)]
+    pub json: bool,
+}
+
+/// Arguments for `surge feature reject`.
+#[derive(Args, Debug)]
+pub struct FeatureRejectArgs {
+    /// Roadmap patch id.
+    pub patch_id: String,
+    /// Optional rejection reason.
+    #[arg(long)]
+    pub reason: Option<String>,
+    /// Conflict resolution to persist with the rejection.
+    #[arg(long, value_enum)]
+    pub conflict_choice: Option<FeatureConflictChoiceArg>,
+    /// Emit JSON.
+    #[arg(long)]
+    pub json: bool,
+}
+
+/// CLI lifecycle status filter.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum FeaturePatchStatusArg {
+    /// Patch has been drafted.
+    Drafted,
+    /// Patch is waiting for approval.
+    PendingApproval,
+    /// Patch has been approved but not fully applied.
+    Approved,
+    /// Patch has been applied.
+    Applied,
+    /// Patch has been rejected.
+    Rejected,
+    /// Patch has been superseded.
+    Superseded,
+}
+
+impl From<FeaturePatchStatusArg> for RoadmapPatchStatus {
+    fn from(value: FeaturePatchStatusArg) -> Self {
+        match value {
+            FeaturePatchStatusArg::Drafted => Self::Drafted,
+            FeaturePatchStatusArg::PendingApproval => Self::PendingApproval,
+            FeaturePatchStatusArg::Approved => Self::Approved,
+            FeaturePatchStatusArg::Applied => Self::Applied,
+            FeaturePatchStatusArg::Rejected => Self::Rejected,
+            FeaturePatchStatusArg::Superseded => Self::Superseded,
+        }
+    }
+}
+
+/// Top-level dispatcher for `surge feature`.
+pub async fn run(command: FeatureCommands) -> Result<()> {
+    match command {
+        FeatureCommands::Describe(args) => describe_command(args).await,
+        FeatureCommands::List(args) => list_command(args).await,
+        FeatureCommands::Show(args) => show_command(args).await,
+        FeatureCommands::Reject(args) => reject_command(args).await,
+    }
+}
+
+async fn list_command(args: FeatureListArgs) -> Result<()> {
+    let storage = Storage::open(&surge_home_dir()?)
+        .await
+        .context("open storage")?;
+    let project_path = if args.all_projects {
+        None
+    } else {
+        Some(load_project_config_for_current_repo()?.1)
+    };
+    let run_id = args
+        .run_id
+        .as_deref()
+        .map(parse_run_id)
+        .transpose()
+        .context("parse --run")?;
+    let records = storage
+        .roadmap_patch_store()
+        .list(&RoadmapPatchIndexFilter {
+            status: args.status.map(Into::into),
+            project_path,
+            run_id,
+            limit: Some(args.limit),
+        })?;
+    if args.json {
+        println!("{}", serde_json::to_string_pretty(&records)?);
+    } else {
+        print_patch_table(&records);
+    }
+    Ok(())
+}
+
+async fn show_command(args: FeatureShowArgs) -> Result<()> {
+    let storage = Storage::open(&surge_home_dir()?)
+        .await
+        .context("open storage")?;
+    let patch_id = parse_patch_id(&args.patch_id)?;
+    let Some(record) = storage.roadmap_patch_store().get(&patch_id)? else {
+        return Err(anyhow!("roadmap patch not found: {patch_id}"));
+    };
+    if args.json {
+        println!("{}", serde_json::to_string_pretty(&record)?);
+    } else {
+        print_patch_detail(&record);
+    }
+    Ok(())
+}
+
+async fn reject_command(args: FeatureRejectArgs) -> Result<()> {
+    let storage = Storage::open(&surge_home_dir()?)
+        .await
+        .context("open storage")?;
+    let patch_id = parse_patch_id(&args.patch_id)?;
+    let Some(record) = storage.roadmap_patch_store().reject(
+        &patch_id,
+        args.reason.as_deref(),
+        args.conflict_choice.map(Into::into),
+        chrono::Utc::now().timestamp_millis(),
+    )?
+    else {
+        return Err(anyhow!("roadmap patch not found: {patch_id}"));
+    };
+    if args.json {
+        println!("{}", serde_json::to_string_pretty(&record)?);
+    } else {
+        println!(
+            "patch_id={} status={} decision={}",
+            record.patch_id,
+            patch_status_label(record.status),
+            record.decision.map_or("none", approval_decision_label)
+        );
+        if let Some(choice) = record.conflict_choice {
+            println!("conflict_choice={}", conflict_choice_label(choice));
+        }
+    }
+    Ok(())
+}
+
+async fn describe_command(args: FeatureDescribeArgs) -> Result<()> {
+    let prompt = args.prompt.join(" ");
+    let (config, project_root) = load_project_config_for_current_repo()?;
+    let storage = Storage::open(&surge_home_dir()?)
+        .await
+        .context("open storage")?;
+    let selector = target_selector(&args)?;
+    let resolver = RoadmapTargetResolver::new(
+        storage.clone(),
+        &project_root,
+        Path::new(PROJECT_ROADMAP_PATH),
+    );
+    let target = resolver.resolve(selector).await?;
+    let worktree = resolve_feature_worktree(args.worktree.as_deref(), &target, &project_root)?;
+    let roadmap_text = tokio::fs::read_to_string(&target.roadmap_path)
+        .await
+        .with_context(|| format!("read roadmap {}", target.roadmap_path.display()))?;
+    let roadmap_prompt = roadmap_prompt_text(&target.roadmap_path, &roadmap_text);
+
+    progress(args.json, format_args!("target={}", target_label(&target)));
+    progress(args.json, format_args!("worktree={}", worktree.display()));
+
+    let planner_run_id = RunId::new();
+    let writer = storage
+        .create_run(planner_run_id, &worktree, Some("feature-planner".into()))
+        .await
+        .context("create feature planner run")?;
+    append_feature_run_started(&writer, &worktree).await?;
+
+    let command_result = run_describe_flow(DescribeFlow {
+        args: &args,
+        prompt,
+        config,
+        project_root,
+        storage: storage.clone(),
+        target,
+        worktree,
+        roadmap_text,
+        roadmap_prompt,
+        planner_run_id,
+        writer: &writer,
+    })
+    .await;
+
+    append_feature_run_terminal(&writer, &command_result).await?;
+    writer
+        .close()
+        .await
+        .context("close feature planner writer")?;
+    command_result
+}
+
+struct DescribeFlow<'a> {
+    args: &'a FeatureDescribeArgs,
+    prompt: String,
+    config: SurgeConfig,
+    project_root: PathBuf,
+    storage: Arc<Storage>,
+    target: RoadmapTargetCandidate,
+    worktree: PathBuf,
+    roadmap_text: String,
+    roadmap_prompt: String,
+    planner_run_id: RunId,
+    writer: &'a surge_persistence::runs::RunWriter,
+}
+
+async fn run_describe_flow(flow: DescribeFlow<'_>) -> Result<()> {
+    let artifact_store = ArtifactStore::new(flow.storage.home().join("runs"));
+    let bridge: Arc<dyn surge_acp::bridge::facade::BridgeFacade> = Arc::new(
+        surge_acp::bridge::AcpBridge::with_defaults().context("AcpBridge::with_defaults")?,
+    );
+    let tool_dispatcher: Arc<dyn ToolDispatcher> =
+        Arc::new(WorktreeToolDispatcher::new(flow.worktree.clone()));
+    let profile_registry = Arc::new(
+        surge_orchestrator::profile_loader::ProfileRegistry::load()
+            .context("load profile registry")?,
+    );
+    let hook_executor = HookExecutor::new();
+    let tool_resolutions: ToolResolutionMap = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
+    let memory = surge_core::run_state::RunMemory::default();
+
+    progress(
+        flow.args.json,
+        format_args!("planner_run_id={}", flow.planner_run_id),
+    );
+    let result = run_feature_planner(FeaturePlannerParams {
+        request: flow.prompt.clone(),
+        roadmap: flow.roadmap_prompt.clone(),
+        bridge: &bridge,
+        writer: flow.writer,
+        artifact_store: &artifact_store,
+        worktree_path: &flow.worktree,
+        tool_dispatcher: &tool_dispatcher,
+        run_memory: &memory,
+        run_id: flow.planner_run_id,
+        tool_resolutions: &tool_resolutions,
+        human_input_timeout: Duration::from_secs(300),
+        mcp_registry: None,
+        mcp_servers: Vec::new(),
+        profile_registry,
+        hook_executor: &hook_executor,
+    })
+    .await?;
+
+    match result {
+        FeaturePlannerResult::OutOfScope => emit_output(
+            flow.args.json,
+            FeatureDescribeOutput::out_of_scope(flow.planner_run_id, &flow.target),
+        ),
+        FeaturePlannerResult::Patched { patch, patch_path } => {
+            let mut patch = *patch;
+            normalize_patch_target(&mut patch, &flow.target);
+            attach_apply_conflicts(&mut patch, &flow.roadmap_text, flow.args.json);
+            let patch_toml = toml::to_string_pretty(&patch).context("serialize roadmap patch")?;
+            tokio::fs::write(&patch_path, patch_toml.as_bytes())
+                .await
+                .with_context(|| format!("write normalized patch {}", patch_path.display()))?;
+            let patch_hash = patch.content_hash().context("hash roadmap patch")?;
+            let draft_artifact = store_patch_draft(
+                &artifact_store,
+                flow.writer,
+                flow.planner_run_id,
+                &patch,
+                patch_toml.as_bytes(),
+            )
+            .await?;
+            let mut record = upsert_patch_index(
+                &flow.storage,
+                &flow.target,
+                &patch,
+                PatchIndexUpdate {
+                    content_hash: patch_hash,
+                    status: RoadmapPatchStatus::Drafted,
+                    patch_artifact: Some(draft_artifact.hash),
+                    patch_path: Some(draft_artifact.path.clone()),
+                    summary_hash: None,
+                    decision: None,
+                    decision_comment: None,
+                    conflict_choice: None,
+                },
+            )?;
+
+            let decision = decide_patch(
+                flow.writer,
+                &patch,
+                flow.args.approval,
+                flow.args.conflict_choice.map(Into::into),
+            )
+            .await?;
+            let mut follow_up_run_id = None;
+            let mut selected_conflict_choice = decision.conflict_choice();
+            let status = match decision {
+                PatchDecision::Store => {
+                    record = upsert_patch_index(
+                        &flow.storage,
+                        &flow.target,
+                        &patch,
+                        PatchIndexUpdate {
+                            content_hash: patch_hash,
+                            status: RoadmapPatchStatus::PendingApproval,
+                            patch_artifact: record.patch_artifact,
+                            patch_path: record.patch_path.clone(),
+                            summary_hash: None,
+                            decision: None,
+                            decision_comment: None,
+                            conflict_choice: None,
+                        },
+                    )?;
+                    "pending_approval".to_owned()
+                },
+                PatchDecision::Reject {
+                    comment,
+                    conflict_choice,
+                } => {
+                    selected_conflict_choice = conflict_choice;
+                    record = upsert_patch_index(
+                        &flow.storage,
+                        &flow.target,
+                        &patch,
+                        PatchIndexUpdate {
+                            content_hash: patch_hash,
+                            status: RoadmapPatchStatus::Rejected,
+                            patch_artifact: record.patch_artifact,
+                            patch_path: record.patch_path.clone(),
+                            summary_hash: None,
+                            decision: Some(RoadmapPatchApprovalDecision::Reject),
+                            decision_comment: comment,
+                            conflict_choice,
+                        },
+                    )?;
+                    "rejected".to_owned()
+                },
+                PatchDecision::Approve { conflict_choice } => {
+                    let apply = apply_approved_patch(
+                        &flow,
+                        &artifact_store,
+                        &patch,
+                        record.patch_artifact,
+                        record.patch_path.clone(),
+                        conflict_choice,
+                    )
+                    .await?;
+                    follow_up_run_id = apply.follow_up_run_id;
+                    if apply.status == RoadmapPatchStatus::Rejected {
+                        selected_conflict_choice = Some(OperatorConflictChoice::RejectPatch);
+                    } else {
+                        selected_conflict_choice = conflict_choice;
+                    }
+                    record = upsert_patch_index(
+                        &flow.storage,
+                        &flow.target,
+                        &patch,
+                        PatchIndexUpdate {
+                            content_hash: patch_hash,
+                            status: apply.status,
+                            patch_artifact: record.patch_artifact,
+                            patch_path: record.patch_path.clone(),
+                            summary_hash: None,
+                            decision: Some(RoadmapPatchApprovalDecision::Approve),
+                            decision_comment: None,
+                            conflict_choice: selected_conflict_choice,
+                        },
+                    )?;
+                    apply.message
+                },
+            };
+
+            emit_output(
+                flow.args.json,
+                FeatureDescribeOutput {
+                    status,
+                    planner_run_id: flow.planner_run_id.to_string(),
+                    patch_id: Some(record.patch_id.to_string()),
+                    target: target_label(&flow.target),
+                    patch_artifact: record.patch_artifact.map(|hash| hash.to_string()),
+                    patch_path: record
+                        .patch_path
+                        .as_ref()
+                        .map(|path| path.display().to_string()),
+                    follow_up_run_id: follow_up_run_id.map(|run_id| run_id.to_string()),
+                    conflict_choice: selected_conflict_choice
+                        .map(conflict_choice_label)
+                        .map(str::to_owned),
+                    message: output_message(record.status),
+                },
+            )
+        },
+    }
+}
+
+struct ApplyOutcome {
+    status: RoadmapPatchStatus,
+    message: String,
+    follow_up_run_id: Option<RunId>,
+}
+
+async fn apply_approved_patch(
+    flow: &DescribeFlow<'_>,
+    artifact_store: &ArtifactStore,
+    patch: &RoadmapPatch,
+    _patch_artifact: Option<ContentHash>,
+    _patch_path: Option<PathBuf>,
+    conflict_choice: Option<OperatorConflictChoice>,
+) -> Result<ApplyOutcome> {
+    let parsed_roadmap = parse_roadmap_document(&flow.target.roadmap_path, &flow.roadmap_text)
+        .with_context(|| format!("parse roadmap {}", flow.target.roadmap_path.display()))?;
+    let route = apply_patch_or_resolve_conflicts(&parsed_roadmap.roadmap, patch, conflict_choice)?;
+    let patch_result = match route {
+        PatchApplyRoute::Apply(patch_result) => patch_result,
+        other => return apply_route_outcome(other, flow, patch).await,
+    };
+
+    match flow.target.amendment_point {
+        RoadmapAmendmentPoint::ProjectFile => {
+            let amended = render_amended_roadmap_document(
+                &flow.target.roadmap_path,
+                &flow.roadmap_text,
+                &parsed_roadmap,
+                &patch_result,
+            )
+            .with_context(|| format!("render amended {}", flow.target.roadmap_path.display()))?;
+            tokio::fs::write(&flow.target.roadmap_path, amended.as_bytes())
+                .await
+                .with_context(|| format!("write {}", flow.target.roadmap_path.display()))?;
+            let artifacts = store_applied_artifacts(
+                artifact_store,
+                flow.writer,
+                flow.planner_run_id,
+                &patch.id,
+                &flow.target.target,
+                amended.as_bytes(),
+                None,
+            )
+            .await?;
+            record_roadmap_updated(
+                flow.writer,
+                &patch.id,
+                &flow.target.target,
+                &artifacts,
+                ActivePickupPolicy::FollowUpOnly,
+            )
+            .await?;
+            Ok(ApplyOutcome {
+                status: RoadmapPatchStatus::Applied,
+                message: "applied_project_roadmap".into(),
+                follow_up_run_id: None,
+            })
+        },
+        RoadmapAmendmentPoint::FollowUpRun => {
+            start_follow_up_outcome(flow, patch, &patch_result, "follow_up_started").await
+        },
+        RoadmapAmendmentPoint::ActiveRunBoundary => {
+            submit_active_run_outcome(flow, patch, &patch_result).await
+        },
+        RoadmapAmendmentPoint::Deferred => {
+            progress(
+                flow.args.json,
+                format_args!(
+                    "approved patch stored; target run is not at an active pickup boundary"
+                ),
+            );
+            Ok(ApplyOutcome {
+                status: RoadmapPatchStatus::Approved,
+                message: "approved_deferred".into(),
+                follow_up_run_id: None,
+            })
+        },
+    }
+}
+
+enum PatchApplyRoute {
+    Apply(RoadmapPatchApplyResult),
+    FollowUp(RoadmapPatchApplyResult),
+    AbortCurrentRun,
+    Rejected,
+}
+
+async fn apply_route_outcome(
+    route: PatchApplyRoute,
+    flow: &DescribeFlow<'_>,
+    patch: &RoadmapPatch,
+) -> Result<ApplyOutcome> {
+    match route {
+        PatchApplyRoute::Apply(_) => Err(anyhow!("internal error: unresolved apply route")),
+        PatchApplyRoute::FollowUp(result) => {
+            start_follow_up_outcome(flow, patch, &result, "conflict_follow_up_started").await
+        },
+        PatchApplyRoute::AbortCurrentRun => {
+            progress(
+                flow.args.json,
+                format_args!("conflict resolution requires aborting the current run before apply"),
+            );
+            Ok(ApplyOutcome {
+                status: RoadmapPatchStatus::Approved,
+                message: "abort_current_run_required".into(),
+                follow_up_run_id: None,
+            })
+        },
+        PatchApplyRoute::Rejected => Ok(ApplyOutcome {
+            status: RoadmapPatchStatus::Rejected,
+            message: "conflict_rejected".into(),
+            follow_up_run_id: None,
+        }),
+    }
+}
+
+fn apply_patch_or_resolve_conflicts(
+    roadmap: &RoadmapArtifact,
+    patch: &RoadmapPatch,
+    conflict_choice: Option<OperatorConflictChoice>,
+) -> Result<PatchApplyRoute> {
+    match patch.apply_to_roadmap(roadmap) {
+        Ok(result) => Ok(PatchApplyRoute::Apply(result)),
+        Err(RoadmapPatchApplyError::InvalidShape { issues }) => Err(anyhow!(
+            "roadmap patch shape is invalid: {}",
+            issues
+                .iter()
+                .map(|issue| format!("{} at {}", issue.code.as_str(), issue.location))
+                .collect::<Vec<_>>()
+                .join(", ")
+        )),
+        Err(RoadmapPatchApplyError::Conflicts { conflicts }) => {
+            let patch_conflicts =
+                surge_orchestrator::roadmap_amendment::apply_conflicts_as_patch_conflicts(
+                    &conflicts,
+                );
+            let Some(choice) = conflict_choice else {
+                return Err(anyhow!(
+                    "roadmap patch has conflicts; choose one with --conflict-choice: {}",
+                    conflict_choice_list(&patch_conflicts)
+                ));
+            };
+            ensure_conflict_choice_allowed(&patch_conflicts, choice)?;
+            tracing::info!(
+                target: "feature_cli",
+                patch_id = %patch.id,
+                conflict_choice = conflict_choice_label(choice),
+                "roadmap_patch_conflict_resolution_selected"
+            );
+            match choice {
+                OperatorConflictChoice::RejectPatch => Ok(PatchApplyRoute::Rejected),
+                OperatorConflictChoice::CreateFollowUpRun => Ok(PatchApplyRoute::FollowUp(
+                    surge_orchestrator::roadmap_amendment::follow_up_result_from_patch(patch),
+                )),
+                OperatorConflictChoice::AbortCurrentRun => Ok(PatchApplyRoute::AbortCurrentRun),
+                OperatorConflictChoice::DeferToNextMilestone => {
+                    let deferred_patch =
+                        defer_patch_to_next_milestone(roadmap, patch, &patch_conflicts)?;
+                    let result = deferred_patch.apply_to_roadmap(roadmap).with_context(|| {
+                        format!(
+                            "apply roadmap patch after {} resolution",
+                            conflict_choice_label(choice)
+                        )
+                    })?;
+                    Ok(PatchApplyRoute::Apply(result))
+                },
+            }
+        },
+    }
+}
+
+async fn start_follow_up_outcome(
+    flow: &DescribeFlow<'_>,
+    patch: &RoadmapPatch,
+    patch_result: &RoadmapPatchApplyResult,
+    message: &str,
+) -> Result<ApplyOutcome> {
+    let project_context = surge_orchestrator::project_context::load_project_context_seed(
+        &flow.project_root,
+        &flow.config,
+    );
+    let request = surge_orchestrator::roadmap_amendment::build_follow_up_run_request(
+        &patch.id,
+        &flow.target.target,
+        patch_result,
+        &flow.worktree,
+        project_context,
+        chrono::Utc::now(),
+    )?;
+    progress(
+        flow.args.json,
+        format_args!("followup_run_id={}", request.run_id),
+    );
+    let follow_up_run_id = request.run_id;
+    let daemon = daemon_engine_facade().await?;
+    let _handle = start_follow_up_run(&daemon, request).await?;
+    progress(
+        flow.args.json,
+        format_args!("followup_run_started={follow_up_run_id}"),
+    );
+    Ok(ApplyOutcome {
+        status: RoadmapPatchStatus::Applied,
+        message: message.into(),
+        follow_up_run_id: Some(follow_up_run_id),
+    })
+}
+
+async fn submit_active_run_outcome(
+    flow: &DescribeFlow<'_>,
+    patch: &RoadmapPatch,
+    patch_result: &RoadmapPatchApplyResult,
+) -> Result<ApplyOutcome> {
+    let run_id = flow
+        .target
+        .run_id
+        .ok_or_else(|| anyhow!("active-run amendment target is missing run_id"))?;
+    let daemon = daemon_engine_facade().await?;
+    let outcome = daemon
+        .submit_roadmap_amendment(
+            run_id,
+            patch.id.clone(),
+            flow.target.target.clone(),
+            patch_result.clone(),
+        )
+        .await?;
+    progress(
+        flow.args.json,
+        format_args!(
+            "active_run_amended={} graph_hash={}",
+            outcome.run_id, outcome.graph_hash
+        ),
+    );
+    Ok(ApplyOutcome {
+        status: RoadmapPatchStatus::Applied,
+        message: "applied_active_run".into(),
+        follow_up_run_id: None,
+    })
+}
+
+async fn daemon_engine_facade() -> Result<DaemonEngineFacade> {
+    crate::commands::engine::ensure_daemon_running().await?;
+    let socket_path = surge_daemon::pidfile::socket_path().context("resolve daemon socket path")?;
+    DaemonEngineFacade::connect(socket_path)
+        .await
+        .context("connect to daemon")
+}
+
+enum PatchDecision {
+    Store,
+    Approve {
+        conflict_choice: Option<OperatorConflictChoice>,
+    },
+    Reject {
+        comment: Option<String>,
+        conflict_choice: Option<OperatorConflictChoice>,
+    },
+}
+
+impl PatchDecision {
+    fn conflict_choice(&self) -> Option<OperatorConflictChoice> {
+        match self {
+            Self::Store => None,
+            Self::Approve { conflict_choice }
+            | Self::Reject {
+                conflict_choice, ..
+            } => *conflict_choice,
+        }
+    }
+}
+
+async fn decide_patch(
+    writer: &surge_persistence::runs::RunWriter,
+    patch: &RoadmapPatch,
+    mode: FeatureApprovalMode,
+    conflict_choice: Option<OperatorConflictChoice>,
+) -> Result<PatchDecision> {
+    validate_requested_conflict_choice(patch, conflict_choice)?;
+    match mode {
+        FeatureApprovalMode::Store => Ok(PatchDecision::Store),
+        FeatureApprovalMode::Approve => {
+            require_conflict_choice_for_approval(patch, conflict_choice)?;
+            if conflict_choice == Some(OperatorConflictChoice::RejectPatch) {
+                record_cli_decision(
+                    writer,
+                    patch,
+                    RoadmapPatchApprovalDecision::Reject,
+                    Some("rejected by conflict resolution".into()),
+                    conflict_choice,
+                )
+                .await?;
+                return Ok(PatchDecision::Reject {
+                    comment: Some("rejected by conflict resolution".into()),
+                    conflict_choice,
+                });
+            }
+            record_cli_decision(
+                writer,
+                patch,
+                RoadmapPatchApprovalDecision::Approve,
+                None,
+                conflict_choice,
+            )
+            .await?;
+            Ok(PatchDecision::Approve { conflict_choice })
+        },
+        FeatureApprovalMode::Reject => {
+            let conflict_choice = conflict_choice.or_else(|| {
+                patch_has_conflicts(patch).then_some(OperatorConflictChoice::RejectPatch)
+            });
+            record_cli_decision(
+                writer,
+                patch,
+                RoadmapPatchApprovalDecision::Reject,
+                Some("rejected by --approval reject".into()),
+                conflict_choice,
+            )
+            .await?;
+            Ok(PatchDecision::Reject {
+                comment: Some("rejected by --approval reject".into()),
+                conflict_choice,
+            })
+        },
+        FeatureApprovalMode::Prompt => prompt_for_patch_decision(writer, patch).await,
+    }
+}
+
+async fn prompt_for_patch_decision(
+    writer: &surge_persistence::runs::RunWriter,
+    patch: &RoadmapPatch,
+) -> Result<PatchDecision> {
+    let mut approval_loop = RoadmapPatchApprovalLoop::new(0);
+    let prompt = approval_loop
+        .request_approval(writer, patch, local_approval_channel())
+        .await?;
+    println!("{}", prompt.summary);
+    println!("[a] approve  [r] reject  [s] store pending");
+    print!("choice: ");
+    io::stdout().flush()?;
+
+    let mut choice = String::new();
+    io::stdin().read_line(&mut choice)?;
+    match choice.trim().to_lowercase().as_str() {
+        "" | "a" | "approve" => {
+            let conflict_choice = prompt_for_conflict_choice(patch)?;
+            if conflict_choice == Some(OperatorConflictChoice::RejectPatch) {
+                approval_loop
+                    .record_decision(
+                        writer,
+                        &patch.id,
+                        ApprovalChannelKind::Desktop,
+                        RoadmapPatchApprovalResolution {
+                            decision: RoadmapPatchApprovalDecision::Reject,
+                            comment: Some("rejected by conflict resolution".into()),
+                            conflict_choice,
+                        },
+                    )
+                    .await?;
+                return Ok(PatchDecision::Reject {
+                    comment: Some("rejected by conflict resolution".into()),
+                    conflict_choice,
+                });
+            }
+            approval_loop
+                .record_decision(
+                    writer,
+                    &patch.id,
+                    ApprovalChannelKind::Desktop,
+                    RoadmapPatchApprovalResolution {
+                        decision: RoadmapPatchApprovalDecision::Approve,
+                        comment: None,
+                        conflict_choice,
+                    },
+                )
+                .await?;
+            Ok(PatchDecision::Approve { conflict_choice })
+        },
+        "r" | "reject" => {
+            print!("reason: ");
+            io::stdout().flush()?;
+            let mut reason = String::new();
+            io::stdin().read_line(&mut reason)?;
+            let comment = reason.trim().to_owned();
+            let comment = (!comment.is_empty()).then_some(comment);
+            let conflict_choice =
+                patch_has_conflicts(patch).then_some(OperatorConflictChoice::RejectPatch);
+            approval_loop
+                .record_decision(
+                    writer,
+                    &patch.id,
+                    ApprovalChannelKind::Desktop,
+                    RoadmapPatchApprovalResolution {
+                        decision: RoadmapPatchApprovalDecision::Reject,
+                        comment: comment.clone(),
+                        conflict_choice,
+                    },
+                )
+                .await?;
+            Ok(PatchDecision::Reject {
+                comment,
+                conflict_choice,
+            })
+        },
+        "s" | "store" | "pending" => Ok(PatchDecision::Store),
+        other => Err(anyhow!("unknown approval choice: {other}")),
+    }
+}
+
+async fn record_cli_decision(
+    writer: &surge_persistence::runs::RunWriter,
+    patch: &RoadmapPatch,
+    decision: RoadmapPatchApprovalDecision,
+    comment: Option<String>,
+    conflict_choice: Option<OperatorConflictChoice>,
+) -> Result<()> {
+    let mut approval_loop = RoadmapPatchApprovalLoop::new(0);
+    approval_loop
+        .request_approval(writer, patch, local_approval_channel())
+        .await?;
+    approval_loop
+        .record_decision(
+            writer,
+            &patch.id,
+            ApprovalChannelKind::Desktop,
+            RoadmapPatchApprovalResolution {
+                decision,
+                comment,
+                conflict_choice,
+            },
+        )
+        .await?;
+    Ok(())
+}
+
+fn prompt_for_conflict_choice(patch: &RoadmapPatch) -> Result<Option<OperatorConflictChoice>> {
+    let choices = patch_conflict_choices(patch);
+    if choices.is_empty() {
+        return Ok(None);
+    }
+
+    println!("conflict choices:");
+    for (index, choice) in choices.iter().enumerate() {
+        println!(
+            "  [{}] {} - {}",
+            index + 1,
+            conflict_choice_label(*choice),
+            conflict_choice_hint(*choice)
+        );
+    }
+    print!("conflict choice: ");
+    io::stdout().flush()?;
+    let mut input = String::new();
+    io::stdin().read_line(&mut input)?;
+    parse_conflict_choice_input(input.trim(), &choices).map(Some)
+}
+
+fn parse_conflict_choice_input(
+    input: &str,
+    choices: &[OperatorConflictChoice],
+) -> Result<OperatorConflictChoice> {
+    if let Ok(index) = input.parse::<usize>() {
+        if (1..=choices.len()).contains(&index) {
+            return Ok(choices[index - 1]);
+        }
+    }
+    choices
+        .iter()
+        .copied()
+        .find(|choice| {
+            conflict_choice_label(*choice) == input || clap_conflict_choice_label(*choice) == input
+        })
+        .ok_or_else(|| anyhow!("unknown conflict choice: {input}"))
+}
+
+fn validate_requested_conflict_choice(
+    patch: &RoadmapPatch,
+    choice: Option<OperatorConflictChoice>,
+) -> Result<()> {
+    let Some(choice) = choice else {
+        return Ok(());
+    };
+    if patch_conflict_choices(patch).contains(&choice) {
+        return Ok(());
+    }
+    Err(anyhow!(
+        "conflict choice {} is not available for this patch",
+        conflict_choice_label(choice)
+    ))
+}
+
+fn ensure_conflict_choice_allowed(
+    conflicts: &[RoadmapPatchConflict],
+    choice: OperatorConflictChoice,
+) -> Result<()> {
+    if conflicts
+        .iter()
+        .any(|conflict| conflict.choices.contains(&choice))
+    {
+        return Ok(());
+    }
+    Err(anyhow!(
+        "conflict choice {} is not available for detected conflicts",
+        conflict_choice_label(choice)
+    ))
+}
+
+fn require_conflict_choice_for_approval(
+    patch: &RoadmapPatch,
+    choice: Option<OperatorConflictChoice>,
+) -> Result<()> {
+    if !patch_has_conflicts(patch) || choice.is_some() {
+        return Ok(());
+    }
+    Err(anyhow!(
+        "patch has conflicts; pass --conflict-choice <choice> or use --approval prompt"
+    ))
+}
+
+fn patch_has_conflicts(patch: &RoadmapPatch) -> bool {
+    !patch.conflicts.is_empty()
+}
+
+fn patch_conflict_choices(patch: &RoadmapPatch) -> Vec<OperatorConflictChoice> {
+    let mut choices = Vec::new();
+    for conflict in &patch.conflicts {
+        choices.extend(conflict.choices.iter().copied());
+    }
+    choices.sort_by_key(|choice| conflict_choice_label(*choice));
+    choices.dedup();
+    choices
+}
+
+fn local_approval_channel() -> ApprovalChannel {
+    ApprovalChannel::Desktop {
+        duration: ApprovalDuration::Persistent,
+    }
+}
+
+fn upsert_patch_index(
+    storage: &Arc<Storage>,
+    target: &RoadmapTargetCandidate,
+    patch: &RoadmapPatch,
+    update: PatchIndexUpdate,
+) -> Result<surge_persistence::roadmap_patches::RoadmapPatchIndexRecord> {
+    storage
+        .roadmap_patch_store()
+        .upsert(&RoadmapPatchIndexUpsert {
+            patch_id: patch.id.clone(),
+            content_hash: update.content_hash,
+            run_id: target.run_id,
+            project_path: target.project_path.clone(),
+            target: target.target.clone(),
+            status: update.status,
+            patch_artifact: update.patch_artifact,
+            patch_path: update.patch_path,
+            summary_hash: update.summary_hash,
+            decision: update.decision,
+            decision_comment: update.decision_comment,
+            conflict_choice: update.conflict_choice,
+            observed_at_ms: chrono::Utc::now().timestamp_millis(),
+        })
+        .map_err(Into::into)
+}
+
+struct PatchIndexUpdate {
+    content_hash: ContentHash,
+    status: RoadmapPatchStatus,
+    patch_artifact: Option<ContentHash>,
+    patch_path: Option<PathBuf>,
+    summary_hash: Option<ContentHash>,
+    decision: Option<RoadmapPatchApprovalDecision>,
+    decision_comment: Option<String>,
+    conflict_choice: Option<OperatorConflictChoice>,
+}
+
+fn normalize_patch_target(patch: &mut RoadmapPatch, target: &RoadmapTargetCandidate) {
+    if patch.target != target.target {
+        tracing::warn!(
+            target: "feature_cli",
+            patch_id = %patch.id,
+            planner_target = ?patch.target,
+            selected_target = ?target.target,
+            "normalizing roadmap patch target to selected CLI target"
+        );
+        patch.target = target.target.clone();
+    }
+}
+
+fn attach_apply_conflicts(patch: &mut RoadmapPatch, roadmap_text: &str, json: bool) {
+    let Ok(roadmap) = toml::from_str::<RoadmapArtifact>(roadmap_text) else {
+        return;
+    };
+    match patch.apply_to_roadmap(&roadmap) {
+        Ok(_) => {},
+        Err(RoadmapPatchApplyError::InvalidShape { issues }) => {
+            tracing::warn!(
+                target: "feature_cli",
+                patch_id = %patch.id,
+                issue_count = issues.len(),
+                "roadmap_patch_apply_shape_invalid"
+            );
+        },
+        Err(RoadmapPatchApplyError::Conflicts { conflicts }) => {
+            let detected =
+                surge_orchestrator::roadmap_amendment::apply_conflicts_as_patch_conflicts(
+                    &conflicts,
+                );
+            for conflict in &detected {
+                tracing::warn!(
+                    target: "feature_cli",
+                    patch_id = %patch.id,
+                    code = ?conflict.code,
+                    item = ?conflict.item,
+                    "roadmap_patch_apply_conflict_detected"
+                );
+            }
+            merge_patch_conflicts(patch, detected);
+            progress(
+                json,
+                format_args!(
+                    "conflicts={} choices={}",
+                    patch.conflicts.len(),
+                    conflict_choice_list(&patch.conflicts)
+                ),
+            );
+        },
+    }
+}
+
+fn merge_patch_conflicts(patch: &mut RoadmapPatch, detected: Vec<RoadmapPatchConflict>) {
+    for mut conflict in detected {
+        match patch
+            .conflicts
+            .iter_mut()
+            .find(|existing| existing.code == conflict.code && existing.item == conflict.item)
+        {
+            Some(existing) => {
+                if existing.message.trim().is_empty() {
+                    existing.message = conflict.message;
+                }
+                if existing.choices.is_empty() {
+                    existing.choices = std::mem::take(&mut conflict.choices);
+                }
+            },
+            None => patch.conflicts.push(conflict),
+        }
+    }
+}
+
+fn defer_patch_to_next_milestone(
+    roadmap: &RoadmapArtifact,
+    patch: &RoadmapPatch,
+    conflicts: &[RoadmapPatchConflict],
+) -> Result<RoadmapPatch> {
+    let mut deferred = patch.clone();
+    let mut generated_milestone_ids = existing_milestone_ids(roadmap);
+    for operation in &mut deferred.operations {
+        rewrite_operation_for_deferred_milestone(
+            operation,
+            roadmap,
+            conflicts,
+            &mut generated_milestone_ids,
+        )?;
+    }
+    tracing::debug!(
+        target: "feature_cli",
+        patch_id = %patch.id,
+        "roadmap_patch_target_recalculated_after_conflict_resolution"
+    );
+    Ok(deferred)
+}
+
+fn rewrite_operation_for_deferred_milestone(
+    operation: &mut RoadmapPatchOperation,
+    roadmap: &RoadmapArtifact,
+    conflicts: &[RoadmapPatchConflict],
+    generated_milestone_ids: &mut BTreeSet<String>,
+) -> Result<()> {
+    match operation {
+        RoadmapPatchOperation::AddMilestone { insertion, .. } => {
+            if let Some(milestone_id) =
+                insertion
+                    .as_ref()
+                    .and_then(insertion_milestone_id)
+                    .filter(|milestone_id| {
+                        conflicts_reference_running_milestone(conflicts, milestone_id)
+                    })
+            {
+                *insertion = Some(safe_milestone_insertion_after(roadmap, milestone_id));
+            }
+        },
+        RoadmapPatchOperation::AddTask {
+            milestone_id,
+            task,
+            insertion,
+        } => {
+            if conflicts_reference_running_milestone(conflicts, milestone_id) {
+                if let Some(next_id) = next_pending_milestone_after(roadmap, milestone_id) {
+                    *milestone_id = next_id;
+                    *insertion = Some(InsertionPoint::AppendToMilestone {
+                        milestone_id: milestone_id.clone(),
+                    });
+                } else {
+                    let source = milestone_id.clone();
+                    let new_id =
+                        unique_cli_id(&format!("{source}-deferred"), generated_milestone_ids);
+                    let mut milestone = RoadmapMilestone::new(
+                        new_id.clone(),
+                        format!("Deferred work after {source}"),
+                    );
+                    task.status = RoadmapStatus::Pending;
+                    milestone.tasks.push(task.clone());
+                    *operation = RoadmapPatchOperation::AddMilestone {
+                        milestone,
+                        insertion: Some(InsertionPoint::AppendToRoadmap),
+                    };
+                }
+            }
+        },
+        RoadmapPatchOperation::ReplaceDraftItem {
+            target,
+            replacement,
+            ..
+        } => {
+            let milestone_id = conflict_milestone_for_item(target);
+            if conflicts_reference_running_milestone(conflicts, milestone_id) {
+                *operation = deferred_replacement_operation(
+                    milestone_id,
+                    replacement,
+                    roadmap,
+                    generated_milestone_ids,
+                );
+            }
+        },
+    }
+    Ok(())
+}
+
+fn deferred_replacement_operation(
+    milestone_id: &str,
+    replacement: &RoadmapPatchItem,
+    roadmap: &RoadmapArtifact,
+    generated_milestone_ids: &mut BTreeSet<String>,
+) -> RoadmapPatchOperation {
+    match replacement {
+        RoadmapPatchItem::Milestone { milestone } => {
+            let mut milestone = milestone.clone();
+            milestone.status = RoadmapStatus::Pending;
+            for task in &mut milestone.tasks {
+                task.status = RoadmapStatus::Pending;
+            }
+            RoadmapPatchOperation::AddMilestone {
+                milestone,
+                insertion: Some(safe_milestone_insertion_after(roadmap, milestone_id)),
+            }
+        },
+        RoadmapPatchItem::Task { task } => {
+            if let Some(next_id) = next_pending_milestone_after(roadmap, milestone_id) {
+                let mut task = task.clone();
+                task.status = RoadmapStatus::Pending;
+                RoadmapPatchOperation::AddTask {
+                    milestone_id: next_id.clone(),
+                    task,
+                    insertion: Some(InsertionPoint::AppendToMilestone {
+                        milestone_id: next_id,
+                    }),
+                }
+            } else {
+                let new_id =
+                    unique_cli_id(&format!("{milestone_id}-deferred"), generated_milestone_ids);
+                let mut milestone =
+                    RoadmapMilestone::new(new_id, format!("Deferred rework after {milestone_id}"));
+                let mut task = task.clone();
+                task.status = RoadmapStatus::Pending;
+                milestone.tasks.push(task);
+                RoadmapPatchOperation::AddMilestone {
+                    milestone,
+                    insertion: Some(InsertionPoint::AppendToRoadmap),
+                }
+            }
+        },
+    }
+}
+
+fn existing_milestone_ids(roadmap: &RoadmapArtifact) -> BTreeSet<String> {
+    roadmap
+        .milestones
+        .iter()
+        .map(|milestone| milestone.id.clone())
+        .collect()
+}
+
+fn unique_cli_id(base: &str, used: &mut BTreeSet<String>) -> String {
+    if used.insert(base.to_owned()) {
+        return base.to_owned();
+    }
+    let mut suffix = 2_u32;
+    loop {
+        let candidate = format!("{base}-{suffix}");
+        if used.insert(candidate.clone()) {
+            return candidate;
+        }
+        suffix += 1;
+    }
+}
+
+fn conflict_milestone_for_item(item: &RoadmapItemRef) -> &str {
+    match item {
+        RoadmapItemRef::Milestone { milestone_id } | RoadmapItemRef::Task { milestone_id, .. } => {
+            milestone_id
+        },
+    }
+}
+
+fn conflicts_reference_running_milestone(
+    conflicts: &[RoadmapPatchConflict],
+    milestone_id: &str,
+) -> bool {
+    conflicts.iter().any(|conflict| {
+        conflict.code == RoadmapPatchConflictCode::RunningMilestone
+            && conflict.item.as_ref().map(conflict_milestone_for_item) == Some(milestone_id)
+    })
+}
+
+fn insertion_milestone_id(insertion: &InsertionPoint) -> Option<&str> {
+    match insertion {
+        InsertionPoint::BeforeMilestone { milestone_id }
+        | InsertionPoint::AfterMilestone { milestone_id }
+        | InsertionPoint::AppendToMilestone { milestone_id }
+        | InsertionPoint::BeforeTask { milestone_id, .. }
+        | InsertionPoint::AfterTask { milestone_id, .. } => Some(milestone_id),
+        InsertionPoint::AppendToRoadmap => None,
+    }
+}
+
+fn safe_milestone_insertion_after(roadmap: &RoadmapArtifact, milestone_id: &str) -> InsertionPoint {
+    next_pending_milestone_after(roadmap, milestone_id).map_or(
+        InsertionPoint::AppendToRoadmap,
+        |next_id| InsertionPoint::BeforeMilestone {
+            milestone_id: next_id,
+        },
+    )
+}
+
+fn next_pending_milestone_after(roadmap: &RoadmapArtifact, milestone_id: &str) -> Option<String> {
+    let start_index = roadmap
+        .milestones
+        .iter()
+        .position(|milestone| milestone.id == milestone_id)?;
+    roadmap
+        .milestones
+        .iter()
+        .skip(start_index + 1)
+        .find(|milestone| milestone.status == RoadmapStatus::Pending)
+        .map(|milestone| milestone.id.clone())
+}
+
+async fn append_feature_run_started(
+    writer: &surge_persistence::runs::RunWriter,
+    worktree: &Path,
+) -> Result<()> {
+    writer
+        .append_event(VersionedEventPayload::new(EventPayload::RunStarted {
+            pipeline_template: None,
+            project_path: worktree.to_path_buf(),
+            initial_prompt: String::new(),
+            config: RunConfig {
+                sandbox_default: SandboxMode::WorkspaceWrite,
+                approval_default: ApprovalPolicy::OnRequest,
+                auto_pr: false,
+                mcp_servers: Vec::new(),
+            },
+        }))
+        .await?;
+    Ok(())
+}
+
+async fn append_feature_run_terminal(
+    writer: &surge_persistence::runs::RunWriter,
+    result: &Result<()>,
+) -> Result<()> {
+    let payload = match result {
+        Ok(()) => EventPayload::RunCompleted {
+            terminal_node: surge_core::keys::NodeKey::try_from(FEATURE_PLANNER_TERMINAL_NODE)
+                .context("feature planner terminal node key")?,
+        },
+        Err(error) => EventPayload::RunFailed {
+            error: error.to_string(),
+        },
+    };
+    writer
+        .append_event(VersionedEventPayload::new(payload))
+        .await?;
+    Ok(())
+}
+
+fn target_selector(args: &FeatureDescribeArgs) -> Result<RoadmapTargetSelector> {
+    match (&args.run_id, args.project) {
+        (Some(_), true) => Err(anyhow!("pass either --run <RUN_ID> or --project, not both")),
+        (Some(run_id), false) => Ok(RoadmapTargetSelector::Run {
+            run_id: parse_run_id(run_id)?,
+        }),
+        (None, true) => Ok(RoadmapTargetSelector::ProjectFile),
+        (None, false) => Ok(RoadmapTargetSelector::Auto),
+    }
+}
+
+fn resolve_feature_worktree(
+    override_path: Option<&Path>,
+    target: &RoadmapTargetCandidate,
+    project_root: &Path,
+) -> Result<PathBuf> {
+    let worktree = override_path
+        .map(Path::to_path_buf)
+        .or_else(|| target.worktree_path.clone())
+        .unwrap_or_else(|| project_root.to_path_buf());
+    let worktree = absolute_path_from(project_root, worktree);
+    if !worktree.exists() {
+        return Err(anyhow!(
+            "worktree path does not exist: {}",
+            worktree.display()
+        ));
+    }
+    Ok(worktree)
+}
+
+fn roadmap_prompt_text(path: &Path, content: &str) -> String {
+    match parse_roadmap_document(path, content) {
+        Ok(parsed) => {
+            let mut prompt = if path.extension().and_then(|ext| ext.to_str()) == Some("toml") {
+                parsed.roadmap.to_markdown()
+            } else {
+                content.to_owned()
+            };
+            prompt.push_str(&roadmap_identifiers_prompt(&parsed));
+            prompt
+        },
+        Err(_) => content.to_owned(),
+    }
+}
+
+fn target_label(target: &RoadmapTargetCandidate) -> String {
+    match target.run_id {
+        Some(run_id) => format!(
+            "run:{run_id}:{}",
+            target
+                .run_status
+                .map_or_else(|| "unknown".to_owned(), |status| status.to_string())
+        ),
+        None => format!("project:{}", target.roadmap_path.display()),
+    }
+}
+
+fn print_patch_table(records: &[RoadmapPatchIndexRecord]) {
+    println!(
+        "{:<24} {:<16} {:<28} UPDATED",
+        "PATCH_ID", "STATUS", "TARGET"
+    );
+    for record in records {
+        println!(
+            "{:<24} {:<16} {:<28} {}",
+            record.patch_id,
+            patch_status_label(record.status),
+            patch_target_label(&record.target),
+            record.updated_at_ms
+        );
+    }
+}
+
+fn print_patch_detail(record: &RoadmapPatchIndexRecord) {
+    println!("patch_id={}", record.patch_id);
+    println!("status={}", patch_status_label(record.status));
+    println!("target={}", patch_target_label(&record.target));
+    println!("content_hash={}", record.content_hash);
+    if let Some(run_id) = record.run_id {
+        println!("run_id={run_id}");
+    }
+    if let Some(path) = &record.patch_path {
+        println!("patch_path={}", path.display());
+    }
+    if let Some(hash) = record.patch_artifact {
+        println!("patch_artifact={hash}");
+    }
+    if let Some(decision) = record.decision {
+        println!("decision={}", approval_decision_label(decision));
+    }
+    if let Some(comment) = &record.decision_comment {
+        println!("comment={comment}");
+    }
+    if let Some(choice) = record.conflict_choice {
+        println!("conflict_choice={}", conflict_choice_label(choice));
+    }
+    println!("created_at_ms={}", record.created_at_ms);
+    println!("updated_at_ms={}", record.updated_at_ms);
+}
+
+fn patch_target_label(target: &RoadmapPatchTarget) -> String {
+    match target {
+        RoadmapPatchTarget::ProjectRoadmap { roadmap_path } => {
+            format!("project:{roadmap_path}")
+        },
+        RoadmapPatchTarget::RunRoadmap { run_id, .. } => format!("run:{run_id}"),
+    }
+}
+
+fn parse_run_id(value: &str) -> Result<RunId> {
+    value
+        .parse()
+        .map_err(|error| anyhow!("invalid run id '{value}': {error}"))
+}
+
+fn parse_patch_id(value: &str) -> Result<RoadmapPatchId> {
+    RoadmapPatchId::new(value)
+        .map_err(|error| anyhow!("invalid roadmap patch id '{value}': {error}"))
+}
+
+fn output_message(status: RoadmapPatchStatus) -> String {
+    match status {
+        RoadmapPatchStatus::Drafted => "patch drafted".into(),
+        RoadmapPatchStatus::PendingApproval => "patch stored pending approval".into(),
+        RoadmapPatchStatus::Approved => "patch approved and stored".into(),
+        RoadmapPatchStatus::Applied => "patch applied".into(),
+        RoadmapPatchStatus::Rejected => "patch rejected".into(),
+        RoadmapPatchStatus::Superseded => "patch superseded".into(),
+    }
+}
+
+fn patch_status_label(status: RoadmapPatchStatus) -> &'static str {
+    match status {
+        RoadmapPatchStatus::Drafted => "drafted",
+        RoadmapPatchStatus::PendingApproval => "pending_approval",
+        RoadmapPatchStatus::Approved => "approved",
+        RoadmapPatchStatus::Applied => "applied",
+        RoadmapPatchStatus::Rejected => "rejected",
+        RoadmapPatchStatus::Superseded => "superseded",
+    }
+}
+
+fn approval_decision_label(decision: RoadmapPatchApprovalDecision) -> &'static str {
+    match decision {
+        RoadmapPatchApprovalDecision::Approve => "approve",
+        RoadmapPatchApprovalDecision::Edit => "edit",
+        RoadmapPatchApprovalDecision::Reject => "reject",
+    }
+}
+
+fn conflict_choice_label(choice: OperatorConflictChoice) -> &'static str {
+    match choice {
+        OperatorConflictChoice::DeferToNextMilestone => "defer_to_next_milestone",
+        OperatorConflictChoice::AbortCurrentRun => "abort_current_run",
+        OperatorConflictChoice::CreateFollowUpRun => "create_follow_up_run",
+        OperatorConflictChoice::RejectPatch => "reject_patch",
+    }
+}
+
+fn clap_conflict_choice_label(choice: OperatorConflictChoice) -> &'static str {
+    match choice {
+        OperatorConflictChoice::DeferToNextMilestone => "defer-to-next-milestone",
+        OperatorConflictChoice::AbortCurrentRun => "abort-current-run",
+        OperatorConflictChoice::CreateFollowUpRun => "create-follow-up-run",
+        OperatorConflictChoice::RejectPatch => "reject-patch",
+    }
+}
+
+fn conflict_choice_hint(choice: OperatorConflictChoice) -> &'static str {
+    match choice {
+        OperatorConflictChoice::DeferToNextMilestone => "move work to the next pending milestone",
+        OperatorConflictChoice::AbortCurrentRun => "pause here and abort the active run first",
+        OperatorConflictChoice::CreateFollowUpRun => "materialize a separate follow-up run",
+        OperatorConflictChoice::RejectPatch => "reject this roadmap patch",
+    }
+}
+
+fn conflict_choice_list(conflicts: &[RoadmapPatchConflict]) -> String {
+    let mut choices = Vec::new();
+    for conflict in conflicts {
+        choices.extend(conflict.choices.iter().copied());
+    }
+    choices.sort_by_key(|choice| conflict_choice_label(*choice));
+    choices.dedup();
+    choices
+        .into_iter()
+        .map(conflict_choice_label)
+        .collect::<Vec<_>>()
+        .join(",")
+}
+
+fn progress(json: bool, args: std::fmt::Arguments<'_>) {
+    if json {
+        eprintln!("{args}");
+    } else {
+        println!("{args}");
+    }
+}
+
+fn emit_output(json: bool, output: FeatureDescribeOutput) -> Result<()> {
+    if json {
+        println!("{}", serde_json::to_string_pretty(&output)?);
+    } else {
+        println!("{}", output.message);
+        if let Some(patch_id) = &output.patch_id {
+            println!("patch_id={patch_id}");
+        }
+        println!("planner_run_id={}", output.planner_run_id);
+        if let Some(run_id) = &output.follow_up_run_id {
+            println!("followup_run_id={run_id}");
+        }
+        if let Some(choice) = &output.conflict_choice {
+            println!("conflict_choice={choice}");
+        }
+    }
+    Ok(())
+}
+
+#[derive(Serialize)]
+struct FeatureDescribeOutput {
+    status: String,
+    planner_run_id: String,
+    patch_id: Option<String>,
+    target: String,
+    patch_artifact: Option<String>,
+    patch_path: Option<String>,
+    follow_up_run_id: Option<String>,
+    conflict_choice: Option<String>,
+    message: String,
+}
+
+impl FeatureDescribeOutput {
+    fn out_of_scope(planner_run_id: RunId, target: &RoadmapTargetCandidate) -> Self {
+        Self {
+            status: "out_of_scope".into(),
+            planner_run_id: planner_run_id.to_string(),
+            patch_id: None,
+            target: target_label(target),
+            patch_artifact: None,
+            patch_path: None,
+            follow_up_run_id: None,
+            conflict_choice: None,
+            message: "request is out of scope for the selected roadmap".into(),
+        }
+    }
+}
+
+fn load_project_config_for_current_repo() -> Result<(SurgeConfig, PathBuf)> {
+    let project_root = GitManager::discover()
+        .map(|manager| manager.repo_path().to_path_buf())
+        .unwrap_or_else(|_| std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")));
+    let config_path = project_root.join("surge.toml");
+    let config = if config_path.exists() {
+        SurgeConfig::load(&config_path)
+            .with_context(|| format!("load {}", config_path.display()))?
+    } else {
+        SurgeConfig::load_or_default().context("load surge config")?
+    };
+    Ok((config, project_root))
+}
+
+fn surge_home_dir() -> Result<PathBuf> {
+    let home = dirs::home_dir().ok_or_else(|| anyhow!("HOME not set"))?;
+    let dir = home.join(".surge");
+    std::fs::create_dir_all(&dir).with_context(|| format!("create {}", dir.display()))?;
+    Ok(dir)
+}
+
+fn absolute_path_from(base: &Path, path: PathBuf) -> PathBuf {
+    if path.is_absolute() {
+        path
+    } else {
+        base.join(path)
+    }
+}

--- a/crates/surge-cli/src/commands/mod.rs
+++ b/crates/surge-cli/src/commands/mod.rs
@@ -5,6 +5,7 @@ pub mod bootstrap;
 pub mod config;
 pub mod daemon;
 pub mod engine;
+pub mod feature;
 pub mod format;
 pub mod git;
 pub mod init;

--- a/crates/surge-cli/src/main.rs
+++ b/crates/surge-cli/src/main.rs
@@ -16,9 +16,9 @@ mod commands;
 
 use commands::{
     agent::AgentCommands, analytics::AnalyticsCommands, bootstrap::BootstrapArgs,
-    config::ConfigCommands, init::InitArgs, insights::InsightsCommands, memory::MemoryCommands,
-    project::ProjectCommands, registry::RegistryCommands, spec::SpecCommands,
-    tracker::TrackerCommand,
+    config::ConfigCommands, feature::FeatureCommands, init::InitArgs, insights::InsightsCommands,
+    memory::MemoryCommands, project::ProjectCommands, registry::RegistryCommands,
+    spec::SpecCommands, tracker::TrackerCommand,
 };
 
 #[derive(Parser)]
@@ -201,6 +201,12 @@ enum Commands {
     /// Bootstrap an adaptive flow from a free-form prompt.
     Bootstrap(BootstrapArgs),
 
+    /// Draft and apply roadmap amendments from follow-up feature requests.
+    Feature {
+        #[command(subcommand)]
+        command: FeatureCommands,
+    },
+
     /// New M6 engine commands — runs flow.toml graphs in-process.
     Engine {
         #[command(subcommand)]
@@ -353,6 +359,7 @@ async fn main() -> Result<()> {
             | Commands::Clean { .. }
             | Commands::Config { .. }
             | Commands::Bootstrap(_)
+            | Commands::Feature { .. }
             | Commands::Engine { .. }
             | Commands::Artifact { .. }
             | Commands::Tracker { .. }
@@ -560,6 +567,10 @@ async fn run_command(command: Commands) -> Result<()> {
 
         Commands::Bootstrap(args) => {
             commands::bootstrap::run(args).await?;
+        },
+
+        Commands::Feature { command } => {
+            commands::feature::run(command).await?;
         },
 
         Commands::Engine { command } => {

--- a/crates/surge-cli/tests/cli_feature_help.rs
+++ b/crates/surge-cli/tests/cli_feature_help.rs
@@ -1,0 +1,64 @@
+//! CLI smoke: `surge feature` exposes the roadmap amendment entrypoint.
+
+use assert_cmd::Command;
+use predicates::str::contains;
+
+#[test]
+fn feature_help_lists_describe() {
+    Command::cargo_bin("surge")
+        .unwrap()
+        .args(["feature", "--help"])
+        .assert()
+        .success()
+        .stdout(contains("describe"))
+        .stdout(contains("list"))
+        .stdout(contains("show"))
+        .stdout(contains("reject"));
+}
+
+#[test]
+fn feature_describe_help_lists_target_and_output_flags() {
+    Command::cargo_bin("surge")
+        .unwrap()
+        .args(["feature", "describe", "--help"])
+        .assert()
+        .success()
+        .stdout(contains("--run"))
+        .stdout(contains("--project"))
+        .stdout(contains("--worktree"))
+        .stdout(contains("--approval"))
+        .stdout(contains("--conflict-choice"))
+        .stdout(contains("--json"));
+}
+
+#[test]
+fn feature_list_empty_registry_json_works() {
+    let temp = tempfile::tempdir().unwrap();
+    let home = temp.path().join("home");
+    std::fs::create_dir_all(&home).unwrap();
+
+    Command::cargo_bin("surge")
+        .unwrap()
+        .args(["feature", "list", "--all-projects", "--json"])
+        .env("HOME", &home)
+        .env("USERPROFILE", &home)
+        .assert()
+        .success()
+        .stdout(contains("[]"));
+}
+
+#[test]
+fn feature_show_missing_patch_reports_error() {
+    let temp = tempfile::tempdir().unwrap();
+    let home = temp.path().join("home");
+    std::fs::create_dir_all(&home).unwrap();
+
+    Command::cargo_bin("surge")
+        .unwrap()
+        .args(["feature", "show", "rpatch-missing"])
+        .env("HOME", &home)
+        .env("USERPROFILE", &home)
+        .assert()
+        .failure()
+        .stderr(contains("roadmap patch not found"));
+}

--- a/crates/surge-core/bundled/profiles/feature-planner-1.0.toml
+++ b/crates/surge-core/bundled/profiles/feature-planner-1.0.toml
@@ -19,13 +19,17 @@ default_max_tokens = 64000
 agent_id = "claude-code"
 
 [sandbox]
-mode = "read-only"
+mode = "workspace-write"
 
 [[outcomes]]
 id = "patched"
 description = "RoadmapPatch drafted with a clear insertion point and dependencies."
 edge_kind_hint = "forward"
 required_artifacts = ["roadmap-patch.toml"]
+
+[[outcomes.produced_artifacts]]
+path = "roadmap-patch.toml"
+contract = { kind = "roadmap-patch", schema_version = 1 }
 
 [[outcomes]]
 id = "out_of_scope"
@@ -40,19 +44,34 @@ source = { source = "any" }
 name = "roadmap"
 source = { source = "any" }
 
+[[hooks.entries]]
+id = "validate-roadmap-patch"
+trigger = "on_outcome"
+matcher = { outcome = "patched" }
+command = "{surge} artifact validate --kind roadmap-patch roadmap-patch.toml"
+on_failure = "reject"
+timeout_seconds = 30
+
 [prompt]
 system = """\
 You are the Feature Planner. Read `{{request}}` and the current `{{roadmap}}` and produce a
 `roadmap-patch.toml` in the project's RoadmapPatch schema.
 
 Required fields:
-- `insertion_point`: which milestone this attaches to and where (`before`/`after`/`replace`).
-- `items`: the new milestone(s) and/or task(s).
-- `dependencies`: explicit edges from new items to existing milestones, when needed.
+- `schema_version = 1`.
+- `id`: stable patch id, preferably `rpatch-<short-content-name>`.
+- `[target]`: the supplied roadmap target.
+- `[[operations]]`: add milestone, add task, or replace draft-only item operations.
+- Each add operation must include an `insertion` table.
+- `dependencies`: explicit edges from new items to existing milestones or tasks, when needed.
 - `rationale`: why this patch is justified now (1-3 sentences referencing concrete project state).
 
 Rules:
 - A patch always lands as an *append* relative to the current head. Never modify completed work.
 - If the request belongs in a follow-up project rather than the current roadmap, report `out_of_scope`.
 - The patch is content-hashed: re-applying the same patch must be a no-op.
+
+When finished:
+1. Write `roadmap-patch.toml`.
+2. Call `report_stage_outcome` with outcome `patched` and `artifacts_produced = ["roadmap-patch.toml"]`.
 """

--- a/crates/surge-core/src/artifact_contract.rs
+++ b/crates/surge-core/src/artifact_contract.rs
@@ -711,23 +711,38 @@ fn introduced_refs(patch: &RoadmapPatch) -> Vec<RoadmapItemRef> {
                 milestone_id: milestone_id.clone(),
                 task_id: task.id.clone(),
             }),
-            RoadmapPatchOperation::ReplaceDraftItem { replacement, .. } => {
-                push_replacement_ref(&mut refs, replacement);
+            RoadmapPatchOperation::ReplaceDraftItem {
+                target,
+                replacement,
+                ..
+            } => {
+                push_replacement_ref(&mut refs, target, replacement);
             },
         }
     }
     refs
 }
 
-fn push_replacement_ref(refs: &mut Vec<RoadmapItemRef>, replacement: &RoadmapPatchItem) {
-    match replacement {
-        RoadmapPatchItem::Milestone { milestone } => refs.push(RoadmapItemRef::Milestone {
+fn push_replacement_ref(
+    refs: &mut Vec<RoadmapItemRef>,
+    target: &RoadmapItemRef,
+    replacement: &RoadmapPatchItem,
+) {
+    match (target, replacement) {
+        (_, RoadmapPatchItem::Milestone { milestone }) => refs.push(RoadmapItemRef::Milestone {
             milestone_id: milestone.id.clone(),
         }),
-        RoadmapPatchItem::Task { task } => refs.push(RoadmapItemRef::Task {
-            milestone_id: String::new(),
+        (
+            RoadmapItemRef::Task {
+                milestone_id,
+                task_id: _,
+            },
+            RoadmapPatchItem::Task { task },
+        ) => refs.push(RoadmapItemRef::Task {
+            milestone_id: milestone_id.clone(),
             task_id: task.id.clone(),
         }),
+        _ => {},
     }
 }
 
@@ -1487,6 +1502,56 @@ milestone_id = "missing"
                 .iter()
                 .any(|diagnostic| { diagnostic.code == ArtifactDiagnosticCode::InvalidReference })
         );
+    }
+
+    #[test]
+    fn replacement_task_introduces_ref_with_target_milestone_context() {
+        let mut milestone = crate::roadmap::RoadmapMilestone::new("m1", "Existing");
+        milestone
+            .tasks
+            .push(crate::roadmap::RoadmapTask::new("m1-t1", "Old task"));
+        let roadmap = RoadmapArtifact::new(vec![milestone]);
+
+        let report = validate_roadmap_patch_text_with_context(
+            r#"schema_version = 1
+id = "rpatch-replace-ref"
+
+[target]
+kind = "project_roadmap"
+roadmap_path = ".ai-factory/ROADMAP.md"
+
+[[operations]]
+op = "replace_draft_item"
+reason = "rename draft task"
+
+[operations.target]
+kind = "task"
+milestone_id = "m1"
+task_id = "m1-t1"
+
+[operations.replacement]
+kind = "task"
+
+[operations.replacement.task]
+id = "m1-t2"
+title = "New task"
+
+[[dependencies]]
+reason = "new task depends on old milestone"
+
+[dependencies.from]
+kind = "task"
+milestone_id = "m1"
+task_id = "m1-t2"
+
+[dependencies.to]
+kind = "milestone"
+milestone_id = "m1"
+"#,
+            &roadmap,
+        );
+
+        assert!(report.is_valid(), "{report:#?}");
     }
 
     #[test]

--- a/crates/surge-core/src/artifact_contract.rs
+++ b/crates/surge-core/src/artifact_contract.rs
@@ -10,6 +10,12 @@ use std::fmt;
 use std::path::Path;
 use std::str::FromStr;
 
+use crate::roadmap::RoadmapArtifact;
+use crate::roadmap_patch::{
+    InsertionPoint, RoadmapItemRef, RoadmapPatch, RoadmapPatchItem, RoadmapPatchOperation,
+    RoadmapPatchValidationCode, RoadmapPatchValidationIssue,
+};
+
 /// Current schema version used by Surge-owned artifact contracts.
 pub const ARTIFACT_SCHEMA_VERSION: u32 = 1;
 
@@ -23,6 +29,8 @@ pub enum ArtifactKind {
     Requirements,
     /// Roadmap Planner artifact.
     Roadmap,
+    /// Roadmap amendment patch artifact.
+    RoadmapPatch,
     /// Spec Author artifact.
     Spec,
     /// Architect decision artifact.
@@ -43,6 +51,7 @@ impl ArtifactKind {
             Self::Description => "description",
             Self::Requirements => "requirements",
             Self::Roadmap => "roadmap",
+            Self::RoadmapPatch => "roadmap-patch",
             Self::Spec => "spec",
             Self::Adr => "adr",
             Self::Story => "story",
@@ -79,6 +88,7 @@ impl FromStr for ArtifactKind {
             "description" | "description-md" => Ok(Self::Description),
             "requirements" | "requirements-md" => Ok(Self::Requirements),
             "roadmap" | "roadmap-md" | "roadmap-toml" => Ok(Self::Roadmap),
+            "roadmap-patch" | "roadmap_patch" | "roadmap-patch-toml" => Ok(Self::RoadmapPatch),
             "spec" | "spec-md" | "spec-toml" => Ok(Self::Spec),
             "adr" | "architecture-decision-record" => Ok(Self::Adr),
             "story" | "story-file" => Ok(Self::Story),
@@ -171,6 +181,12 @@ pub enum ArtifactDiagnosticCode {
     GraphValidationFailed,
     /// Flow graph failed to deserialize into the engine graph model.
     GraphParseFailed,
+    /// Roadmap patch has no operations.
+    MissingOperation,
+    /// Roadmap patch add operation is missing an insertion point.
+    MissingInsertionPoint,
+    /// Roadmap patch references a missing roadmap item.
+    InvalidReference,
 }
 
 impl ArtifactDiagnosticCode {
@@ -189,6 +205,9 @@ impl ArtifactDiagnosticCode {
             Self::UnsupportedArtifactKind => "unsupported_artifact_kind",
             Self::GraphValidationFailed => "graph_validation_failed",
             Self::GraphParseFailed => "graph_parse_failed",
+            Self::MissingOperation => "missing_operation",
+            Self::MissingInsertionPoint => "missing_insertion_point",
+            Self::InvalidReference => "invalid_reference",
         }
     }
 }
@@ -385,6 +404,7 @@ pub const fn contract_for(kind: ArtifactKind) -> ArtifactContract {
         ArtifactKind::Description => DESCRIPTION_CONTRACT,
         ArtifactKind::Requirements => REQUIREMENTS_CONTRACT,
         ArtifactKind::Roadmap => ROADMAP_CONTRACT,
+        ArtifactKind::RoadmapPatch => ROADMAP_PATCH_CONTRACT,
         ArtifactKind::Spec => SPEC_CONTRACT,
         ArtifactKind::Adr => ADR_CONTRACT,
         ArtifactKind::Story => STORY_CONTRACT,
@@ -424,6 +444,22 @@ pub fn validate_artifact_text(kind: ArtifactKind, content: &str) -> ArtifactVali
     report
 }
 
+/// Validate a roadmap patch and resolve references against a roadmap context.
+#[must_use]
+pub fn validate_roadmap_patch_text_with_context(
+    content: &str,
+    roadmap: &RoadmapArtifact,
+) -> ArtifactValidationReport {
+    let mut report = validate_artifact_text(ArtifactKind::RoadmapPatch, content);
+    let Some(patch) = parse_roadmap_patch_for_context(&mut report, content) else {
+        return report;
+    };
+    if report.is_valid() {
+        validate_roadmap_patch_context(&mut report, &patch, roadmap);
+    }
+    report
+}
+
 fn validate_artifact_path_into(report: &mut ArtifactValidationReport, path: &Path) {
     let contract = contract_for(report.kind);
     if contract.accepts_path(path) {
@@ -450,6 +486,7 @@ fn validate_artifact_text_into(
         ArtifactKind::Description => validate_description_markdown(report, content),
         ArtifactKind::Requirements => validate_requirements_markdown(report, content),
         ArtifactKind::Roadmap => validate_roadmap(report, path, content),
+        ArtifactKind::RoadmapPatch => validate_roadmap_patch(report, content),
         ArtifactKind::Spec => validate_spec(report, path, content),
         ArtifactKind::Adr => validate_adr_markdown(report, content),
         ArtifactKind::Story => validate_story_markdown(report, content),
@@ -485,6 +522,19 @@ fn validate_roadmap(report: &mut ArtifactValidationReport, path: Option<&Path>, 
         require_markdown_sections(report, content, &["Milestones", "Dependencies", "Risks"]);
     } else {
         let _ = validate_toml_artifact(report, content, &["milestones"]);
+    }
+}
+
+fn validate_roadmap_patch(report: &mut ArtifactValidationReport, content: &str) {
+    if validate_toml_artifact(report, content, &["id", "target", "operations"]).is_none() {
+        return;
+    }
+
+    let Some(patch) = parse_roadmap_patch(report, content) else {
+        return;
+    };
+    for issue in patch.validate_shape() {
+        report.push(roadmap_patch_issue_to_diagnostic(issue));
     }
 }
 
@@ -555,6 +605,236 @@ fn validate_toml_artifact(
     validate_schema_version(report, &value, ARTIFACT_SCHEMA_VERSION);
     require_toml_fields(report, &value, required_fields);
     Some(value)
+}
+
+fn parse_roadmap_patch(
+    report: &mut ArtifactValidationReport,
+    content: &str,
+) -> Option<RoadmapPatch> {
+    match toml::from_str::<RoadmapPatch>(content) {
+        Ok(patch) => Some(patch),
+        Err(error) => {
+            report.push(ArtifactValidationDiagnostic::error(
+                ArtifactKind::RoadmapPatch,
+                ArtifactDiagnosticCode::InvalidToml,
+                None,
+                format!("roadmap patch failed to parse: {error}"),
+            ));
+            None
+        },
+    }
+}
+
+fn parse_roadmap_patch_for_context(
+    report: &mut ArtifactValidationReport,
+    content: &str,
+) -> Option<RoadmapPatch> {
+    if report.is_valid() {
+        parse_roadmap_patch(report, content)
+    } else {
+        None
+    }
+}
+
+fn roadmap_patch_issue_to_diagnostic(
+    issue: RoadmapPatchValidationIssue,
+) -> ArtifactValidationDiagnostic {
+    ArtifactValidationDiagnostic::error(
+        ArtifactKind::RoadmapPatch,
+        roadmap_patch_code_to_artifact_code(issue.code),
+        Some(issue.location),
+        issue.message,
+    )
+}
+
+const fn roadmap_patch_code_to_artifact_code(
+    code: RoadmapPatchValidationCode,
+) -> ArtifactDiagnosticCode {
+    match code {
+        RoadmapPatchValidationCode::UnsupportedSchemaVersion => {
+            ArtifactDiagnosticCode::UnsupportedSchemaVersion
+        },
+        RoadmapPatchValidationCode::MissingOperation => ArtifactDiagnosticCode::MissingOperation,
+        RoadmapPatchValidationCode::MissingInsertionPoint => {
+            ArtifactDiagnosticCode::MissingInsertionPoint
+        },
+        RoadmapPatchValidationCode::MissingTargetReference
+        | RoadmapPatchValidationCode::MissingTitle
+        | RoadmapPatchValidationCode::MissingConflictMessage
+        | RoadmapPatchValidationCode::MissingConflictChoice => ArtifactDiagnosticCode::MissingField,
+    }
+}
+
+fn validate_roadmap_patch_context(
+    report: &mut ArtifactValidationReport,
+    patch: &RoadmapPatch,
+    roadmap: &RoadmapArtifact,
+) {
+    let introduced = introduced_refs(patch);
+    for (index, operation) in patch.operations.iter().enumerate() {
+        validate_operation_references(report, roadmap, &introduced, index, operation);
+    }
+    for (index, dependency) in patch.dependencies.iter().enumerate() {
+        validate_context_ref(
+            report,
+            roadmap,
+            &introduced,
+            &dependency.from,
+            format!("dependencies[{index}].from"),
+        );
+        validate_context_ref(
+            report,
+            roadmap,
+            &introduced,
+            &dependency.to,
+            format!("dependencies[{index}].to"),
+        );
+    }
+}
+
+fn introduced_refs(patch: &RoadmapPatch) -> Vec<RoadmapItemRef> {
+    let mut refs = Vec::new();
+    for operation in &patch.operations {
+        match operation {
+            RoadmapPatchOperation::AddMilestone { milestone, .. } => {
+                refs.push(RoadmapItemRef::Milestone {
+                    milestone_id: milestone.id.clone(),
+                });
+                refs.extend(milestone.tasks.iter().map(|task| RoadmapItemRef::Task {
+                    milestone_id: milestone.id.clone(),
+                    task_id: task.id.clone(),
+                }));
+            },
+            RoadmapPatchOperation::AddTask {
+                milestone_id, task, ..
+            } => refs.push(RoadmapItemRef::Task {
+                milestone_id: milestone_id.clone(),
+                task_id: task.id.clone(),
+            }),
+            RoadmapPatchOperation::ReplaceDraftItem { replacement, .. } => {
+                push_replacement_ref(&mut refs, replacement);
+            },
+        }
+    }
+    refs
+}
+
+fn push_replacement_ref(refs: &mut Vec<RoadmapItemRef>, replacement: &RoadmapPatchItem) {
+    match replacement {
+        RoadmapPatchItem::Milestone { milestone } => refs.push(RoadmapItemRef::Milestone {
+            milestone_id: milestone.id.clone(),
+        }),
+        RoadmapPatchItem::Task { task } => refs.push(RoadmapItemRef::Task {
+            milestone_id: String::new(),
+            task_id: task.id.clone(),
+        }),
+    }
+}
+
+fn validate_operation_references(
+    report: &mut ArtifactValidationReport,
+    roadmap: &RoadmapArtifact,
+    introduced: &[RoadmapItemRef],
+    index: usize,
+    operation: &RoadmapPatchOperation,
+) {
+    match operation {
+        RoadmapPatchOperation::AddMilestone { insertion, .. }
+        | RoadmapPatchOperation::AddTask { insertion, .. } => {
+            if let Some(insertion) = insertion {
+                validate_insertion_context(report, roadmap, introduced, index, insertion);
+            }
+        },
+        RoadmapPatchOperation::ReplaceDraftItem { target, .. } => {
+            validate_context_ref(
+                report,
+                roadmap,
+                introduced,
+                target,
+                format!("operations[{index}].target"),
+            );
+        },
+    }
+}
+
+fn validate_insertion_context(
+    report: &mut ArtifactValidationReport,
+    roadmap: &RoadmapArtifact,
+    introduced: &[RoadmapItemRef],
+    index: usize,
+    insertion: &InsertionPoint,
+) {
+    match insertion {
+        InsertionPoint::AppendToRoadmap => {},
+        InsertionPoint::BeforeMilestone { milestone_id }
+        | InsertionPoint::AfterMilestone { milestone_id }
+        | InsertionPoint::AppendToMilestone { milestone_id } => {
+            let reference = RoadmapItemRef::Milestone {
+                milestone_id: milestone_id.clone(),
+            };
+            validate_context_ref(
+                report,
+                roadmap,
+                introduced,
+                &reference,
+                format!("operations[{index}].insertion"),
+            );
+        },
+        InsertionPoint::BeforeTask {
+            milestone_id,
+            task_id,
+        }
+        | InsertionPoint::AfterTask {
+            milestone_id,
+            task_id,
+        } => {
+            let reference = RoadmapItemRef::Task {
+                milestone_id: milestone_id.clone(),
+                task_id: task_id.clone(),
+            };
+            validate_context_ref(
+                report,
+                roadmap,
+                introduced,
+                &reference,
+                format!("operations[{index}].insertion"),
+            );
+        },
+    }
+}
+
+fn validate_context_ref(
+    report: &mut ArtifactValidationReport,
+    roadmap: &RoadmapArtifact,
+    introduced: &[RoadmapItemRef],
+    reference: &RoadmapItemRef,
+    location: String,
+) {
+    if roadmap_contains_ref(roadmap, reference) || introduced.contains(reference) {
+        return;
+    }
+
+    report.push(ArtifactValidationDiagnostic::error(
+        ArtifactKind::RoadmapPatch,
+        ArtifactDiagnosticCode::InvalidReference,
+        Some(location),
+        "roadmap patch references an item not present in the supplied roadmap context",
+    ));
+}
+
+fn roadmap_contains_ref(roadmap: &RoadmapArtifact, reference: &RoadmapItemRef) -> bool {
+    match reference {
+        RoadmapItemRef::Milestone { milestone_id } => roadmap
+            .milestones
+            .iter()
+            .any(|milestone| milestone.id == *milestone_id),
+        RoadmapItemRef::Task {
+            milestone_id,
+            task_id,
+        } => roadmap.milestones.iter().any(|milestone| {
+            milestone.id == *milestone_id && milestone.tasks.iter().any(|task| task.id == *task_id)
+        }),
+    }
 }
 
 fn validate_spec_toml_acceptance(report: &mut ArtifactValidationReport, value: &toml::Value) {
@@ -797,6 +1077,7 @@ fn is_story_path(path: &str) -> bool {
 const DESCRIPTION_ALIASES: &[&str] = &[];
 const REQUIREMENTS_ALIASES: &[&str] = &["requirements.md"];
 const ROADMAP_ALIASES: &[&str] = &["roadmap.md"];
+const ROADMAP_PATCH_ALIASES: &[&str] = &["roadmap_patch.toml"];
 const SPEC_ALIASES: &[&str] = &["spec.md"];
 const ADR_ALIASES: &[&str] = &["adr.md"];
 const STORY_ALIASES: &[&str] = &[];
@@ -831,6 +1112,16 @@ const ROADMAP_CONTRACT: ArtifactContract = ArtifactContract {
     schema_version_owner: SchemaVersionOwner::ArtifactContract,
     validator_kind: "roadmap",
     aliases: ROADMAP_ALIASES,
+};
+
+const ROADMAP_PATCH_CONTRACT: ArtifactContract = ArtifactContract {
+    kind: ArtifactKind::RoadmapPatch,
+    canonical_path: "roadmap-patch.toml",
+    primary_format: ArtifactFormat::Toml,
+    markdown_compatibility: None,
+    schema_version_owner: SchemaVersionOwner::ArtifactContract,
+    validator_kind: "roadmap-patch",
+    aliases: ROADMAP_PATCH_ALIASES,
 };
 
 const SPEC_CONTRACT: ArtifactContract = ArtifactContract {
@@ -883,10 +1174,11 @@ const FLOW_CONTRACT: ArtifactContract = ArtifactContract {
     aliases: FLOW_ALIASES,
 };
 
-const CONTRACTS: [ArtifactContract; 8] = [
+const CONTRACTS: [ArtifactContract; 9] = [
     DESCRIPTION_CONTRACT,
     REQUIREMENTS_CONTRACT,
     ROADMAP_CONTRACT,
+    ROADMAP_PATCH_CONTRACT,
     SPEC_CONTRACT,
     ADR_CONTRACT,
     STORY_CONTRACT,
@@ -910,6 +1202,7 @@ mod tests {
                 ArtifactKind::Description,
                 ArtifactKind::Requirements,
                 ArtifactKind::Roadmap,
+                ArtifactKind::RoadmapPatch,
                 ArtifactKind::Spec,
                 ArtifactKind::Adr,
                 ArtifactKind::Story,
@@ -929,6 +1222,10 @@ mod tests {
             "spec-md".parse::<ArtifactKind>().unwrap(),
             ArtifactKind::Spec
         );
+        assert_eq!(
+            "roadmap-patch-toml".parse::<ArtifactKind>().unwrap(),
+            ArtifactKind::RoadmapPatch
+        );
         assert!("unknown".parse::<ArtifactKind>().is_err());
     }
 
@@ -944,6 +1241,10 @@ mod tests {
         );
         assert_eq!(
             ArtifactContractRef::current(ArtifactKind::Spec).schema_version,
+            ARTIFACT_SCHEMA_VERSION
+        );
+        assert_eq!(
+            ArtifactContractRef::current(ArtifactKind::RoadmapPatch).schema_version,
             ARTIFACT_SCHEMA_VERSION
         );
     }
@@ -1098,6 +1399,94 @@ subtasks = [
         );
 
         assert!(report.is_valid(), "{report:#?}");
+    }
+
+    #[test]
+    fn validates_roadmap_patch_toml_shape() {
+        let report = validate_artifact(
+            ArtifactKind::RoadmapPatch,
+            Some(Path::new("roadmap-patch.toml")),
+            r#"schema_version = 1
+id = "rpatch-demo"
+rationale = "Add follow-up feature work."
+status = "drafted"
+
+[target]
+kind = "project_roadmap"
+roadmap_path = ".ai-factory/ROADMAP.md"
+
+[[operations]]
+op = "add_milestone"
+
+[operations.milestone]
+id = "m2"
+title = "Follow-up feature"
+
+[operations.insertion]
+kind = "append_to_roadmap"
+"#,
+        );
+
+        assert!(report.is_valid(), "{report:#?}");
+    }
+
+    #[test]
+    fn rejects_roadmap_patch_without_operations() {
+        let report = validate_artifact(
+            ArtifactKind::RoadmapPatch,
+            Some(Path::new("roadmap-patch.toml")),
+            r#"schema_version = 1
+id = "rpatch-empty"
+operations = []
+
+[target]
+kind = "project_roadmap"
+roadmap_path = ".ai-factory/ROADMAP.md"
+"#,
+        );
+
+        assert!(
+            report
+                .diagnostics
+                .iter()
+                .any(|diagnostic| { diagnostic.code == ArtifactDiagnosticCode::MissingOperation })
+        );
+    }
+
+    #[test]
+    fn validates_roadmap_patch_references_against_context() {
+        let roadmap = RoadmapArtifact::new(vec![crate::roadmap::RoadmapMilestone::new(
+            "m1", "Existing",
+        )]);
+        let report = validate_roadmap_patch_text_with_context(
+            r#"schema_version = 1
+id = "rpatch-context"
+
+[target]
+kind = "project_roadmap"
+roadmap_path = ".ai-factory/ROADMAP.md"
+
+[[operations]]
+op = "add_task"
+milestone_id = "missing"
+
+[operations.task]
+id = "m1-t2"
+title = "New task"
+
+[operations.insertion]
+kind = "append_to_milestone"
+milestone_id = "missing"
+"#,
+            &roadmap,
+        );
+
+        assert!(
+            report
+                .diagnostics
+                .iter()
+                .any(|diagnostic| { diagnostic.code == ArtifactDiagnosticCode::InvalidReference })
+        );
     }
 
     #[test]

--- a/crates/surge-core/src/lib.rs
+++ b/crates/surge-core/src/lib.rs
@@ -26,6 +26,7 @@ pub mod config;
 pub mod event;
 pub mod id;
 pub mod roadmap;
+pub mod roadmap_patch;
 pub mod spec;
 pub mod state;
 
@@ -69,6 +70,15 @@ pub use roadmap::{
     Priority, RoadmapArtifact, RoadmapDependency, RoadmapItem, RoadmapMilestone, RoadmapRisk,
     RoadmapStatus, RoadmapTask, Timeline, TimelineBatch,
 };
+pub use roadmap_patch::{
+    ActivePickupPolicy, InsertionPoint, OperatorConflictChoice, ROADMAP_PATCH_SCHEMA_VERSION,
+    RoadmapItemRef, RoadmapPatch, RoadmapPatchApplyConflict, RoadmapPatchApplyError,
+    RoadmapPatchApplyResult, RoadmapPatchApprovalDecision, RoadmapPatchConflict,
+    RoadmapPatchConflictCode, RoadmapPatchDependency, RoadmapPatchHashError, RoadmapPatchId,
+    RoadmapPatchIdError, RoadmapPatchItem, RoadmapPatchOperation, RoadmapPatchStatus,
+    RoadmapPatchTarget, RoadmapPatchValidationCode, RoadmapPatchValidationIssue,
+    apply_roadmap_patch, conflict_choices_for_code,
+};
 pub use spec::{
     AcceptanceCriteria, Complexity, Spec, SpecArtifact, Subtask, SubtaskExecution, SubtaskState,
 };
@@ -81,6 +91,7 @@ pub use artifact_contract::{
     ArtifactDiagnosticSeverity, ArtifactFormat, ArtifactKind, ArtifactValidationDiagnostic,
     ArtifactValidationError, ArtifactValidationReport, SchemaVersionOwner, all_contracts,
     contract_for, validate_artifact, validate_artifact_path, validate_artifact_text,
+    validate_roadmap_patch_text_with_context,
 };
 pub use bundled_flows::{BUNDLED_FLOW_COUNT, BundledFlow, BundledFlows};
 pub use content_hash::ContentHash;

--- a/crates/surge-core/src/profile/bundled.rs
+++ b/crates/surge-core/src/profile/bundled.rs
@@ -141,6 +141,7 @@ fn parse(raw: &str, expected_name: &str) -> Profile {
 mod tests {
     use super::*;
     use crate::artifact_contract::ArtifactKind;
+    use crate::sandbox::SandboxMode;
 
     #[test]
     fn all_returns_expected_count() {
@@ -210,6 +211,25 @@ mod tests {
             assert_eq!(declaration.path, path);
             assert_eq!(declaration.contract.schema_version, 1);
         }
+    }
+
+    #[test]
+    fn feature_planner_declares_patch_artifact_and_write_sandbox() {
+        let profile = BundledRegistry::by_name_latest("feature-planner").expect("bundled profile");
+        let patched = profile
+            .outcomes
+            .iter()
+            .find(|outcome| outcome.id.as_ref() == "patched")
+            .expect("patched outcome");
+        let declaration = patched
+            .produced_artifacts
+            .iter()
+            .find(|artifact| artifact.contract.kind == ArtifactKind::RoadmapPatch)
+            .expect("roadmap patch artifact declaration");
+
+        assert_eq!(declaration.path, "roadmap-patch.toml");
+        assert_eq!(declaration.contract.schema_version, 1);
+        assert_eq!(profile.sandbox.mode, SandboxMode::WorkspaceWrite);
     }
 
     #[test]

--- a/crates/surge-core/src/roadmap.rs
+++ b/crates/surge-core/src/roadmap.rs
@@ -12,7 +12,7 @@ use crate::spec::Complexity;
 /// `flow.toml` is generated. The older [`Timeline`] scheduling model remains
 /// available for runtime planning; this wrapper captures the authored roadmap
 /// shape and schema version.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RoadmapArtifact {
     /// Artifact contract schema version.
     #[serde(default = "default_artifact_schema_version")]
@@ -39,6 +39,63 @@ impl RoadmapArtifact {
             risks: Vec::new(),
         }
     }
+
+    /// Render a deterministic `roadmap.md` representation.
+    #[must_use]
+    pub fn to_markdown(&self) -> String {
+        let mut out = String::from("# Roadmap\n\n");
+        for milestone in &self.milestones {
+            out.push_str(&format!("## {}: {}\n", milestone.id, milestone.title));
+            if milestone.status != RoadmapStatus::Pending {
+                out.push_str(&format!("Status: {}\n", milestone.status));
+            }
+            if milestone.tasks.is_empty() {
+                out.push('\n');
+                continue;
+            }
+            for task in &milestone.tasks {
+                out.push_str(&format!(
+                    "- [{}] {}: {}",
+                    markdown_checkbox(task.status),
+                    task.id,
+                    task.title
+                ));
+                if task.status != RoadmapStatus::Pending {
+                    out.push_str(&format!(" ({})", task.status));
+                }
+                out.push('\n');
+                if let Some(description) = &task.description {
+                    out.push_str(&format!("  - {}\n", description));
+                }
+                for criterion in &task.acceptance_criteria {
+                    out.push_str(&format!("  - AC: {criterion}\n"));
+                }
+            }
+            out.push('\n');
+        }
+        if !self.dependencies.is_empty() {
+            out.push_str("## Dependencies\n");
+            for dependency in &self.dependencies {
+                out.push_str(&format!("- {} -> {}", dependency.from, dependency.to));
+                if !dependency.reason.trim().is_empty() {
+                    out.push_str(&format!(": {}", dependency.reason));
+                }
+                out.push('\n');
+            }
+            out.push('\n');
+        }
+        if !self.risks.is_empty() {
+            out.push_str("## Risks\n");
+            for risk in &self.risks {
+                out.push_str(&format!("- {}", risk.description));
+                if let Some(mitigation) = &risk.mitigation {
+                    out.push_str(&format!(" (mitigation: {mitigation})"));
+                }
+                out.push('\n');
+            }
+        }
+        out
+    }
 }
 
 impl Default for RoadmapArtifact {
@@ -48,12 +105,15 @@ impl Default for RoadmapArtifact {
 }
 
 /// One deliverable-focused roadmap milestone.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RoadmapMilestone {
     /// Stable human-authored identifier, for example `m1`.
     pub id: String,
     /// Human-readable milestone title.
     pub title: String,
+    /// Current execution status for amendment safety checks.
+    #[serde(default, skip_serializing_if = "RoadmapStatus::is_pending")]
+    pub status: RoadmapStatus,
     /// Ordered tasks within this milestone.
     #[serde(default)]
     pub tasks: Vec<RoadmapTask>,
@@ -66,18 +126,22 @@ impl RoadmapMilestone {
         Self {
             id: id.into(),
             title: title.into(),
+            status: RoadmapStatus::Pending,
             tasks: Vec::new(),
         }
     }
 }
 
 /// One task within a roadmap milestone.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RoadmapTask {
     /// Stable human-authored identifier, for example `m1-t1`.
     pub id: String,
     /// Human-readable task title.
     pub title: String,
+    /// Current execution status for amendment safety checks.
+    #[serde(default, skip_serializing_if = "RoadmapStatus::is_pending")]
+    pub status: RoadmapStatus,
     /// Optional short description.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
@@ -93,6 +157,7 @@ impl RoadmapTask {
         Self {
             id: id.into(),
             title: title.into(),
+            status: RoadmapStatus::Pending,
             description: None,
             acceptance_criteria: Vec::new(),
         }
@@ -100,7 +165,7 @@ impl RoadmapTask {
 }
 
 /// Directed dependency between roadmap milestones.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RoadmapDependency {
     /// Milestone that must finish first.
     pub from: String,
@@ -112,7 +177,7 @@ pub struct RoadmapDependency {
 }
 
 /// Risk tracked by the roadmap artifact.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RoadmapRisk {
     /// Risk description.
     pub description: String,
@@ -183,10 +248,36 @@ pub enum RoadmapStatus {
 }
 
 impl RoadmapStatus {
+    /// Returns `true` when the item has not started.
+    #[must_use]
+    pub fn is_pending(&self) -> bool {
+        matches!(self, Self::Pending)
+    }
+
     /// Returns `true` if no further execution will happen.
     #[must_use]
     pub fn is_terminal(self) -> bool {
         matches!(self, Self::Completed | Self::Failed | Self::Skipped)
+    }
+}
+
+impl std::fmt::Display for RoadmapStatus {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(match self {
+            Self::Pending => "pending",
+            Self::Running => "running",
+            Self::Paused => "paused",
+            Self::Completed => "completed",
+            Self::Failed => "failed",
+            Self::Skipped => "skipped",
+        })
+    }
+}
+
+const fn markdown_checkbox(status: RoadmapStatus) -> &'static str {
+    match status {
+        RoadmapStatus::Completed => "x",
+        _ => " ",
     }
 }
 

--- a/crates/surge-core/src/roadmap.rs
+++ b/crates/surge-core/src/roadmap.rs
@@ -277,6 +277,7 @@ impl std::fmt::Display for RoadmapStatus {
 const fn markdown_checkbox(status: RoadmapStatus) -> &'static str {
     match status {
         RoadmapStatus::Completed => "x",
+        RoadmapStatus::Running => "~",
         _ => " ",
     }
 }
@@ -542,5 +543,19 @@ mod tests {
         let item = timeline.find_item_mut(spec_id).unwrap();
         item.status = RoadmapStatus::Running;
         assert_eq!(timeline.batches[0].items[0].status, RoadmapStatus::Running);
+    }
+
+    #[test]
+    fn to_markdown_preserves_running_checkbox_marker() {
+        let mut milestone = RoadmapMilestone::new("m1", "Active");
+        milestone
+            .tasks
+            .push(RoadmapTask::new("m1-t1", "Currently running"));
+        milestone.tasks[0].status = RoadmapStatus::Running;
+        let roadmap = RoadmapArtifact::new(vec![milestone]);
+
+        let markdown = roadmap.to_markdown();
+
+        assert!(markdown.contains("- [~] m1-t1: Currently running (running)"));
     }
 }

--- a/crates/surge-core/src/roadmap_patch.rs
+++ b/crates/surge-core/src/roadmap_patch.rs
@@ -30,6 +30,7 @@ impl RoadmapPatchId {
     /// unsupported characters.
     pub fn new(value: impl Into<String>) -> Result<Self, RoadmapPatchIdError> {
         let value = value.into();
+        let value = value.trim().to_owned();
         validate_patch_id(&value)?;
         Ok(Self(value))
     }
@@ -1427,6 +1428,13 @@ mod tests {
                 .collect(),
             other => panic!("expected conflicts, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn patch_id_new_stores_trimmed_value() {
+        let patch_id = RoadmapPatchId::new("  rpatch-trimmed  ").unwrap();
+
+        assert_eq!(patch_id.as_str(), "rpatch-trimmed");
     }
 
     #[test]

--- a/crates/surge-core/src/roadmap_patch.rs
+++ b/crates/surge-core/src/roadmap_patch.rs
@@ -1,0 +1,1598 @@
+//! Typed roadmap amendment patches.
+//!
+//! This module is pure domain code. It models the `roadmap-patch.toml` artifact
+//! that Feature Planner agents produce, plus stable IDs, lifecycle status, and
+//! shape diagnostics that callers can log without parsing prose.
+
+use crate::artifact_contract::ARTIFACT_SCHEMA_VERSION;
+use crate::content_hash::ContentHash;
+use crate::id::RunId;
+use crate::roadmap::{
+    RoadmapArtifact, RoadmapDependency, RoadmapMilestone, RoadmapStatus, RoadmapTask,
+};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::collections::{BTreeMap, BTreeSet};
+use std::fmt;
+use std::str::FromStr;
+
+/// Current schema version for `roadmap-patch.toml`.
+pub const ROADMAP_PATCH_SCHEMA_VERSION: u32 = ARTIFACT_SCHEMA_VERSION;
+
+/// Stable identifier for a roadmap patch.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct RoadmapPatchId(String);
+
+impl RoadmapPatchId {
+    /// Create a validated patch ID.
+    ///
+    /// # Errors
+    /// Returns [`RoadmapPatchIdError`] when the ID is empty or contains
+    /// unsupported characters.
+    pub fn new(value: impl Into<String>) -> Result<Self, RoadmapPatchIdError> {
+        let value = value.into();
+        validate_patch_id(&value)?;
+        Ok(Self(value))
+    }
+
+    /// Build a deterministic patch ID from a content hash.
+    #[must_use]
+    pub fn from_content_hash(hash: ContentHash) -> Self {
+        let prefix = hash.to_hex().chars().take(16).collect::<String>();
+        Self(format!("rpatch-{prefix}"))
+    }
+
+    /// Borrow the stable string form.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for RoadmapPatchId {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.0)
+    }
+}
+
+impl FromStr for RoadmapPatchId {
+    type Err = RoadmapPatchIdError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        Self::new(value)
+    }
+}
+
+impl Serialize for RoadmapPatchId {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(self.as_str())
+    }
+}
+
+impl<'de> Deserialize<'de> for RoadmapPatchId {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let value = String::deserialize(deserializer)?;
+        Self::new(value).map_err(serde::de::Error::custom)
+    }
+}
+
+/// Error returned when a roadmap patch ID is malformed.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum RoadmapPatchIdError {
+    /// Patch ID is empty after trimming.
+    #[error("roadmap patch id must not be empty")]
+    Empty,
+    /// Patch ID contains a character outside the stable portable set.
+    #[error("roadmap patch id contains unsupported character {character:?}")]
+    UnsupportedCharacter {
+        /// Unsupported character.
+        character: char,
+    },
+}
+
+/// Machine-readable roadmap amendment artifact.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RoadmapPatch {
+    /// Artifact schema version.
+    #[serde(default = "default_schema_version")]
+    pub schema_version: u32,
+    /// Stable patch identifier.
+    pub id: RoadmapPatchId,
+    /// Roadmap or run this patch amends.
+    pub target: RoadmapPatchTarget,
+    /// Human-readable reason for the amendment.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub rationale: String,
+    /// Ordered patch operations.
+    #[serde(default)]
+    pub operations: Vec<RoadmapPatchOperation>,
+    /// Cross-item dependencies introduced by this patch.
+    #[serde(default)]
+    pub dependencies: Vec<RoadmapPatchDependency>,
+    /// Conflicts detected while drafting or applying the patch.
+    #[serde(default)]
+    pub conflicts: Vec<RoadmapPatchConflict>,
+    /// Current lifecycle state.
+    #[serde(default)]
+    pub status: RoadmapPatchStatus,
+}
+
+impl RoadmapPatch {
+    /// Create a patch in the drafted state.
+    #[must_use]
+    pub fn new(
+        id: RoadmapPatchId,
+        target: RoadmapPatchTarget,
+        operations: Vec<RoadmapPatchOperation>,
+    ) -> Self {
+        Self {
+            schema_version: ROADMAP_PATCH_SCHEMA_VERSION,
+            id,
+            target,
+            rationale: String::new(),
+            operations,
+            dependencies: Vec::new(),
+            conflicts: Vec::new(),
+            status: RoadmapPatchStatus::Drafted,
+        }
+    }
+
+    /// Compute the stable hash used for idempotency.
+    ///
+    /// The hash excludes `id` and `status`; lifecycle transitions should not
+    /// change whether two patches describe the same amendment.
+    ///
+    /// # Errors
+    /// Returns [`RoadmapPatchHashError`] if canonical TOML serialization fails.
+    pub fn content_hash(&self) -> Result<ContentHash, RoadmapPatchHashError> {
+        let input = RoadmapPatchHashInput {
+            schema_version: self.schema_version,
+            target: &self.target,
+            rationale: &self.rationale,
+            operations: &self.operations,
+            dependencies: &self.dependencies,
+            conflicts: &self.conflicts,
+        };
+        let canonical = toml::to_string(&input)?;
+        Ok(ContentHash::compute(canonical.as_bytes()))
+    }
+
+    /// Return shape-level diagnostics that do not require reading a roadmap.
+    #[must_use]
+    pub fn validate_shape(&self) -> Vec<RoadmapPatchValidationIssue> {
+        let mut issues = Vec::new();
+        push_schema_issue(self.schema_version, &mut issues);
+        push_empty_operations_issue(self.operations.is_empty(), &mut issues);
+
+        for (index, operation) in self.operations.iter().enumerate() {
+            operation.validate_shape(index, &mut issues);
+        }
+        for (index, dependency) in self.dependencies.iter().enumerate() {
+            dependency.validate_shape(index, &mut issues);
+        }
+        for (index, conflict) in self.conflicts.iter().enumerate() {
+            conflict.validate_shape(index, &mut issues);
+        }
+
+        issues
+    }
+
+    /// Apply this patch to a roadmap artifact.
+    ///
+    /// # Errors
+    /// Returns [`RoadmapPatchApplyError`] when the patch shape is invalid or
+    /// when one or more operations would mutate completed/running history,
+    /// reference missing items, duplicate IDs, or introduce dependency cycles.
+    pub fn apply_to_roadmap(
+        &self,
+        roadmap: &RoadmapArtifact,
+    ) -> Result<RoadmapPatchApplyResult, RoadmapPatchApplyError> {
+        apply_roadmap_patch(roadmap, self)
+    }
+}
+
+/// Error returned when patch hash computation fails.
+#[derive(Debug, thiserror::Error)]
+pub enum RoadmapPatchHashError {
+    /// Canonical TOML serialization failed.
+    #[error("failed to serialize roadmap patch for hashing: {0}")]
+    Serialize(#[from] toml::ser::Error),
+}
+
+/// Result of applying a roadmap patch.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RoadmapPatchApplyResult {
+    /// Amended roadmap artifact.
+    pub roadmap: RoadmapArtifact,
+    /// Deterministic markdown rendering for `roadmap.md`.
+    pub markdown: String,
+    /// Milestone ids inserted by the patch.
+    pub inserted_milestones: Vec<String>,
+    /// Task refs inserted by the patch.
+    pub inserted_tasks: Vec<RoadmapItemRef>,
+    /// Existing draft refs replaced by the patch.
+    pub replaced_items: Vec<RoadmapItemRef>,
+    /// Dependency edges accepted by the patch.
+    pub dependencies_added: Vec<RoadmapPatchDependency>,
+}
+
+/// One typed conflict found while applying a roadmap patch.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RoadmapPatchApplyConflict {
+    /// Stable conflict code.
+    pub code: RoadmapPatchConflictCode,
+    /// Item involved in the conflict, when known.
+    pub item: Option<RoadmapItemRef>,
+    /// Human-readable conflict summary.
+    pub message: String,
+}
+
+impl RoadmapPatchApplyConflict {
+    fn new(
+        code: RoadmapPatchConflictCode,
+        item: Option<RoadmapItemRef>,
+        message: impl Into<String>,
+    ) -> Self {
+        Self {
+            code,
+            item,
+            message: message.into(),
+        }
+    }
+
+    /// Convert an apply-time conflict into operator-facing patch metadata.
+    #[must_use]
+    pub fn to_patch_conflict(&self) -> RoadmapPatchConflict {
+        RoadmapPatchConflict {
+            code: self.code,
+            item: self.item.clone(),
+            message: self.message.clone(),
+            choices: conflict_choices_for_code(self.code),
+            selected_choice: None,
+        }
+    }
+}
+
+/// Error returned by pure roadmap patch application.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum RoadmapPatchApplyError {
+    /// Patch shape failed validation before apply.
+    #[error("roadmap patch shape is invalid")]
+    InvalidShape {
+        /// Shape validation issues.
+        issues: Vec<RoadmapPatchValidationIssue>,
+    },
+    /// Patch conflicts with the supplied roadmap.
+    #[error("roadmap patch has apply conflicts")]
+    Conflicts {
+        /// Typed apply conflicts.
+        conflicts: Vec<RoadmapPatchApplyConflict>,
+    },
+}
+
+/// Apply a roadmap patch to a typed roadmap artifact.
+///
+/// # Errors
+/// Returns [`RoadmapPatchApplyError`] if the patch is malformed for apply or
+/// conflicts with the supplied roadmap state.
+pub fn apply_roadmap_patch(
+    roadmap: &RoadmapArtifact,
+    patch: &RoadmapPatch,
+) -> Result<RoadmapPatchApplyResult, RoadmapPatchApplyError> {
+    let issues = patch.validate_shape();
+    if !issues.is_empty() {
+        return Err(RoadmapPatchApplyError::InvalidShape { issues });
+    }
+
+    let mut context = RoadmapPatchApplyContext::new(roadmap.clone());
+    for operation in &patch.operations {
+        context.apply_operation(operation);
+    }
+    if context.conflicts.is_empty() {
+        context.apply_dependencies(&patch.dependencies);
+    }
+    context.finish()
+}
+
+struct RoadmapPatchApplyContext {
+    roadmap: RoadmapArtifact,
+    inserted_milestones: Vec<String>,
+    inserted_tasks: Vec<RoadmapItemRef>,
+    replaced_items: Vec<RoadmapItemRef>,
+    dependencies_added: Vec<RoadmapPatchDependency>,
+    conflicts: Vec<RoadmapPatchApplyConflict>,
+}
+
+impl RoadmapPatchApplyContext {
+    fn new(roadmap: RoadmapArtifact) -> Self {
+        Self {
+            roadmap,
+            inserted_milestones: Vec::new(),
+            inserted_tasks: Vec::new(),
+            replaced_items: Vec::new(),
+            dependencies_added: Vec::new(),
+            conflicts: Vec::new(),
+        }
+    }
+
+    fn apply_operation(&mut self, operation: &RoadmapPatchOperation) {
+        match operation {
+            RoadmapPatchOperation::AddMilestone {
+                milestone,
+                insertion,
+            } => self.add_milestone(milestone, insertion.as_ref()),
+            RoadmapPatchOperation::AddTask {
+                milestone_id,
+                task,
+                insertion,
+            } => self.add_task(milestone_id, task, insertion.as_ref()),
+            RoadmapPatchOperation::ReplaceDraftItem {
+                target,
+                replacement,
+                ..
+            } => self.replace_draft_item(target, replacement),
+        }
+    }
+
+    fn add_milestone(&mut self, milestone: &RoadmapMilestone, insertion: Option<&InsertionPoint>) {
+        if self.has_milestone(&milestone.id) {
+            self.push_duplicate(RoadmapItemRef::Milestone {
+                milestone_id: milestone.id.clone(),
+            });
+            return;
+        }
+
+        let Some(insertion) = insertion else {
+            self.push_unsupported("missing milestone insertion point");
+            return;
+        };
+        let milestone = pending_milestone(milestone);
+        match insertion {
+            InsertionPoint::AppendToRoadmap => {
+                self.inserted_milestones.push(milestone.id.clone());
+                self.roadmap.milestones.push(milestone);
+            },
+            InsertionPoint::BeforeMilestone { milestone_id } => {
+                self.insert_milestone_near(milestone_id, milestone, InsertSide::Before);
+            },
+            InsertionPoint::AfterMilestone { milestone_id } => {
+                self.insert_milestone_near(milestone_id, milestone, InsertSide::After);
+            },
+            _ => self.push_unsupported("milestone insertions must target roadmap milestones"),
+        }
+    }
+
+    fn insert_milestone_near(
+        &mut self,
+        target_id: &str,
+        milestone: RoadmapMilestone,
+        side: InsertSide,
+    ) {
+        let target_ref = RoadmapItemRef::Milestone {
+            milestone_id: target_id.to_owned(),
+        };
+        let Some(index) = self.find_milestone_index(target_id) else {
+            self.push_missing(target_ref);
+            return;
+        };
+        if self.push_status_conflict(target_ref, self.roadmap.milestones[index].status) {
+            return;
+        }
+        let insert_at = match side {
+            InsertSide::Before => index,
+            InsertSide::After => index + 1,
+        };
+        self.inserted_milestones.push(milestone.id.clone());
+        self.roadmap.milestones.insert(insert_at, milestone);
+    }
+
+    fn add_task(
+        &mut self,
+        milestone_id: &str,
+        task: &RoadmapTask,
+        insertion: Option<&InsertionPoint>,
+    ) {
+        let Some(milestone_index) = self.find_milestone_index(milestone_id) else {
+            self.push_missing(RoadmapItemRef::Milestone {
+                milestone_id: milestone_id.to_owned(),
+            });
+            return;
+        };
+        let milestone_ref = RoadmapItemRef::Milestone {
+            milestone_id: milestone_id.to_owned(),
+        };
+        if self.push_status_conflict(
+            milestone_ref,
+            self.roadmap.milestones[milestone_index].status,
+        ) {
+            return;
+        }
+        if self.has_task_in_milestone(milestone_index, &task.id) {
+            self.push_duplicate(RoadmapItemRef::Task {
+                milestone_id: milestone_id.to_owned(),
+                task_id: task.id.clone(),
+            });
+            return;
+        }
+        let Some(insert_at) = self.task_insert_index(milestone_index, milestone_id, insertion)
+        else {
+            return;
+        };
+        let task = pending_task(task);
+        self.inserted_tasks.push(RoadmapItemRef::Task {
+            milestone_id: milestone_id.to_owned(),
+            task_id: task.id.clone(),
+        });
+        self.roadmap.milestones[milestone_index]
+            .tasks
+            .insert(insert_at, task);
+    }
+
+    fn task_insert_index(
+        &mut self,
+        milestone_index: usize,
+        milestone_id: &str,
+        insertion: Option<&InsertionPoint>,
+    ) -> Option<usize> {
+        match insertion {
+            Some(InsertionPoint::AppendToMilestone {
+                milestone_id: insertion_milestone,
+            }) if insertion_milestone == milestone_id => {
+                Some(self.roadmap.milestones[milestone_index].tasks.len())
+            },
+            Some(InsertionPoint::BeforeTask {
+                milestone_id: insertion_milestone,
+                task_id,
+            }) if insertion_milestone == milestone_id => self.task_insert_index_near(
+                milestone_index,
+                milestone_id,
+                task_id,
+                InsertSide::Before,
+            ),
+            Some(InsertionPoint::AfterTask {
+                milestone_id: insertion_milestone,
+                task_id,
+            }) if insertion_milestone == milestone_id => self.task_insert_index_near(
+                milestone_index,
+                milestone_id,
+                task_id,
+                InsertSide::After,
+            ),
+            _ => {
+                self.push_unsupported("task insertions must target tasks in the target milestone");
+                None
+            },
+        }
+    }
+
+    fn task_insert_index_near(
+        &mut self,
+        milestone_index: usize,
+        milestone_id: &str,
+        task_id: &str,
+        side: InsertSide,
+    ) -> Option<usize> {
+        let target_ref = RoadmapItemRef::Task {
+            milestone_id: milestone_id.to_owned(),
+            task_id: task_id.to_owned(),
+        };
+        let Some(task_index) = find_task_index(&self.roadmap.milestones[milestone_index], task_id)
+        else {
+            self.push_missing(target_ref);
+            return None;
+        };
+        let status = self.roadmap.milestones[milestone_index].tasks[task_index].status;
+        if self.push_status_conflict(target_ref, status) {
+            return None;
+        }
+        Some(match side {
+            InsertSide::Before => task_index,
+            InsertSide::After => task_index + 1,
+        })
+    }
+
+    fn replace_draft_item(&mut self, target: &RoadmapItemRef, replacement: &RoadmapPatchItem) {
+        match (target, replacement) {
+            (
+                RoadmapItemRef::Milestone { milestone_id },
+                RoadmapPatchItem::Milestone { milestone },
+            ) => self.replace_milestone(milestone_id, milestone),
+            (
+                RoadmapItemRef::Task {
+                    milestone_id,
+                    task_id,
+                },
+                RoadmapPatchItem::Task { task },
+            ) => self.replace_task(milestone_id, task_id, task),
+            _ => self.push_unsupported("replacement item kind must match target item kind"),
+        }
+    }
+
+    fn replace_milestone(&mut self, milestone_id: &str, replacement: &RoadmapMilestone) {
+        let target_ref = RoadmapItemRef::Milestone {
+            milestone_id: milestone_id.to_owned(),
+        };
+        let Some(index) = self.find_milestone_index(milestone_id) else {
+            self.push_missing(target_ref);
+            return;
+        };
+        if self.push_status_conflict(target_ref.clone(), self.roadmap.milestones[index].status) {
+            return;
+        }
+        if replacement.id != milestone_id && self.has_milestone(&replacement.id) {
+            self.push_duplicate(RoadmapItemRef::Milestone {
+                milestone_id: replacement.id.clone(),
+            });
+            return;
+        }
+        self.roadmap.milestones[index] = pending_milestone(replacement);
+        self.replaced_items.push(target_ref);
+    }
+
+    fn replace_task(&mut self, milestone_id: &str, task_id: &str, replacement: &RoadmapTask) {
+        let milestone_ref = RoadmapItemRef::Milestone {
+            milestone_id: milestone_id.to_owned(),
+        };
+        let Some(milestone_index) = self.find_milestone_index(milestone_id) else {
+            self.push_missing(milestone_ref);
+            return;
+        };
+        if self.push_status_conflict(
+            milestone_ref,
+            self.roadmap.milestones[milestone_index].status,
+        ) {
+            return;
+        }
+        let target_ref = RoadmapItemRef::Task {
+            milestone_id: milestone_id.to_owned(),
+            task_id: task_id.to_owned(),
+        };
+        let Some(task_index) = find_task_index(&self.roadmap.milestones[milestone_index], task_id)
+        else {
+            self.push_missing(target_ref);
+            return;
+        };
+        let task_status = self.roadmap.milestones[milestone_index].tasks[task_index].status;
+        if self.push_status_conflict(target_ref.clone(), task_status) {
+            return;
+        }
+        if replacement.id != task_id && self.has_task_in_milestone(milestone_index, &replacement.id)
+        {
+            self.push_duplicate(RoadmapItemRef::Task {
+                milestone_id: milestone_id.to_owned(),
+                task_id: replacement.id.clone(),
+            });
+            return;
+        }
+        self.roadmap.milestones[milestone_index].tasks[task_index] = pending_task(replacement);
+        self.replaced_items.push(target_ref);
+    }
+
+    fn apply_dependencies(&mut self, dependencies: &[RoadmapPatchDependency]) {
+        for dependency in dependencies {
+            if !self.dependency_refs_exist(dependency) {
+                continue;
+            }
+            if let (
+                RoadmapItemRef::Milestone { milestone_id: from },
+                RoadmapItemRef::Milestone { milestone_id: to },
+            ) = (&dependency.from, &dependency.to)
+            {
+                self.add_milestone_dependency(from, to, &dependency.reason);
+            }
+            self.dependencies_added.push(dependency.clone());
+        }
+        if has_milestone_dependency_cycle(&self.roadmap) {
+            self.conflicts.push(RoadmapPatchApplyConflict::new(
+                RoadmapPatchConflictCode::DependencyCycle,
+                None,
+                "patch would introduce a milestone dependency cycle",
+            ));
+        }
+    }
+
+    fn dependency_refs_exist(&mut self, dependency: &RoadmapPatchDependency) -> bool {
+        let mut ok = true;
+        for reference in [&dependency.from, &dependency.to] {
+            if !self.contains_ref(reference) {
+                self.push_missing(reference.clone());
+                ok = false;
+            }
+        }
+        ok
+    }
+
+    fn add_milestone_dependency(&mut self, from: &str, to: &str, reason: &str) {
+        let exists = self
+            .roadmap
+            .dependencies
+            .iter()
+            .any(|dependency| dependency.from == from && dependency.to == to);
+        if exists {
+            return;
+        }
+        self.roadmap.dependencies.push(RoadmapDependency {
+            from: from.to_owned(),
+            to: to.to_owned(),
+            reason: reason.to_owned(),
+        });
+    }
+
+    fn finish(self) -> Result<RoadmapPatchApplyResult, RoadmapPatchApplyError> {
+        if !self.conflicts.is_empty() {
+            return Err(RoadmapPatchApplyError::Conflicts {
+                conflicts: self.conflicts,
+            });
+        }
+        Ok(RoadmapPatchApplyResult {
+            markdown: self.roadmap.to_markdown(),
+            roadmap: self.roadmap,
+            inserted_milestones: self.inserted_milestones,
+            inserted_tasks: self.inserted_tasks,
+            replaced_items: self.replaced_items,
+            dependencies_added: self.dependencies_added,
+        })
+    }
+
+    fn has_milestone(&self, milestone_id: &str) -> bool {
+        self.roadmap
+            .milestones
+            .iter()
+            .any(|milestone| milestone.id == milestone_id)
+    }
+
+    fn has_task_in_milestone(&self, milestone_index: usize, task_id: &str) -> bool {
+        self.roadmap.milestones[milestone_index]
+            .tasks
+            .iter()
+            .any(|task| task.id == task_id)
+    }
+
+    fn find_milestone_index(&self, milestone_id: &str) -> Option<usize> {
+        self.roadmap
+            .milestones
+            .iter()
+            .position(|milestone| milestone.id == milestone_id)
+    }
+
+    fn contains_ref(&self, reference: &RoadmapItemRef) -> bool {
+        match reference {
+            RoadmapItemRef::Milestone { milestone_id } => self.has_milestone(milestone_id),
+            RoadmapItemRef::Task {
+                milestone_id,
+                task_id,
+            } => self
+                .find_milestone_index(milestone_id)
+                .is_some_and(|index| self.has_task_in_milestone(index, task_id)),
+        }
+    }
+
+    fn push_missing(&mut self, item: RoadmapItemRef) {
+        self.conflicts.push(RoadmapPatchApplyConflict::new(
+            RoadmapPatchConflictCode::MissingTarget,
+            Some(item),
+            "patch references a missing roadmap item",
+        ));
+    }
+
+    fn push_duplicate(&mut self, item: RoadmapItemRef) {
+        self.conflicts.push(RoadmapPatchApplyConflict::new(
+            RoadmapPatchConflictCode::DuplicateItem,
+            Some(item),
+            "patch would duplicate an existing roadmap item id",
+        ));
+    }
+
+    fn push_unsupported(&mut self, message: impl Into<String>) {
+        self.conflicts.push(RoadmapPatchApplyConflict::new(
+            RoadmapPatchConflictCode::UnsupportedOperation,
+            None,
+            message,
+        ));
+    }
+
+    fn push_status_conflict(&mut self, item: RoadmapItemRef, status: RoadmapStatus) -> bool {
+        let Some(code) = status_conflict_code(status) else {
+            return false;
+        };
+        self.conflicts.push(RoadmapPatchApplyConflict::new(
+            code,
+            Some(item),
+            format!("patch cannot amend item with status {status}"),
+        ));
+        true
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum InsertSide {
+    Before,
+    After,
+}
+
+fn pending_milestone(milestone: &RoadmapMilestone) -> RoadmapMilestone {
+    let mut milestone = milestone.clone();
+    milestone.status = RoadmapStatus::Pending;
+    for task in &mut milestone.tasks {
+        task.status = RoadmapStatus::Pending;
+    }
+    milestone
+}
+
+fn pending_task(task: &RoadmapTask) -> RoadmapTask {
+    let mut task = task.clone();
+    task.status = RoadmapStatus::Pending;
+    task
+}
+
+fn find_task_index(milestone: &RoadmapMilestone, task_id: &str) -> Option<usize> {
+    milestone.tasks.iter().position(|task| task.id == task_id)
+}
+
+const fn status_conflict_code(status: RoadmapStatus) -> Option<RoadmapPatchConflictCode> {
+    match status {
+        RoadmapStatus::Running | RoadmapStatus::Paused => {
+            Some(RoadmapPatchConflictCode::RunningMilestone)
+        },
+        RoadmapStatus::Completed | RoadmapStatus::Failed | RoadmapStatus::Skipped => {
+            Some(RoadmapPatchConflictCode::CompletedHistory)
+        },
+        RoadmapStatus::Pending => None,
+    }
+}
+
+fn has_milestone_dependency_cycle(roadmap: &RoadmapArtifact) -> bool {
+    let mut graph: BTreeMap<&str, Vec<&str>> = BTreeMap::new();
+    for milestone in &roadmap.milestones {
+        graph.entry(milestone.id.as_str()).or_default();
+    }
+    for dependency in &roadmap.dependencies {
+        graph
+            .entry(dependency.from.as_str())
+            .or_default()
+            .push(dependency.to.as_str());
+    }
+
+    let mut visited = BTreeSet::new();
+    let mut visiting = BTreeSet::new();
+    graph
+        .keys()
+        .any(|node| dependency_dfs_has_cycle(node, &graph, &mut visiting, &mut visited))
+}
+
+fn dependency_dfs_has_cycle<'a>(
+    node: &'a str,
+    graph: &BTreeMap<&'a str, Vec<&'a str>>,
+    visiting: &mut BTreeSet<&'a str>,
+    visited: &mut BTreeSet<&'a str>,
+) -> bool {
+    if visited.contains(node) {
+        return false;
+    }
+    if !visiting.insert(node) {
+        return true;
+    }
+    for next in graph.get(node).into_iter().flatten() {
+        if dependency_dfs_has_cycle(next, graph, visiting, visited) {
+            return true;
+        }
+    }
+    visiting.remove(node);
+    visited.insert(node);
+    false
+}
+
+/// Target amended by a roadmap patch.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum RoadmapPatchTarget {
+    /// Project-level roadmap file.
+    ProjectRoadmap {
+        /// Portable path relative to the project root.
+        roadmap_path: String,
+    },
+    /// Roadmap artifact belonging to a run.
+    RunRoadmap {
+        /// Target run.
+        run_id: RunId,
+        /// Stored roadmap artifact hash, when known.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        roadmap_artifact: Option<ContentHash>,
+        /// Stored flow artifact hash, when known.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        flow_artifact: Option<ContentHash>,
+        /// Whether the active runner may pick up this amendment.
+        #[serde(default)]
+        active_pickup: ActivePickupPolicy,
+    },
+}
+
+/// Active-run pickup policy for a patch target.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ActivePickupPolicy {
+    /// Runner may pick up new work at a safe loop boundary.
+    #[default]
+    Allowed,
+    /// Always create a follow-up run rather than amending the active graph.
+    FollowUpOnly,
+    /// Keep the patch pending until an operator chooses a resolution.
+    Disabled,
+}
+
+/// Insertion point for append/insert operations.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum InsertionPoint {
+    /// Append a milestone to the end of the roadmap.
+    AppendToRoadmap,
+    /// Insert before an existing milestone.
+    BeforeMilestone {
+        /// Existing milestone ID.
+        milestone_id: String,
+    },
+    /// Insert after an existing milestone.
+    AfterMilestone {
+        /// Existing milestone ID.
+        milestone_id: String,
+    },
+    /// Append a task to an existing milestone.
+    AppendToMilestone {
+        /// Existing milestone ID.
+        milestone_id: String,
+    },
+    /// Insert before an existing task.
+    BeforeTask {
+        /// Existing milestone ID.
+        milestone_id: String,
+        /// Existing task ID.
+        task_id: String,
+    },
+    /// Insert after an existing task.
+    AfterTask {
+        /// Existing milestone ID.
+        milestone_id: String,
+        /// Existing task ID.
+        task_id: String,
+    },
+}
+
+impl InsertionPoint {
+    fn is_empty_reference(&self) -> bool {
+        match self {
+            Self::AppendToRoadmap => false,
+            Self::BeforeMilestone { milestone_id }
+            | Self::AfterMilestone { milestone_id }
+            | Self::AppendToMilestone { milestone_id } => milestone_id.trim().is_empty(),
+            Self::BeforeTask {
+                milestone_id,
+                task_id,
+            }
+            | Self::AfterTask {
+                milestone_id,
+                task_id,
+            } => milestone_id.trim().is_empty() || task_id.trim().is_empty(),
+        }
+    }
+}
+
+/// One operation inside a roadmap patch.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "op", rename_all = "snake_case")]
+pub enum RoadmapPatchOperation {
+    /// Insert a new milestone.
+    AddMilestone {
+        /// New milestone.
+        milestone: RoadmapMilestone,
+        /// Position for the new milestone.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        insertion: Option<InsertionPoint>,
+    },
+    /// Insert a new task into an existing milestone.
+    AddTask {
+        /// Existing milestone ID.
+        milestone_id: String,
+        /// New task.
+        task: RoadmapTask,
+        /// Position for the new task.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        insertion: Option<InsertionPoint>,
+    },
+    /// Replace an item that is still draft-only and not part of completed history.
+    ReplaceDraftItem {
+        /// Existing draft item to replace.
+        target: RoadmapItemRef,
+        /// Replacement item.
+        replacement: RoadmapPatchItem,
+        /// Human-readable replacement reason.
+        #[serde(default, skip_serializing_if = "String::is_empty")]
+        reason: String,
+    },
+}
+
+impl RoadmapPatchOperation {
+    fn validate_shape(&self, index: usize, issues: &mut Vec<RoadmapPatchValidationIssue>) {
+        match self {
+            Self::AddMilestone {
+                milestone,
+                insertion,
+            } => validate_add_milestone(index, milestone, insertion.as_ref(), issues),
+            Self::AddTask {
+                milestone_id,
+                task,
+                insertion,
+            } => validate_add_task(index, milestone_id, task, insertion.as_ref(), issues),
+            Self::ReplaceDraftItem {
+                target,
+                replacement,
+                ..
+            } => validate_replace_draft_item(index, target, replacement, issues),
+        }
+    }
+}
+
+/// Reference to a roadmap milestone or task.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum RoadmapItemRef {
+    /// Milestone reference.
+    Milestone {
+        /// Milestone ID.
+        milestone_id: String,
+    },
+    /// Task reference.
+    Task {
+        /// Milestone ID containing the task.
+        milestone_id: String,
+        /// Task ID.
+        task_id: String,
+    },
+}
+
+impl RoadmapItemRef {
+    fn is_empty(&self) -> bool {
+        match self {
+            Self::Milestone { milestone_id } => milestone_id.trim().is_empty(),
+            Self::Task {
+                milestone_id,
+                task_id,
+            } => milestone_id.trim().is_empty() || task_id.trim().is_empty(),
+        }
+    }
+}
+
+/// Replacement item for a draft-only roadmap item.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum RoadmapPatchItem {
+    /// Replacement milestone.
+    Milestone {
+        /// Milestone contents.
+        milestone: RoadmapMilestone,
+    },
+    /// Replacement task.
+    Task {
+        /// Task contents.
+        task: RoadmapTask,
+    },
+}
+
+/// Dependency edge introduced by a patch.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RoadmapPatchDependency {
+    /// Source item that must complete first.
+    pub from: RoadmapItemRef,
+    /// Dependent item.
+    pub to: RoadmapItemRef,
+    /// Human-readable reason.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub reason: String,
+}
+
+impl RoadmapPatchDependency {
+    /// Convert a milestone dependency into a patch dependency.
+    #[must_use]
+    pub fn from_milestone_dependency(dependency: RoadmapDependency) -> Self {
+        Self {
+            from: RoadmapItemRef::Milestone {
+                milestone_id: dependency.from,
+            },
+            to: RoadmapItemRef::Milestone {
+                milestone_id: dependency.to,
+            },
+            reason: dependency.reason,
+        }
+    }
+
+    fn validate_shape(&self, index: usize, issues: &mut Vec<RoadmapPatchValidationIssue>) {
+        if self.from.is_empty() {
+            issues.push(RoadmapPatchValidationIssue::new(
+                RoadmapPatchValidationCode::MissingTargetReference,
+                format!("dependencies[{index}].from"),
+                "dependency source reference must not be empty",
+            ));
+        }
+        if self.to.is_empty() {
+            issues.push(RoadmapPatchValidationIssue::new(
+                RoadmapPatchValidationCode::MissingTargetReference,
+                format!("dependencies[{index}].to"),
+                "dependency target reference must not be empty",
+            ));
+        }
+    }
+}
+
+/// Conflict metadata attached to a roadmap patch.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RoadmapPatchConflict {
+    /// Stable conflict code.
+    pub code: RoadmapPatchConflictCode,
+    /// Roadmap item involved in the conflict, when known.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub item: Option<RoadmapItemRef>,
+    /// Operator-facing explanation.
+    pub message: String,
+    /// Available operator choices.
+    #[serde(default)]
+    pub choices: Vec<OperatorConflictChoice>,
+    /// Selected choice, once the operator has resolved the conflict.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub selected_choice: Option<OperatorConflictChoice>,
+}
+
+impl RoadmapPatchConflict {
+    fn validate_shape(&self, index: usize, issues: &mut Vec<RoadmapPatchValidationIssue>) {
+        if self.message.trim().is_empty() {
+            issues.push(RoadmapPatchValidationIssue::new(
+                RoadmapPatchValidationCode::MissingConflictMessage,
+                format!("conflicts[{index}].message"),
+                "conflict message must not be empty",
+            ));
+        }
+        if self.choices.is_empty() {
+            issues.push(RoadmapPatchValidationIssue::new(
+                RoadmapPatchValidationCode::MissingConflictChoice,
+                format!("conflicts[{index}].choices"),
+                "conflict must expose at least one operator choice",
+            ));
+        }
+    }
+}
+
+/// Stable conflict classes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RoadmapPatchConflictCode {
+    /// Referenced item could not be found.
+    MissingTarget,
+    /// Patch references an item already running.
+    RunningMilestone,
+    /// Patch would mutate completed history.
+    CompletedHistory,
+    /// Patch would duplicate an existing item ID.
+    DuplicateItem,
+    /// Patch would introduce a dependency cycle.
+    DependencyCycle,
+    /// Operation cannot be represented safely.
+    UnsupportedOperation,
+}
+
+/// Operator choice for resolving an amendment conflict.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum OperatorConflictChoice {
+    /// Defer the new work to the next safe milestone.
+    DeferToNextMilestone,
+    /// Abort the current run before applying the patch.
+    AbortCurrentRun,
+    /// Create a follow-up run instead of amending the active run.
+    CreateFollowUpRun,
+    /// Reject the patch.
+    RejectPatch,
+}
+
+/// Operator choices that are safe to present for one conflict class.
+#[must_use]
+pub fn conflict_choices_for_code(code: RoadmapPatchConflictCode) -> Vec<OperatorConflictChoice> {
+    match code {
+        RoadmapPatchConflictCode::RunningMilestone => vec![
+            OperatorConflictChoice::DeferToNextMilestone,
+            OperatorConflictChoice::AbortCurrentRun,
+            OperatorConflictChoice::CreateFollowUpRun,
+            OperatorConflictChoice::RejectPatch,
+        ],
+        RoadmapPatchConflictCode::CompletedHistory => vec![
+            OperatorConflictChoice::CreateFollowUpRun,
+            OperatorConflictChoice::RejectPatch,
+        ],
+        RoadmapPatchConflictCode::MissingTarget
+        | RoadmapPatchConflictCode::DuplicateItem
+        | RoadmapPatchConflictCode::DependencyCycle
+        | RoadmapPatchConflictCode::UnsupportedOperation => {
+            vec![OperatorConflictChoice::RejectPatch]
+        },
+    }
+}
+
+/// Lifecycle state for a roadmap patch.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RoadmapPatchStatus {
+    /// Patch has been drafted by Feature Planner.
+    #[default]
+    Drafted,
+    /// Patch is waiting for operator approval.
+    PendingApproval,
+    /// Operator approved the patch.
+    Approved,
+    /// Patch was applied to a roadmap or follow-up run.
+    Applied,
+    /// Operator rejected the patch.
+    Rejected,
+    /// Patch was superseded by a later draft.
+    Superseded,
+}
+
+/// Operator approval decision for a drafted patch.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RoadmapPatchApprovalDecision {
+    /// Approve and apply the patch.
+    Approve,
+    /// Ask the Feature Planner to revise the patch.
+    Edit,
+    /// Reject the patch.
+    Reject,
+}
+
+/// Shape-level validation codes for roadmap patches.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RoadmapPatchValidationCode {
+    /// Schema version is not supported.
+    UnsupportedSchemaVersion,
+    /// Patch has no operations.
+    MissingOperation,
+    /// An add operation has no insertion point.
+    MissingInsertionPoint,
+    /// A milestone/task/reference ID is empty.
+    MissingTargetReference,
+    /// A milestone or task title is empty.
+    MissingTitle,
+    /// Conflict message is empty.
+    MissingConflictMessage,
+    /// Conflict has no operator choice.
+    MissingConflictChoice,
+}
+
+impl RoadmapPatchValidationCode {
+    /// Stable snake-case code for logs and diagnostics.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::UnsupportedSchemaVersion => "unsupported_schema_version",
+            Self::MissingOperation => "missing_operation",
+            Self::MissingInsertionPoint => "missing_insertion_point",
+            Self::MissingTargetReference => "missing_target_reference",
+            Self::MissingTitle => "missing_title",
+            Self::MissingConflictMessage => "missing_conflict_message",
+            Self::MissingConflictChoice => "missing_conflict_choice",
+        }
+    }
+}
+
+impl fmt::Display for RoadmapPatchValidationCode {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+/// One shape-level validation issue.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RoadmapPatchValidationIssue {
+    /// Stable machine-readable code.
+    pub code: RoadmapPatchValidationCode,
+    /// Field path or logical location.
+    pub location: String,
+    /// Short user-safe explanation.
+    pub message: String,
+}
+
+impl RoadmapPatchValidationIssue {
+    /// Create a validation issue.
+    #[must_use]
+    pub fn new(
+        code: RoadmapPatchValidationCode,
+        location: impl Into<String>,
+        message: impl Into<String>,
+    ) -> Self {
+        Self {
+            code,
+            location: location.into(),
+            message: message.into(),
+        }
+    }
+}
+
+#[derive(Serialize)]
+struct RoadmapPatchHashInput<'a> {
+    schema_version: u32,
+    target: &'a RoadmapPatchTarget,
+    rationale: &'a str,
+    operations: &'a [RoadmapPatchOperation],
+    dependencies: &'a [RoadmapPatchDependency],
+    conflicts: &'a [RoadmapPatchConflict],
+}
+
+fn validate_patch_id(value: &str) -> Result<(), RoadmapPatchIdError> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return Err(RoadmapPatchIdError::Empty);
+    }
+
+    for character in trimmed.chars() {
+        if is_patch_id_character(character) {
+            continue;
+        }
+        return Err(RoadmapPatchIdError::UnsupportedCharacter { character });
+    }
+
+    Ok(())
+}
+
+const fn is_patch_id_character(character: char) -> bool {
+    character.is_ascii_alphanumeric() || character == '-' || character == '_' || character == '.'
+}
+
+fn push_schema_issue(schema_version: u32, issues: &mut Vec<RoadmapPatchValidationIssue>) {
+    if schema_version == ROADMAP_PATCH_SCHEMA_VERSION {
+        return;
+    }
+    issues.push(RoadmapPatchValidationIssue::new(
+        RoadmapPatchValidationCode::UnsupportedSchemaVersion,
+        "schema_version",
+        format!("expected schema_version {ROADMAP_PATCH_SCHEMA_VERSION}"),
+    ));
+}
+
+fn push_empty_operations_issue(
+    operations_empty: bool,
+    issues: &mut Vec<RoadmapPatchValidationIssue>,
+) {
+    if !operations_empty {
+        return;
+    }
+    issues.push(RoadmapPatchValidationIssue::new(
+        RoadmapPatchValidationCode::MissingOperation,
+        "operations",
+        "patch must contain at least one operation",
+    ));
+}
+
+fn validate_add_milestone(
+    index: usize,
+    milestone: &RoadmapMilestone,
+    insertion: Option<&InsertionPoint>,
+    issues: &mut Vec<RoadmapPatchValidationIssue>,
+) {
+    validate_required_text(
+        &milestone.id,
+        RoadmapPatchValidationCode::MissingTargetReference,
+        format!("operations[{index}].milestone.id"),
+        "new milestone id must not be empty",
+        issues,
+    );
+    validate_required_text(
+        &milestone.title,
+        RoadmapPatchValidationCode::MissingTitle,
+        format!("operations[{index}].milestone.title"),
+        "new milestone title must not be empty",
+        issues,
+    );
+    validate_insertion(index, insertion, issues);
+}
+
+fn validate_add_task(
+    index: usize,
+    milestone_id: &str,
+    task: &RoadmapTask,
+    insertion: Option<&InsertionPoint>,
+    issues: &mut Vec<RoadmapPatchValidationIssue>,
+) {
+    validate_required_text(
+        milestone_id,
+        RoadmapPatchValidationCode::MissingTargetReference,
+        format!("operations[{index}].milestone_id"),
+        "target milestone id must not be empty",
+        issues,
+    );
+    validate_required_text(
+        &task.id,
+        RoadmapPatchValidationCode::MissingTargetReference,
+        format!("operations[{index}].task.id"),
+        "new task id must not be empty",
+        issues,
+    );
+    validate_required_text(
+        &task.title,
+        RoadmapPatchValidationCode::MissingTitle,
+        format!("operations[{index}].task.title"),
+        "new task title must not be empty",
+        issues,
+    );
+    validate_insertion(index, insertion, issues);
+}
+
+fn validate_replace_draft_item(
+    index: usize,
+    target: &RoadmapItemRef,
+    replacement: &RoadmapPatchItem,
+    issues: &mut Vec<RoadmapPatchValidationIssue>,
+) {
+    if target.is_empty() {
+        issues.push(RoadmapPatchValidationIssue::new(
+            RoadmapPatchValidationCode::MissingTargetReference,
+            format!("operations[{index}].target"),
+            "replacement target reference must not be empty",
+        ));
+    }
+    match replacement {
+        RoadmapPatchItem::Milestone { milestone } => validate_required_text(
+            &milestone.title,
+            RoadmapPatchValidationCode::MissingTitle,
+            format!("operations[{index}].replacement.milestone.title"),
+            "replacement milestone title must not be empty",
+            issues,
+        ),
+        RoadmapPatchItem::Task { task } => validate_required_text(
+            &task.title,
+            RoadmapPatchValidationCode::MissingTitle,
+            format!("operations[{index}].replacement.task.title"),
+            "replacement task title must not be empty",
+            issues,
+        ),
+    }
+}
+
+fn validate_insertion(
+    index: usize,
+    insertion: Option<&InsertionPoint>,
+    issues: &mut Vec<RoadmapPatchValidationIssue>,
+) {
+    let Some(insertion) = insertion else {
+        issues.push(RoadmapPatchValidationIssue::new(
+            RoadmapPatchValidationCode::MissingInsertionPoint,
+            format!("operations[{index}].insertion"),
+            "add operation must include an insertion point",
+        ));
+        return;
+    };
+
+    if insertion.is_empty_reference() {
+        issues.push(RoadmapPatchValidationIssue::new(
+            RoadmapPatchValidationCode::MissingTargetReference,
+            format!("operations[{index}].insertion"),
+            "insertion point reference must not be empty",
+        ));
+    }
+}
+
+fn validate_required_text(
+    value: &str,
+    code: RoadmapPatchValidationCode,
+    location: String,
+    message: &'static str,
+    issues: &mut Vec<RoadmapPatchValidationIssue>,
+) {
+    if !value.trim().is_empty() {
+        return;
+    }
+    issues.push(RoadmapPatchValidationIssue::new(code, location, message));
+}
+
+const fn default_schema_version() -> u32 {
+    ROADMAP_PATCH_SCHEMA_VERSION
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn target() -> RoadmapPatchTarget {
+        RoadmapPatchTarget::ProjectRoadmap {
+            roadmap_path: ".ai-factory/ROADMAP.md".into(),
+        }
+    }
+
+    fn base_roadmap() -> RoadmapArtifact {
+        let mut milestone = RoadmapMilestone::new("m1", "Foundation");
+        milestone
+            .tasks
+            .push(RoadmapTask::new("m1-t1", "First task"));
+        RoadmapArtifact::new(vec![milestone])
+    }
+
+    fn patch(operations: Vec<RoadmapPatchOperation>) -> RoadmapPatch {
+        RoadmapPatch::new(
+            RoadmapPatchId::new("rpatch-apply").unwrap(),
+            target(),
+            operations,
+        )
+    }
+
+    fn conflict_codes(error: RoadmapPatchApplyError) -> Vec<RoadmapPatchConflictCode> {
+        match error {
+            RoadmapPatchApplyError::Conflicts { conflicts } => conflicts
+                .into_iter()
+                .map(|conflict| conflict.code)
+                .collect(),
+            other => panic!("expected conflicts, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn applies_append_milestone_task_dependency_and_markdown() {
+        let mut patch = patch(vec![
+            RoadmapPatchOperation::AddMilestone {
+                milestone: RoadmapMilestone::new("m2", "Approval flow"),
+                insertion: Some(InsertionPoint::AppendToRoadmap),
+            },
+            RoadmapPatchOperation::AddTask {
+                milestone_id: "m1".into(),
+                task: RoadmapTask::new("m1-t2", "Second task"),
+                insertion: Some(InsertionPoint::AppendToMilestone {
+                    milestone_id: "m1".into(),
+                }),
+            },
+        ]);
+        patch.dependencies.push(RoadmapPatchDependency {
+            from: RoadmapItemRef::Milestone {
+                milestone_id: "m1".into(),
+            },
+            to: RoadmapItemRef::Milestone {
+                milestone_id: "m2".into(),
+            },
+            reason: "foundation first".into(),
+        });
+
+        let result = patch.apply_to_roadmap(&base_roadmap()).unwrap();
+
+        assert_eq!(
+            result
+                .roadmap
+                .milestones
+                .iter()
+                .map(|milestone| milestone.id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["m1", "m2"]
+        );
+        assert_eq!(result.roadmap.milestones[0].tasks[1].id, "m1-t2");
+        assert_eq!(result.roadmap.dependencies.len(), 1);
+        assert!(result.markdown.contains("## m2: Approval flow"));
+        assert!(result.markdown.contains("- [ ] m1-t2: Second task"));
+    }
+
+    #[test]
+    fn rejects_task_append_to_completed_milestone() {
+        let mut roadmap = base_roadmap();
+        roadmap.milestones[0].status = RoadmapStatus::Completed;
+        let patch = patch(vec![RoadmapPatchOperation::AddTask {
+            milestone_id: "m1".into(),
+            task: RoadmapTask::new("m1-t2", "Late task"),
+            insertion: Some(InsertionPoint::AppendToMilestone {
+                milestone_id: "m1".into(),
+            }),
+        }]);
+
+        let codes = conflict_codes(patch.apply_to_roadmap(&roadmap).unwrap_err());
+
+        assert_eq!(codes, vec![RoadmapPatchConflictCode::CompletedHistory]);
+    }
+
+    #[test]
+    fn rejects_insert_after_running_milestone() {
+        let mut roadmap = base_roadmap();
+        roadmap.milestones[0].status = RoadmapStatus::Running;
+        let patch = patch(vec![RoadmapPatchOperation::AddMilestone {
+            milestone: RoadmapMilestone::new("m2", "Blocked"),
+            insertion: Some(InsertionPoint::AfterMilestone {
+                milestone_id: "m1".into(),
+            }),
+        }]);
+
+        let codes = conflict_codes(patch.apply_to_roadmap(&roadmap).unwrap_err());
+
+        assert_eq!(codes, vec![RoadmapPatchConflictCode::RunningMilestone]);
+    }
+
+    #[test]
+    fn running_conflict_surfaces_operator_resolution_choices() {
+        let mut roadmap = base_roadmap();
+        roadmap.milestones[0].status = RoadmapStatus::Running;
+        let patch = patch(vec![RoadmapPatchOperation::AddTask {
+            milestone_id: "m1".into(),
+            task: RoadmapTask::new("m1-t2", "Later task"),
+            insertion: Some(InsertionPoint::AppendToMilestone {
+                milestone_id: "m1".into(),
+            }),
+        }]);
+        let RoadmapPatchApplyError::Conflicts { conflicts } =
+            patch.apply_to_roadmap(&roadmap).unwrap_err()
+        else {
+            panic!("expected running milestone conflict");
+        };
+
+        let conflict = conflicts[0].to_patch_conflict();
+
+        assert_eq!(conflict.code, RoadmapPatchConflictCode::RunningMilestone);
+        assert_eq!(
+            conflict.choices,
+            vec![
+                OperatorConflictChoice::DeferToNextMilestone,
+                OperatorConflictChoice::AbortCurrentRun,
+                OperatorConflictChoice::CreateFollowUpRun,
+                OperatorConflictChoice::RejectPatch,
+            ]
+        );
+    }
+
+    #[test]
+    fn replaces_pending_task_only() {
+        let patch = patch(vec![RoadmapPatchOperation::ReplaceDraftItem {
+            target: RoadmapItemRef::Task {
+                milestone_id: "m1".into(),
+                task_id: "m1-t1".into(),
+            },
+            replacement: RoadmapPatchItem::Task {
+                task: RoadmapTask::new("m1-t1", "Updated first task"),
+            },
+            reason: "clearer wording".into(),
+        }]);
+
+        let result = patch.apply_to_roadmap(&base_roadmap()).unwrap();
+
+        assert_eq!(
+            result.roadmap.milestones[0].tasks[0].title,
+            "Updated first task"
+        );
+        assert_eq!(
+            result.replaced_items,
+            vec![RoadmapItemRef::Task {
+                milestone_id: "m1".into(),
+                task_id: "m1-t1".into()
+            }]
+        );
+    }
+
+    #[test]
+    fn rejects_milestone_dependency_cycle() {
+        let mut roadmap = base_roadmap();
+        roadmap
+            .milestones
+            .push(RoadmapMilestone::new("m2", "Second"));
+        roadmap.dependencies.push(RoadmapDependency {
+            from: "m1".into(),
+            to: "m2".into(),
+            reason: String::new(),
+        });
+        let mut patch = patch(vec![RoadmapPatchOperation::AddTask {
+            milestone_id: "m2".into(),
+            task: RoadmapTask::new("m2-t1", "Noop"),
+            insertion: Some(InsertionPoint::AppendToMilestone {
+                milestone_id: "m2".into(),
+            }),
+        }]);
+        patch.dependencies.push(RoadmapPatchDependency {
+            from: RoadmapItemRef::Milestone {
+                milestone_id: "m2".into(),
+            },
+            to: RoadmapItemRef::Milestone {
+                milestone_id: "m1".into(),
+            },
+            reason: "cycle".into(),
+        });
+
+        let codes = conflict_codes(patch.apply_to_roadmap(&roadmap).unwrap_err());
+
+        assert!(codes.contains(&RoadmapPatchConflictCode::DependencyCycle));
+    }
+}

--- a/crates/surge-core/src/run_event.rs
+++ b/crates/surge-core/src/run_event.rs
@@ -9,6 +9,10 @@ use crate::hooks::HookFailureMode;
 use crate::id::{RunId, SessionId};
 use crate::keys::{EdgeKey, NodeKey, OutcomeKey, SubgraphKey, TemplateKey};
 use crate::notify_config::NotifyChannelKind;
+use crate::roadmap_patch::{
+    ActivePickupPolicy, OperatorConflictChoice, RoadmapPatchApprovalDecision, RoadmapPatchId,
+    RoadmapPatchTarget,
+};
 use crate::sandbox::SandboxMode;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
@@ -114,6 +118,55 @@ pub enum EventPayload {
     PipelineMaterialized {
         graph: Box<Graph>,
         graph_hash: ContentHash,
+    },
+
+    // Roadmap amendment lifecycle
+    RoadmapPatchDrafted {
+        patch_id: RoadmapPatchId,
+        target: RoadmapPatchTarget,
+        patch_artifact: ContentHash,
+        patch_path: PathBuf,
+    },
+    RoadmapPatchApprovalRequested {
+        patch_id: RoadmapPatchId,
+        target: RoadmapPatchTarget,
+        channel: ApprovalChannel,
+        summary_hash: ContentHash,
+    },
+    RoadmapPatchApprovalDecided {
+        patch_id: RoadmapPatchId,
+        decision: RoadmapPatchApprovalDecision,
+        channel_used: ApprovalChannelKind,
+        comment: Option<String>,
+        conflict_choice: Option<OperatorConflictChoice>,
+    },
+    RoadmapPatchApplied {
+        patch_id: RoadmapPatchId,
+        target: RoadmapPatchTarget,
+        amended_roadmap_artifact: ContentHash,
+        amended_roadmap_path: PathBuf,
+        amended_flow_artifact: Option<ContentHash>,
+        amended_flow_path: Option<PathBuf>,
+    },
+    RoadmapUpdated {
+        patch_id: RoadmapPatchId,
+        target: RoadmapPatchTarget,
+        roadmap_artifact: ContentHash,
+        roadmap_path: PathBuf,
+        flow_artifact: Option<ContentHash>,
+        flow_path: Option<PathBuf>,
+        active_pickup: ActivePickupPolicy,
+    },
+    /// Accepted graph revision for an active roadmap amendment. The full
+    /// graph is embedded so replay can reconstruct the active topology
+    /// without reading mutable artifact paths.
+    GraphRevisionAccepted {
+        patch_id: RoadmapPatchId,
+        target: RoadmapPatchTarget,
+        previous_graph_hash: ContentHash,
+        graph: Box<Graph>,
+        graph_hash: ContentHash,
+        active_pickup: ActivePickupPolicy,
     },
 
     // Stage execution
@@ -345,6 +398,12 @@ impl EventPayload {
             Self::BootstrapEditRequested { .. } => "BootstrapEditRequested",
             Self::BootstrapTelemetry { .. } => "BootstrapTelemetry",
             Self::PipelineMaterialized { .. } => "PipelineMaterialized",
+            Self::RoadmapPatchDrafted { .. } => "RoadmapPatchDrafted",
+            Self::RoadmapPatchApprovalRequested { .. } => "RoadmapPatchApprovalRequested",
+            Self::RoadmapPatchApprovalDecided { .. } => "RoadmapPatchApprovalDecided",
+            Self::RoadmapPatchApplied { .. } => "RoadmapPatchApplied",
+            Self::RoadmapUpdated { .. } => "RoadmapUpdated",
+            Self::GraphRevisionAccepted { .. } => "GraphRevisionAccepted",
             Self::StageEntered { .. } => "StageEntered",
             Self::StageInputsResolved { .. } => "StageInputsResolved",
             Self::SessionOpened { .. } => "SessionOpened",
@@ -427,6 +486,42 @@ pub struct RunConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn minimal_graph_for_event(start: &str) -> Graph {
+        use crate::graph::{GraphMetadata, SCHEMA_VERSION};
+        use crate::node::{Node, NodeConfig, Position};
+        use crate::terminal_config::{TerminalConfig, TerminalKind};
+
+        let start = NodeKey::try_from(start).unwrap();
+        let mut nodes = BTreeMap::new();
+        nodes.insert(
+            start.clone(),
+            Node {
+                id: start.clone(),
+                position: Position::default(),
+                declared_outcomes: vec![],
+                config: NodeConfig::Terminal(TerminalConfig {
+                    kind: TerminalKind::Success,
+                    message: None,
+                }),
+            },
+        );
+        Graph {
+            schema_version: SCHEMA_VERSION,
+            metadata: GraphMetadata {
+                name: "minimal".into(),
+                description: None,
+                template_origin: None,
+                created_at: chrono::Utc::now(),
+                author: None,
+                archetype: None,
+            },
+            start,
+            nodes,
+            edges: vec![],
+            subgraphs: BTreeMap::new(),
+        }
+    }
 
     #[test]
     fn run_started_bincode_roundtrip() {
@@ -564,6 +659,100 @@ mod tests {
         let bytes = payload.to_bincode().unwrap();
         let parsed = EventPayload::from_bincode(&bytes).unwrap();
         assert_eq!(payload, parsed);
+    }
+
+    #[test]
+    fn roadmap_patch_lifecycle_events_roundtrip() {
+        let patch_id = RoadmapPatchId::new("rpatch-demo").unwrap();
+        let target = RoadmapPatchTarget::ProjectRoadmap {
+            roadmap_path: ".ai-factory/ROADMAP.md".into(),
+        };
+        let patch_hash = ContentHash::compute(b"roadmap-patch");
+        let roadmap_hash = ContentHash::compute(b"roadmap");
+        let flow_hash = ContentHash::compute(b"flow");
+
+        let events = vec![
+            EventPayload::RoadmapPatchDrafted {
+                patch_id: patch_id.clone(),
+                target: target.clone(),
+                patch_artifact: patch_hash,
+                patch_path: PathBuf::from("roadmap-patch.toml"),
+            },
+            EventPayload::RoadmapPatchApprovalRequested {
+                patch_id: patch_id.clone(),
+                target: target.clone(),
+                channel: ApprovalChannel::Desktop {
+                    duration: crate::approvals::ApprovalDuration::Transient,
+                },
+                summary_hash: ContentHash::compute(b"summary"),
+            },
+            EventPayload::RoadmapPatchApprovalDecided {
+                patch_id: patch_id.clone(),
+                decision: RoadmapPatchApprovalDecision::Approve,
+                channel_used: ApprovalChannelKind::Desktop,
+                comment: Some("ship it".into()),
+                conflict_choice: None,
+            },
+            EventPayload::RoadmapPatchApplied {
+                patch_id: patch_id.clone(),
+                target: target.clone(),
+                amended_roadmap_artifact: roadmap_hash,
+                amended_roadmap_path: PathBuf::from("roadmap.toml"),
+                amended_flow_artifact: Some(flow_hash),
+                amended_flow_path: Some(PathBuf::from("flow.toml")),
+            },
+            EventPayload::RoadmapUpdated {
+                patch_id: patch_id.clone(),
+                target: target.clone(),
+                roadmap_artifact: roadmap_hash,
+                roadmap_path: PathBuf::from("roadmap.toml"),
+                flow_artifact: Some(flow_hash),
+                flow_path: Some(PathBuf::from("flow.toml")),
+                active_pickup: ActivePickupPolicy::Allowed,
+            },
+            EventPayload::GraphRevisionAccepted {
+                patch_id,
+                target,
+                previous_graph_hash: ContentHash::compute(b"old-flow"),
+                graph: Box::new(minimal_graph_for_event("end")),
+                graph_hash: flow_hash,
+                active_pickup: ActivePickupPolicy::Allowed,
+            },
+        ];
+
+        for payload in events {
+            let bytes = payload.to_bincode().unwrap();
+            let parsed = EventPayload::from_bincode(&bytes).unwrap();
+            assert_eq!(payload, parsed);
+        }
+    }
+
+    #[test]
+    fn roadmap_patch_discriminants_are_stable() {
+        let patch_id = RoadmapPatchId::new("rpatch-demo").unwrap();
+        let target = RoadmapPatchTarget::ProjectRoadmap {
+            roadmap_path: ".ai-factory/ROADMAP.md".into(),
+        };
+        let payload = EventPayload::RoadmapPatchDrafted {
+            patch_id,
+            target,
+            patch_artifact: ContentHash::compute(b"patch"),
+            patch_path: PathBuf::from("roadmap-patch.toml"),
+        };
+
+        assert_eq!(payload.discriminant_str(), "RoadmapPatchDrafted");
+
+        let payload = EventPayload::GraphRevisionAccepted {
+            patch_id: RoadmapPatchId::new("rpatch-graph").unwrap(),
+            target: RoadmapPatchTarget::ProjectRoadmap {
+                roadmap_path: ".ai-factory/ROADMAP.md".into(),
+            },
+            previous_graph_hash: ContentHash::compute(b"old-flow"),
+            graph: Box::new(minimal_graph_for_event("end")),
+            graph_hash: ContentHash::compute(b"new-flow"),
+            active_pickup: ActivePickupPolicy::Allowed,
+        };
+        assert_eq!(payload.discriminant_str(), "GraphRevisionAccepted");
     }
 
     // Stage execution + routing variants

--- a/crates/surge-core/src/run_state.rs
+++ b/crates/surge-core/src/run_state.rs
@@ -5,6 +5,10 @@ use crate::edge::EdgeKind;
 use crate::graph::Graph;
 use crate::id::SessionId;
 use crate::keys::{NodeKey, OutcomeKey};
+use crate::roadmap_patch::{
+    ActivePickupPolicy, RoadmapPatchApprovalDecision, RoadmapPatchId, RoadmapPatchStatus,
+    RoadmapPatchTarget,
+};
 use crate::run_event::{BootstrapDecision, BootstrapStage, EventPayload, RunEvent};
 use std::collections::BTreeMap;
 use std::path::PathBuf;
@@ -34,8 +38,9 @@ pub enum RunState {
         substate: BootstrapSubstate,
     },
     Pipeline {
-        /// `Arc<Graph>` because the graph is frozen post-PipelineMaterialized.
-        /// Each fold step shares the same graph; cloning is one atomic increment.
+        /// `Arc<Graph>` because each fold step shares the current graph by
+        /// reference-count. `PipelineMaterialized` establishes revision 0;
+        /// `GraphRevisionAccepted` may replace it with an amended graph.
         graph: Arc<Graph>,
         cursor: Cursor,
         memory: RunMemory,
@@ -99,6 +104,36 @@ pub struct RunMemory {
     /// to expose the most recent operator feedback to the re-entered agent
     /// stage. Empty for non-bootstrap runs.
     pub last_edit_feedback_by_stage: BTreeMap<BootstrapStage, String>,
+    /// Latest roadmap patch lifecycle state derived from roadmap amendment
+    /// events. This intentionally stores artifact refs only; full patch
+    /// bodies stay in the artifact store.
+    pub roadmap_patches: BTreeMap<RoadmapPatchId, RoadmapPatchMemory>,
+    /// Latest accepted graph revision metadata, if an active amendment
+    /// changed the executable graph after `PipelineMaterialized`.
+    pub latest_graph_revision: Option<GraphRevisionMemory>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct RoadmapPatchMemory {
+    pub target: RoadmapPatchTarget,
+    pub status: RoadmapPatchStatus,
+    pub patch_artifact: Option<ContentHash>,
+    pub patch_path: Option<PathBuf>,
+    pub roadmap_artifact: Option<ContentHash>,
+    pub roadmap_path: Option<PathBuf>,
+    pub flow_artifact: Option<ContentHash>,
+    pub flow_path: Option<PathBuf>,
+    pub updated_seq: u64,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct GraphRevisionMemory {
+    pub patch_id: RoadmapPatchId,
+    pub target: RoadmapPatchTarget,
+    pub previous_graph_hash: ContentHash,
+    pub graph_hash: ContentHash,
+    pub active_pickup: ActivePickupPolicy,
+    pub updated_seq: u64,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -437,6 +472,59 @@ pub fn apply(state: RunState, event: &RunEvent) -> Result<RunState, FoldError> {
                 unreachable!()
             }
         },
+        (
+            state @ RunState::Pipeline { .. },
+            EventPayload::RoadmapPatchDrafted { .. }
+            | EventPayload::RoadmapPatchApprovalRequested { .. }
+            | EventPayload::RoadmapPatchApprovalDecided { .. }
+            | EventPayload::RoadmapPatchApplied { .. }
+            | EventPayload::RoadmapUpdated { .. },
+        ) => {
+            if let RunState::Pipeline {
+                graph,
+                cursor,
+                mut memory,
+                pending_human_input,
+            } = state
+            {
+                memory.apply_event(event);
+                Ok(RunState::Pipeline {
+                    graph,
+                    cursor,
+                    memory,
+                    pending_human_input,
+                })
+            } else {
+                unreachable!()
+            }
+        },
+        (
+            state @ RunState::Pipeline { .. },
+            EventPayload::GraphRevisionAccepted { graph: revised, .. },
+        ) => {
+            if let RunState::Pipeline {
+                cursor,
+                mut memory,
+                pending_human_input,
+                ..
+            } = state
+            {
+                if !revised.nodes.contains_key(&cursor.node) {
+                    return Err(FoldError::UnknownNode {
+                        node: cursor.node.clone(),
+                    });
+                }
+                memory.apply_event(event);
+                Ok(RunState::Pipeline {
+                    graph: Arc::new(revised.as_ref().clone()),
+                    cursor,
+                    memory,
+                    pending_human_input,
+                })
+            } else {
+                unreachable!()
+            }
+        },
         // Many (state, event) pairs are pass-through — events like ToolCalled,
         // EdgeTraversed, SandboxElevation*, ApprovalRequested/Decided,
         // BootstrapStageStarted etc. are recorded for replay but do not drive
@@ -547,9 +635,185 @@ impl RunMemory {
             } => {
                 *self.node_visits.entry(to.clone()).or_insert(0) += 1;
             },
+            EventPayload::RoadmapPatchDrafted {
+                patch_id,
+                target,
+                patch_artifact,
+                patch_path,
+            } => {
+                self.roadmap_patches.insert(
+                    patch_id.clone(),
+                    RoadmapPatchMemory {
+                        target: target.clone(),
+                        status: RoadmapPatchStatus::Drafted,
+                        patch_artifact: Some(*patch_artifact),
+                        patch_path: Some(patch_path.clone()),
+                        roadmap_artifact: None,
+                        roadmap_path: None,
+                        flow_artifact: None,
+                        flow_path: None,
+                        updated_seq: event.seq,
+                    },
+                );
+            },
+            EventPayload::RoadmapPatchApprovalRequested {
+                patch_id, target, ..
+            } => {
+                self.upsert_roadmap_patch_status(
+                    patch_id,
+                    target,
+                    RoadmapPatchStatus::PendingApproval,
+                    event.seq,
+                );
+            },
+            EventPayload::RoadmapPatchApprovalDecided {
+                patch_id, decision, ..
+            } => {
+                self.update_roadmap_patch_decision(patch_id, *decision, event.seq);
+            },
+            EventPayload::RoadmapPatchApplied {
+                patch_id,
+                target,
+                amended_roadmap_artifact,
+                amended_roadmap_path,
+                amended_flow_artifact,
+                amended_flow_path,
+            } => {
+                self.upsert_roadmap_patch_artifacts(
+                    patch_id,
+                    target,
+                    RoadmapPatchArtifactUpdate {
+                        roadmap_artifact: *amended_roadmap_artifact,
+                        roadmap_path: amended_roadmap_path.clone(),
+                        flow_artifact: *amended_flow_artifact,
+                        flow_path: amended_flow_path.clone(),
+                        seq: event.seq,
+                    },
+                );
+            },
+            EventPayload::RoadmapUpdated {
+                patch_id,
+                target,
+                roadmap_artifact,
+                roadmap_path,
+                flow_artifact,
+                flow_path,
+                ..
+            } => {
+                self.upsert_roadmap_patch_artifacts(
+                    patch_id,
+                    target,
+                    RoadmapPatchArtifactUpdate {
+                        roadmap_artifact: *roadmap_artifact,
+                        roadmap_path: roadmap_path.clone(),
+                        flow_artifact: *flow_artifact,
+                        flow_path: flow_path.clone(),
+                        seq: event.seq,
+                    },
+                );
+            },
+            EventPayload::GraphRevisionAccepted {
+                patch_id,
+                target,
+                previous_graph_hash,
+                graph_hash,
+                active_pickup,
+                ..
+            } => {
+                self.latest_graph_revision = Some(GraphRevisionMemory {
+                    patch_id: patch_id.clone(),
+                    target: target.clone(),
+                    previous_graph_hash: *previous_graph_hash,
+                    graph_hash: *graph_hash,
+                    active_pickup: *active_pickup,
+                    updated_seq: event.seq,
+                });
+            },
             _ => {},
         }
     }
+
+    fn upsert_roadmap_patch_status(
+        &mut self,
+        patch_id: &RoadmapPatchId,
+        target: &RoadmapPatchTarget,
+        status: RoadmapPatchStatus,
+        seq: u64,
+    ) {
+        self.roadmap_patches
+            .entry(patch_id.clone())
+            .and_modify(|record| {
+                record.target = target.clone();
+                record.status = status;
+                record.updated_seq = seq;
+            })
+            .or_insert_with(|| RoadmapPatchMemory {
+                target: target.clone(),
+                status,
+                patch_artifact: None,
+                patch_path: None,
+                roadmap_artifact: None,
+                roadmap_path: None,
+                flow_artifact: None,
+                flow_path: None,
+                updated_seq: seq,
+            });
+    }
+
+    fn update_roadmap_patch_decision(
+        &mut self,
+        patch_id: &RoadmapPatchId,
+        decision: RoadmapPatchApprovalDecision,
+        seq: u64,
+    ) {
+        let status = match decision {
+            RoadmapPatchApprovalDecision::Approve => RoadmapPatchStatus::Approved,
+            RoadmapPatchApprovalDecision::Edit => RoadmapPatchStatus::Drafted,
+            RoadmapPatchApprovalDecision::Reject => RoadmapPatchStatus::Rejected,
+        };
+        if let Some(record) = self.roadmap_patches.get_mut(patch_id) {
+            record.status = status;
+            record.updated_seq = seq;
+        }
+    }
+
+    fn upsert_roadmap_patch_artifacts(
+        &mut self,
+        patch_id: &RoadmapPatchId,
+        target: &RoadmapPatchTarget,
+        update: RoadmapPatchArtifactUpdate,
+    ) {
+        self.roadmap_patches
+            .entry(patch_id.clone())
+            .and_modify(|record| {
+                record.target = target.clone();
+                record.status = RoadmapPatchStatus::Applied;
+                record.roadmap_artifact = Some(update.roadmap_artifact);
+                record.roadmap_path = Some(update.roadmap_path.clone());
+                record.flow_artifact = update.flow_artifact;
+                record.flow_path = update.flow_path.clone();
+                record.updated_seq = update.seq;
+            })
+            .or_insert_with(|| RoadmapPatchMemory {
+                target: target.clone(),
+                status: RoadmapPatchStatus::Applied,
+                patch_artifact: None,
+                patch_path: None,
+                roadmap_artifact: Some(update.roadmap_artifact),
+                roadmap_path: Some(update.roadmap_path),
+                flow_artifact: update.flow_artifact,
+                flow_path: update.flow_path,
+                updated_seq: update.seq,
+            });
+    }
+}
+
+struct RoadmapPatchArtifactUpdate {
+    roadmap_artifact: ContentHash,
+    roadmap_path: PathBuf,
+    flow_artifact: Option<ContentHash>,
+    flow_path: Option<PathBuf>,
+    seq: u64,
 }
 
 #[cfg(test)]
@@ -568,6 +832,45 @@ mod tests {
             seq,
             timestamp: Utc::now(),
             payload,
+        }
+    }
+
+    fn graph_with_terminal(name: &str, start: &str) -> Graph {
+        use crate::graph::{GraphMetadata, SCHEMA_VERSION};
+        use std::collections::BTreeMap;
+
+        let start = NodeKey::try_from(start).unwrap();
+        let mut nodes = BTreeMap::new();
+        nodes.insert(start.clone(), terminal_node(start.clone()));
+        Graph {
+            schema_version: SCHEMA_VERSION,
+            metadata: GraphMetadata {
+                name: name.into(),
+                description: None,
+                template_origin: None,
+                created_at: chrono::Utc::now(),
+                author: None,
+                archetype: None,
+            },
+            start,
+            nodes,
+            edges: vec![],
+            subgraphs: BTreeMap::new(),
+        }
+    }
+
+    fn terminal_node(key: NodeKey) -> crate::node::Node {
+        use crate::node::{Node, NodeConfig, Position};
+        use crate::terminal_config::{TerminalConfig, TerminalKind};
+
+        Node {
+            id: key,
+            position: Position::default(),
+            declared_outcomes: vec![],
+            config: NodeConfig::Terminal(TerminalConfig {
+                kind: TerminalKind::Success,
+                message: None,
+            }),
         }
     }
 
@@ -896,6 +1199,196 @@ mod tests {
                 assert_eq!(cursor.attempt, 1);
             },
             other => panic!("expected Pipeline state, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn roadmap_patch_events_update_run_memory_without_mutating_graph() {
+        use crate::graph::{Graph, GraphMetadata, SCHEMA_VERSION};
+        use crate::node::{Node, NodeConfig, Position};
+        use crate::terminal_config::{TerminalConfig, TerminalKind};
+        use std::collections::BTreeMap;
+
+        let end = NodeKey::try_from("end").unwrap();
+        let mut nodes = BTreeMap::new();
+        nodes.insert(
+            end.clone(),
+            Node {
+                id: end.clone(),
+                position: Position::default(),
+                declared_outcomes: vec![],
+                config: NodeConfig::Terminal(TerminalConfig {
+                    kind: TerminalKind::Success,
+                    message: None,
+                }),
+            },
+        );
+        let graph = Graph {
+            schema_version: SCHEMA_VERSION,
+            metadata: GraphMetadata {
+                name: "roadmap-patch-memory".into(),
+                description: None,
+                template_origin: None,
+                created_at: chrono::Utc::now(),
+                author: None,
+                archetype: None,
+            },
+            start: end.clone(),
+            nodes,
+            edges: vec![],
+            subgraphs: BTreeMap::new(),
+        };
+        let patch_id = RoadmapPatchId::new("rpatch-memory").unwrap();
+        let target = RoadmapPatchTarget::ProjectRoadmap {
+            roadmap_path: ".ai-factory/ROADMAP.md".into(),
+        };
+        let roadmap_hash = ContentHash::compute(b"roadmap");
+
+        let events = vec![
+            make_event(
+                1,
+                EventPayload::RunStarted {
+                    pipeline_template: None,
+                    project_path: PathBuf::from("/tmp"),
+                    initial_prompt: "test".into(),
+                    config: RunConfig {
+                        sandbox_default: SandboxMode::WorkspaceWrite,
+                        approval_default: ApprovalPolicy::OnRequest,
+                        auto_pr: false,
+                        mcp_servers: Vec::new(),
+                    },
+                },
+            ),
+            make_event(
+                2,
+                EventPayload::PipelineMaterialized {
+                    graph: Box::new(graph),
+                    graph_hash: ContentHash::compute(b"graph"),
+                },
+            ),
+            make_event(
+                3,
+                EventPayload::RoadmapPatchDrafted {
+                    patch_id: patch_id.clone(),
+                    target: target.clone(),
+                    patch_artifact: ContentHash::compute(b"patch"),
+                    patch_path: PathBuf::from("roadmap-patch.toml"),
+                },
+            ),
+            make_event(
+                4,
+                EventPayload::RoadmapPatchApprovalDecided {
+                    patch_id: patch_id.clone(),
+                    decision: RoadmapPatchApprovalDecision::Approve,
+                    channel_used: crate::approvals::ApprovalChannelKind::Desktop,
+                    comment: None,
+                    conflict_choice: None,
+                },
+            ),
+            make_event(
+                5,
+                EventPayload::RoadmapUpdated {
+                    patch_id: patch_id.clone(),
+                    target,
+                    roadmap_artifact: roadmap_hash,
+                    roadmap_path: PathBuf::from("roadmap.toml"),
+                    flow_artifact: None,
+                    flow_path: None,
+                    active_pickup: crate::roadmap_patch::ActivePickupPolicy::Allowed,
+                },
+            ),
+        ];
+
+        let state = fold(&events).unwrap();
+        match state {
+            RunState::Pipeline {
+                graph,
+                cursor,
+                memory,
+                ..
+            } => {
+                assert_eq!(cursor.node, end);
+                assert_eq!(graph.start, end, "roadmap events must not mutate graph");
+                let patch = &memory.roadmap_patches[&patch_id];
+                assert_eq!(patch.status, RoadmapPatchStatus::Applied);
+                assert_eq!(patch.roadmap_artifact, Some(roadmap_hash));
+                assert_eq!(patch.updated_seq, 5);
+            },
+            other => panic!("expected Pipeline, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn graph_revision_event_updates_pipeline_graph_and_revision_memory() {
+        let base_graph = graph_with_terminal("base", "end");
+        let mut amended_graph = graph_with_terminal("amended", "amend_001");
+        let old_cursor_node = NodeKey::try_from("end").unwrap();
+        amended_graph.nodes.insert(
+            old_cursor_node.clone(),
+            terminal_node(old_cursor_node.clone()),
+        );
+        let patch_id = RoadmapPatchId::new("rpatch-graph").unwrap();
+        let target = RoadmapPatchTarget::ProjectRoadmap {
+            roadmap_path: ".ai-factory/ROADMAP.md".into(),
+        };
+        let previous_graph_hash = ContentHash::compute(b"base-flow");
+        let graph_hash = ContentHash::compute(b"amended-flow");
+
+        let events = vec![
+            make_event(
+                1,
+                EventPayload::RunStarted {
+                    pipeline_template: None,
+                    project_path: PathBuf::from("/tmp"),
+                    initial_prompt: "test".into(),
+                    config: RunConfig {
+                        sandbox_default: SandboxMode::WorkspaceWrite,
+                        approval_default: ApprovalPolicy::OnRequest,
+                        auto_pr: false,
+                        mcp_servers: Vec::new(),
+                    },
+                },
+            ),
+            make_event(
+                2,
+                EventPayload::PipelineMaterialized {
+                    graph: Box::new(base_graph),
+                    graph_hash: previous_graph_hash,
+                },
+            ),
+            make_event(
+                3,
+                EventPayload::GraphRevisionAccepted {
+                    patch_id: patch_id.clone(),
+                    target: target.clone(),
+                    previous_graph_hash,
+                    graph: Box::new(amended_graph),
+                    graph_hash,
+                    active_pickup: ActivePickupPolicy::Allowed,
+                },
+            ),
+        ];
+
+        let state = fold(&events).unwrap();
+        match state {
+            RunState::Pipeline {
+                graph,
+                cursor,
+                memory,
+                ..
+            } => {
+                assert_eq!(graph.start, NodeKey::try_from("amend_001").unwrap());
+                assert_eq!(cursor.node, old_cursor_node);
+                let revision = memory
+                    .latest_graph_revision
+                    .expect("graph revision metadata recorded");
+                assert_eq!(revision.patch_id, patch_id);
+                assert_eq!(revision.target, target);
+                assert_eq!(revision.previous_graph_hash, previous_graph_hash);
+                assert_eq!(revision.graph_hash, graph_hash);
+                assert_eq!(revision.updated_seq, 3);
+            },
+            other => panic!("expected Pipeline, got {other:?}"),
         }
     }
 

--- a/crates/surge-core/tests/snapshots/fold_hook_events__fold_hook_events_memory.snap
+++ b/crates/surge-core/tests/snapshots/fold_hook_events__fold_hook_events_memory.snap
@@ -29,4 +29,6 @@ RunMemory {
     bootstrap_edit_counts: {},
     node_visits: {},
     last_edit_feedback_by_stage: {},
+    roadmap_patches: {},
+    latest_graph_revision: None,
 }

--- a/crates/surge-daemon/src/server.rs
+++ b/crates/surge-daemon/src/server.rs
@@ -288,8 +288,9 @@ async fn dispatch(
             run_id,
             graph,
             worktree_path,
-            mut run_config,
+            run_config,
         } => {
+            let mut run_config = *run_config;
             let config = SurgeConfig::discover_from(&worktree_path).unwrap_or_else(|e| {
                 tracing::debug!(
                     path = %worktree_path.display(),
@@ -597,6 +598,27 @@ async fn dispatch(
                     message: format!("{e}"),
                 }),
             }
+        },
+
+        DaemonRequest::SubmitRoadmapAmendment {
+            request_id,
+            run_id,
+            patch_id,
+            target,
+            patch_result,
+        } => match facade
+            .submit_roadmap_amendment(run_id, patch_id, target, *patch_result)
+            .await
+        {
+            Ok(outcome) => Some(DaemonResponse::SubmitRoadmapAmendmentOk {
+                request_id,
+                outcome: Box::new(outcome),
+            }),
+            Err(e) => Some(DaemonResponse::Error {
+                request_id,
+                code: ErrorCode::EngineError,
+                message: format!("{e}"),
+            }),
         },
 
         DaemonRequest::ResolveHumanInput {
@@ -953,7 +975,10 @@ async fn forward_per_run_to_client(
     loop {
         match rx.recv().await {
             Ok(event) => {
-                let frame = DaemonEvent::PerRun { run_id, event };
+                let frame = DaemonEvent::PerRun {
+                    run_id,
+                    event: Box::new(event),
+                };
                 let mut w = writer.lock().await;
                 if let Err(e) = write_frame(&mut *w, &frame).await {
                     tracing::debug!(
@@ -1084,9 +1109,12 @@ mod tests {
             .expect("lag response frame");
 
         match frame {
-            surge_orchestrator::engine::ipc::InboundServerFrame::Event(DaemonEvent::Global(
-                GlobalDaemonEvent::SubscriberLagged { dropped },
-            )) => assert!(dropped > 0, "lagged event should report dropped count"),
+            surge_orchestrator::engine::ipc::InboundServerFrame::Event(event) => match *event {
+                DaemonEvent::Global(GlobalDaemonEvent::SubscriberLagged { dropped }) => {
+                    assert!(dropped > 0, "lagged event should report dropped count");
+                },
+                other => panic!("expected SubscriberLagged global event, got {other:?}"),
+            },
             other => panic!("expected SubscriberLagged global event, got {other:?}"),
         }
     }

--- a/crates/surge-daemon/tests/daemon_list_queued.rs
+++ b/crates/surge-daemon/tests/daemon_list_queued.rs
@@ -243,7 +243,7 @@ async fn list_runs_includes_queued_run_as_awaiting() {
             run_id: run1,
             graph: Box::new(make_minimal_graph()),
             worktree_path: temp.path().to_path_buf(),
-            run_config: EngineRunConfig::default(),
+            run_config: Box::new(EngineRunConfig::default()),
         },
     )
     .await
@@ -270,7 +270,7 @@ async fn list_runs_includes_queued_run_as_awaiting() {
             run_id: run2,
             graph: Box::new(make_minimal_graph()),
             worktree_path: temp.path().to_path_buf(),
-            run_config: EngineRunConfig::default(),
+            run_config: Box::new(EngineRunConfig::default()),
         },
     )
     .await

--- a/crates/surge-daemon/tests/daemon_queue_drain.rs
+++ b/crates/surge-daemon/tests/daemon_queue_drain.rs
@@ -220,7 +220,7 @@ async fn queued_run_admitted_after_completion() {
         run_id: run1,
         graph: Box::new(make_minimal_graph()),
         worktree_path: temp.path().to_path_buf(),
-        run_config: EngineRunConfig::default(),
+        run_config: Box::new(EngineRunConfig::default()),
     };
     write_frame(&mut write_half, &req1)
         .await
@@ -245,7 +245,7 @@ async fn queued_run_admitted_after_completion() {
         run_id: run2,
         graph: Box::new(make_minimal_graph()),
         worktree_path: temp.path().to_path_buf(),
-        run_config: EngineRunConfig::default(),
+        run_config: Box::new(EngineRunConfig::default()),
     };
     write_frame(&mut write_half, &req2)
         .await

--- a/crates/surge-daemon/tests/daemon_queue_full.rs
+++ b/crates/surge-daemon/tests/daemon_queue_full.rs
@@ -214,7 +214,7 @@ async fn third_start_run_at_saturation_returns_queue_full() {
         run_id: run1,
         graph: Box::new(make_minimal_graph()),
         worktree_path: temp.path().to_path_buf(),
-        run_config: EngineRunConfig::default(),
+        run_config: Box::new(EngineRunConfig::default()),
     };
     write_frame(&mut write_half, &req1)
         .await
@@ -239,7 +239,7 @@ async fn third_start_run_at_saturation_returns_queue_full() {
         run_id: run2,
         graph: Box::new(make_minimal_graph()),
         worktree_path: temp.path().to_path_buf(),
-        run_config: EngineRunConfig::default(),
+        run_config: Box::new(EngineRunConfig::default()),
     };
     write_frame(&mut write_half, &req2)
         .await
@@ -269,7 +269,7 @@ async fn third_start_run_at_saturation_returns_queue_full() {
         run_id: run3,
         graph: Box::new(make_minimal_graph()),
         worktree_path: temp.path().to_path_buf(),
-        run_config: EngineRunConfig::default(),
+        run_config: Box::new(EngineRunConfig::default()),
     };
     write_frame(&mut write_half, &req3)
         .await

--- a/crates/surge-daemon/tests/daemon_queued_subscribe_test.rs
+++ b/crates/surge-daemon/tests/daemon_queued_subscribe_test.rs
@@ -223,7 +223,7 @@ async fn subscribe_to_queued_run_streams_after_admission() {
         run_id: run1,
         graph: Box::new(make_minimal_graph()),
         worktree_path: temp.path().to_path_buf(),
-        run_config: EngineRunConfig::default(),
+        run_config: Box::new(EngineRunConfig::default()),
     };
     write_frame(&mut write_half, &req1)
         .await
@@ -246,7 +246,7 @@ async fn subscribe_to_queued_run_streams_after_admission() {
         run_id: run2,
         graph: Box::new(make_minimal_graph()),
         worktree_path: temp.path().to_path_buf(),
-        run_config: EngineRunConfig::default(),
+        run_config: Box::new(EngineRunConfig::default()),
     };
     write_frame(&mut write_half, &req2)
         .await
@@ -301,17 +301,18 @@ async fn subscribe_to_queued_run_streams_after_admission() {
         )
         .await;
         match next_frame {
-            Ok(Ok(Some(InboundServerFrame::Event(DaemonEvent::PerRun { run_id, event }))))
-                if run_id == run2 =>
-            {
-                saw_run2_event = true;
-                // We expect the Terminal event from the
-                // delayed-finish path of the stub for run 2.
-                assert!(
-                    matches!(event, EngineRunEvent::Terminal { .. }),
-                    "first per-run event for run2 should be Terminal; got {event:?}"
-                );
-                break;
+            Ok(Ok(Some(InboundServerFrame::Event(frame)))) => match *frame {
+                DaemonEvent::PerRun { run_id, event } if run_id == run2 => {
+                    saw_run2_event = true;
+                    // We expect the Terminal event from the
+                    // delayed-finish path of the stub for run 2.
+                    assert!(
+                        matches!(*event, EngineRunEvent::Terminal { .. }),
+                        "first per-run event for run2 should be Terminal; got {event:?}"
+                    );
+                    break;
+                },
+                _ => continue,
             },
             Ok(Ok(Some(_))) => continue, // unrelated frame; keep reading
             Ok(Ok(None)) => break,       // EOF — daemon closed
@@ -387,7 +388,7 @@ async fn subscribe_to_queued_then_stop_does_not_leak_waiter() {
         run_id: run1,
         graph: Box::new(make_minimal_graph()),
         worktree_path: temp.path().to_path_buf(),
-        run_config: EngineRunConfig::default(),
+        run_config: Box::new(EngineRunConfig::default()),
     };
     write_frame(&mut write_half, &req1)
         .await
@@ -409,7 +410,7 @@ async fn subscribe_to_queued_then_stop_does_not_leak_waiter() {
         run_id: run2,
         graph: Box::new(make_minimal_graph()),
         worktree_path: temp.path().to_path_buf(),
-        run_config: EngineRunConfig::default(),
+        run_config: Box::new(EngineRunConfig::default()),
     };
     write_frame(&mut write_half, &req2)
         .await
@@ -486,10 +487,11 @@ async fn subscribe_to_queued_then_stop_does_not_leak_waiter() {
     )
     .await;
     match stray {
-        Ok(Ok(Some(InboundServerFrame::Event(DaemonEvent::PerRun { run_id, event })))) => {
-            if run_id == run2 {
+        Ok(Ok(Some(InboundServerFrame::Event(frame)))) => match *frame {
+            DaemonEvent::PerRun { run_id, event } if run_id == run2 => {
                 panic!("queued-then-stopped run2 emitted a PerRun frame post-StopRun: {event:?}");
-            }
+            },
+            _ => {},
         },
         Ok(Ok(Some(_))) | Ok(Ok(None)) | Ok(Err(_)) | Err(_) => {
             // Timeout (expected) or unrelated frame — both fine.

--- a/crates/surge-daemon/tests/daemon_stop_queued.rs
+++ b/crates/surge-daemon/tests/daemon_stop_queued.rs
@@ -242,7 +242,7 @@ async fn stop_run_cancels_queued_run() {
         run_id: run1,
         graph: Box::new(make_minimal_graph()),
         worktree_path: temp.path().to_path_buf(),
-        run_config: EngineRunConfig::default(),
+        run_config: Box::new(EngineRunConfig::default()),
     };
     write_frame(&mut write_half, &req1)
         .await
@@ -267,7 +267,7 @@ async fn stop_run_cancels_queued_run() {
         run_id: run2,
         graph: Box::new(make_minimal_graph()),
         worktree_path: temp.path().to_path_buf(),
-        run_config: EngineRunConfig::default(),
+        run_config: Box::new(EngineRunConfig::default()),
     };
     write_frame(&mut write_half, &req2)
         .await

--- a/crates/surge-daemon/tests/daemon_subscribe_global.rs
+++ b/crates/surge-daemon/tests/daemon_subscribe_global.rs
@@ -205,7 +205,7 @@ async fn subscribe_global_delivers_run_lifecycle_events() {
         run_id,
         graph: Box::new(make_minimal_graph()),
         worktree_path: temp.path().to_path_buf(),
-        run_config: EngineRunConfig::default(),
+        run_config: Box::new(EngineRunConfig::default()),
     };
     write_frame(&mut write_half, &req)
         .await
@@ -329,7 +329,7 @@ async fn subscribe_global_is_idempotent_within_a_connection() {
         run_id,
         graph: Box::new(make_minimal_graph()),
         worktree_path: temp.path().to_path_buf(),
-        run_config: EngineRunConfig::default(),
+        run_config: Box::new(EngineRunConfig::default()),
     };
     write_frame(&mut write_half, &req)
         .await

--- a/crates/surge-daemon/tests/inbox_callback_e2e.rs
+++ b/crates/surge-daemon/tests/inbox_callback_e2e.rs
@@ -155,7 +155,7 @@ impl EngineFacade for MockEngineFacade {
                     let node = NodeKey::try_new("bootstrap_agent").unwrap();
                     let _ = tx_for_task.send(EngineRunEvent::Persisted {
                         seq: 0,
-                        payload: EventPayload::StageEntered { node, attempt: 0 },
+                        payload: Box::new(EventPayload::StageEntered { node, attempt: 0 }),
                     });
                     tokio::time::sleep(Duration::from_millis(50)).await;
                     let outcome = RunOutcome::Completed {

--- a/crates/surge-notify/src/lib.rs
+++ b/crates/surge-notify/src/lib.rs
@@ -25,7 +25,10 @@ pub mod webhook;
 pub use deliverer::{NotifyDeliverer, NotifyDeliveryContext, NotifyError, RenderedNotification};
 pub use desktop::DesktopDeliverer;
 pub use email::{EmailCredentials, EmailDeliverer, EmailSecretResolver};
-pub use messages::{InboxCardPayload, NotifyMessage};
+pub use messages::{
+    InboxCardPayload, NotifyMessage, RoadmapAmendmentNotificationKind,
+    RoadmapAmendmentNotificationPayload,
+};
 pub use multiplexer::MultiplexingNotifier;
 pub use render::{RenderContext, render};
 pub use slack::{SlackCredentials, SlackDeliverer, SlackSecretResolver};

--- a/crates/surge-notify/src/messages.rs
+++ b/crates/surge-notify/src/messages.rs
@@ -3,7 +3,16 @@
 //! Defines `NotifyMessage` enum and payload structs that channel
 //! formatters (Telegram, Desktop, etc.) pattern-match and render.
 
+use std::fmt::Write as _;
+use std::path::PathBuf;
+
+use crate::deliverer::RenderedNotification;
 use serde::{Deserialize, Serialize};
+use surge_core::RunId;
+use surge_core::notify_config::NotifySeverity;
+use surge_core::roadmap_patch::{
+    OperatorConflictChoice, RoadmapPatchId, RoadmapPatchStatus, RoadmapPatchTarget,
+};
 use surge_intake::types::{Priority, TaskId};
 
 /// Payload for the `InboxCard` notification variant.
@@ -35,6 +44,94 @@ pub struct InboxCardPayload {
     pub callback_token: String,
 }
 
+/// Lifecycle event type for roadmap amendment notifications.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RoadmapAmendmentNotificationKind {
+    /// A patch needs human approval.
+    ApprovalRequested,
+    /// A patch was applied to a roadmap/flow.
+    PatchApplied,
+    /// An active runner observed or picked up an amendment.
+    RunnerPickup,
+    /// A follow-up run was materialized or started.
+    FollowUpRunCreated,
+    /// Applying the patch hit a conflict that needs operator input.
+    ConflictDetected,
+    /// A patch was rejected.
+    PatchRejected,
+}
+
+impl RoadmapAmendmentNotificationKind {
+    /// Stable `snake_case` label.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::ApprovalRequested => "approval_requested",
+            Self::PatchApplied => "patch_applied",
+            Self::RunnerPickup => "runner_pickup",
+            Self::FollowUpRunCreated => "follow_up_run_created",
+            Self::ConflictDetected => "conflict_detected",
+            Self::PatchRejected => "patch_rejected",
+        }
+    }
+}
+
+/// Structured notification payload for roadmap amendment lifecycle events.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RoadmapAmendmentNotificationPayload {
+    /// Notification lifecycle kind.
+    pub kind: RoadmapAmendmentNotificationKind,
+    /// Patch this notification concerns.
+    pub patch_id: RoadmapPatchId,
+    /// Target roadmap/run for the patch.
+    pub target: RoadmapPatchTarget,
+    /// Parent or active run id, when applicable.
+    pub run_id: Option<RunId>,
+    /// Follow-up run id, when one was created.
+    pub follow_up_run_id: Option<RunId>,
+    /// Current patch lifecycle status, when known.
+    pub status: Option<RoadmapPatchStatus>,
+    /// Short human-readable summary.
+    pub summary: String,
+    /// Additional human-readable detail.
+    pub detail: Option<String>,
+    /// Stable conflict codes or labels.
+    #[serde(default)]
+    pub conflict_codes: Vec<String>,
+    /// Operator choices available for conflicts.
+    #[serde(default)]
+    pub conflict_choices: Vec<OperatorConflictChoice>,
+    /// Artifact paths worth linking in rendered channels.
+    #[serde(default)]
+    pub artifact_paths: Vec<PathBuf>,
+}
+
+impl RoadmapAmendmentNotificationPayload {
+    /// Build a payload with the required lifecycle fields.
+    #[must_use]
+    pub fn new(
+        kind: RoadmapAmendmentNotificationKind,
+        patch_id: RoadmapPatchId,
+        target: RoadmapPatchTarget,
+        summary: impl Into<String>,
+    ) -> Self {
+        Self {
+            kind,
+            patch_id,
+            target,
+            run_id: None,
+            follow_up_run_id: None,
+            status: None,
+            summary: summary.into(),
+            detail: None,
+            conflict_codes: Vec::new(),
+            conflict_choices: Vec::new(),
+            artifact_paths: Vec::new(),
+        }
+    }
+}
+
 /// Notification message type.
 ///
 /// Used by channel-specific formatters to render payloads for delivery
@@ -43,6 +140,73 @@ pub struct InboxCardPayload {
 pub enum NotifyMessage {
     /// An inbox card — a freshly-detected task waiting for user action.
     InboxCard(InboxCardPayload),
+    /// Roadmap amendment lifecycle message.
+    RoadmapAmendment(Box<RoadmapAmendmentNotificationPayload>),
+}
+
+impl NotifyMessage {
+    /// Render this structured message to the channel-neutral notification body.
+    #[must_use]
+    pub fn render(&self) -> RenderedNotification {
+        match self {
+            Self::InboxCard(payload) => render_inbox_card(payload),
+            Self::RoadmapAmendment(payload) => render_roadmap_amendment(payload),
+        }
+    }
+}
+
+fn render_inbox_card(payload: &InboxCardPayload) -> RenderedNotification {
+    RenderedNotification {
+        severity: NotifySeverity::Info,
+        title: format!("Inbox: {}", payload.title),
+        body: format!("{}\n{}", payload.summary, payload.task_url),
+        artifact_paths: Vec::new(),
+    }
+}
+
+fn render_roadmap_amendment(payload: &RoadmapAmendmentNotificationPayload) -> RenderedNotification {
+    let severity = match payload.kind {
+        RoadmapAmendmentNotificationKind::ConflictDetected
+        | RoadmapAmendmentNotificationKind::PatchRejected => NotifySeverity::Warn,
+        RoadmapAmendmentNotificationKind::ApprovalRequested
+        | RoadmapAmendmentNotificationKind::PatchApplied
+        | RoadmapAmendmentNotificationKind::RunnerPickup
+        | RoadmapAmendmentNotificationKind::FollowUpRunCreated => NotifySeverity::Info,
+    };
+    let mut body = format!(
+        "{}\npatch_id={}\ntarget={}",
+        payload.summary,
+        payload.patch_id,
+        amendment_target_label(&payload.target)
+    );
+    if let Some(detail) = &payload.detail {
+        body.push('\n');
+        body.push_str(detail);
+    }
+    if let Some(run_id) = payload.run_id {
+        let _ = write!(body, "\nrun_id={run_id}");
+    }
+    if let Some(run_id) = payload.follow_up_run_id {
+        let _ = write!(body, "\nfollowup_run_id={run_id}");
+    }
+    if !payload.conflict_codes.is_empty() {
+        let _ = write!(body, "\nconflicts={}", payload.conflict_codes.join(", "));
+    }
+    RenderedNotification {
+        severity,
+        title: format!("Roadmap amendment: {}", payload.kind.as_str()),
+        body,
+        artifact_paths: payload.artifact_paths.clone(),
+    }
+}
+
+fn amendment_target_label(target: &RoadmapPatchTarget) -> String {
+    match target {
+        RoadmapPatchTarget::ProjectRoadmap { roadmap_path } => {
+            format!("project:{roadmap_path}")
+        },
+        RoadmapPatchTarget::RunRoadmap { run_id, .. } => format!("run:{run_id}"),
+    }
 }
 
 #[cfg(test)]
@@ -70,6 +234,35 @@ mod inbox_card_tests {
                 assert_eq!(p.callback_token, "01HKGZTOKABC");
                 assert_eq!(p.priority, Priority::High);
             },
+            NotifyMessage::RoadmapAmendment(_) => panic!("expected inbox card"),
         }
+    }
+
+    #[test]
+    fn round_trip_and_render_roadmap_amendment() {
+        let patch_id = RoadmapPatchId::new("rpatch-notify").unwrap();
+        let payload = RoadmapAmendmentNotificationPayload {
+            kind: RoadmapAmendmentNotificationKind::ConflictDetected,
+            patch_id: patch_id.clone(),
+            target: RoadmapPatchTarget::ProjectRoadmap {
+                roadmap_path: ".ai-factory/ROADMAP.md".into(),
+            },
+            run_id: None,
+            follow_up_run_id: Some(RunId::new()),
+            status: Some(RoadmapPatchStatus::Approved),
+            summary: "Patch needs a decision".into(),
+            detail: Some("Milestone is already running".into()),
+            conflict_codes: vec!["running_milestone".into()],
+            conflict_choices: vec![OperatorConflictChoice::CreateFollowUpRun],
+            artifact_paths: vec!["roadmap-patch.toml".into()],
+        };
+        let msg = NotifyMessage::RoadmapAmendment(Box::new(payload));
+        let s = serde_json::to_string(&msg).unwrap();
+        let back: NotifyMessage = serde_json::from_str(&s).unwrap();
+        let rendered = back.render();
+        assert_eq!(rendered.severity, NotifySeverity::Warn);
+        assert!(rendered.body.contains(patch_id.as_str()));
+        assert!(rendered.body.contains("running_milestone"));
+        assert_eq!(rendered.artifact_paths.len(), 1);
     }
 }

--- a/crates/surge-notify/src/messages.rs
+++ b/crates/surge-notify/src/messages.rs
@@ -192,6 +192,18 @@ fn render_roadmap_amendment(payload: &RoadmapAmendmentNotificationPayload) -> Re
     if !payload.conflict_codes.is_empty() {
         let _ = write!(body, "\nconflicts={}", payload.conflict_codes.join(", "));
     }
+    if let Some(status) = payload.status {
+        let _ = write!(body, "\nstatus={}", roadmap_patch_status_label(status));
+    }
+    if !payload.conflict_choices.is_empty() {
+        let choices = payload
+            .conflict_choices
+            .iter()
+            .map(|choice| operator_conflict_choice_label(*choice))
+            .collect::<Vec<_>>()
+            .join(", ");
+        let _ = write!(body, "\nconflict_choices={choices}");
+    }
     RenderedNotification {
         severity,
         title: format!("Roadmap amendment: {}", payload.kind.as_str()),
@@ -206,6 +218,26 @@ fn amendment_target_label(target: &RoadmapPatchTarget) -> String {
             format!("project:{roadmap_path}")
         },
         RoadmapPatchTarget::RunRoadmap { run_id, .. } => format!("run:{run_id}"),
+    }
+}
+
+const fn roadmap_patch_status_label(status: RoadmapPatchStatus) -> &'static str {
+    match status {
+        RoadmapPatchStatus::Drafted => "drafted",
+        RoadmapPatchStatus::PendingApproval => "pending_approval",
+        RoadmapPatchStatus::Approved => "approved",
+        RoadmapPatchStatus::Applied => "applied",
+        RoadmapPatchStatus::Rejected => "rejected",
+        RoadmapPatchStatus::Superseded => "superseded",
+    }
+}
+
+const fn operator_conflict_choice_label(choice: OperatorConflictChoice) -> &'static str {
+    match choice {
+        OperatorConflictChoice::DeferToNextMilestone => "defer_to_next_milestone",
+        OperatorConflictChoice::AbortCurrentRun => "abort_current_run",
+        OperatorConflictChoice::CreateFollowUpRun => "create_follow_up_run",
+        OperatorConflictChoice::RejectPatch => "reject_patch",
     }
 }
 
@@ -263,6 +295,12 @@ mod inbox_card_tests {
         assert_eq!(rendered.severity, NotifySeverity::Warn);
         assert!(rendered.body.contains(patch_id.as_str()));
         assert!(rendered.body.contains("running_milestone"));
+        assert!(rendered.body.contains("status=approved"));
+        assert!(
+            rendered
+                .body
+                .contains("conflict_choices=create_follow_up_run")
+        );
         assert_eq!(rendered.artifact_paths.len(), 1);
     }
 }

--- a/crates/surge-notify/src/multiplexer.rs
+++ b/crates/surge-notify/src/multiplexer.rs
@@ -3,6 +3,7 @@
 //! method). Default state: all channels return `ChannelNotConfigured`.
 
 use crate::deliverer::{NotifyDeliverer, NotifyDeliveryContext, NotifyError, RenderedNotification};
+use crate::messages::NotifyMessage;
 use async_trait::async_trait;
 use std::sync::Arc;
 use surge_core::notify_config::NotifyChannel;
@@ -57,6 +58,17 @@ impl MultiplexingNotifier {
     pub fn with_telegram(mut self, d: Arc<dyn NotifyDeliverer>) -> Self {
         self.telegram = Some(d);
         self
+    }
+
+    /// Render a structured [`NotifyMessage`] and deliver it to one channel.
+    pub async fn deliver_message(
+        &self,
+        ctx: &NotifyDeliveryContext<'_>,
+        channel: &NotifyChannel,
+        message: &NotifyMessage,
+    ) -> Result<(), NotifyError> {
+        let rendered = message.render();
+        self.deliver(ctx, channel, &rendered).await
     }
 }
 
@@ -142,6 +154,33 @@ mod tests {
             node: &node,
         };
         mux.deliver(&ctx, &NotifyChannel::Desktop, &rendered())
+            .await
+            .unwrap();
+        assert_eq!(*rec.calls.lock().unwrap(), 1);
+    }
+
+    #[tokio::test]
+    async fn delivers_structured_message_after_rendering() {
+        let rec = Arc::new(Recorder {
+            calls: Mutex::new(0),
+        });
+        let mux = MultiplexingNotifier::new().with_desktop(rec.clone());
+        let node = NodeKey::try_from("n").unwrap();
+        let ctx = NotifyDeliveryContext {
+            run_id: RunId::new(),
+            node: &node,
+        };
+        let message = NotifyMessage::InboxCard(crate::messages::InboxCardPayload {
+            task_id: surge_intake::types::TaskId::try_new("github_issues:o/r#1").unwrap(),
+            source_id: "github_issues:o/r".into(),
+            provider: "github_issues".into(),
+            title: "Fix parser".into(),
+            summary: "Parser fails on nesting".into(),
+            priority: surge_intake::types::Priority::High,
+            task_url: "https://example.com".into(),
+            callback_token: "token".into(),
+        });
+        mux.deliver_message(&ctx, &NotifyChannel::Desktop, &message)
             .await
             .unwrap();
         assert_eq!(*rec.calls.lock().unwrap(), 1);

--- a/crates/surge-orchestrator/src/engine/config.rs
+++ b/crates/surge-orchestrator/src/engine/config.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use surge_core::content_hash::ContentHash;
 use surge_core::id::RunId;
+use surge_core::keys::{KeyParseError, NodeKey};
 use surge_core::mcp_config::McpServerRef;
 
 use crate::profile_loader::ProfileRegistry;
@@ -77,6 +78,11 @@ pub struct EngineRunConfig {
     /// Optional stable project context captured at run start.
     #[serde(default)]
     pub project_context: Option<ProjectContextSeed>,
+    /// Additional first-class artifacts copied into a run before its first
+    /// stage executes. Used by follow-up amendment runs to seed the appended
+    /// roadmap slice without relying on mutable project files.
+    #[serde(default)]
+    pub seed_artifacts: Vec<RunSeedArtifact>,
     /// Bootstrap-flow knobs. Default values are tuned for the bundled
     /// bootstrap graph; non-bootstrap runs ignore the section entirely.
     #[serde(default)]
@@ -104,6 +110,44 @@ impl ProjectContextSeed {
             content,
             hash,
         }
+    }
+}
+
+/// Caller-supplied artifact copied into the run worktree at start.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+pub struct RunSeedArtifact {
+    /// Artifact name visible through `ArtifactSource::RunArtifact`.
+    pub name: String,
+    /// Portable relative path inside the run worktree.
+    pub relative_path: std::path::PathBuf,
+    /// Captured artifact body.
+    pub content: String,
+    /// Synthetic or real producer node recorded in `ArtifactProduced`.
+    pub producer: NodeKey,
+    /// Hash of `content`, computed before the run starts.
+    pub hash: ContentHash,
+}
+
+impl RunSeedArtifact {
+    /// Build a seed artifact and compute its content hash.
+    ///
+    /// # Errors
+    /// Returns [`KeyParseError`] when `producer` is not a valid node key.
+    pub fn new(
+        name: impl Into<String>,
+        relative_path: impl Into<std::path::PathBuf>,
+        content: impl Into<String>,
+        producer: &str,
+    ) -> Result<Self, KeyParseError> {
+        let content = content.into();
+        let hash = ContentHash::compute(content.as_bytes());
+        Ok(Self {
+            name: name.into(),
+            relative_path: relative_path.into(),
+            content,
+            producer: NodeKey::try_from(producer)?,
+            hash,
+        })
     }
 }
 
@@ -141,6 +185,7 @@ impl Default for EngineRunConfig {
             initial_prompt: String::new(),
             bootstrap_parent: None,
             project_context: None,
+            seed_artifacts: Vec::new(),
             bootstrap: BootstrapRunConfig::default(),
         }
     }
@@ -192,6 +237,7 @@ mod tests {
             initial_prompt: String::new(),
             bootstrap_parent: None,
             project_context: None,
+            seed_artifacts: Vec::new(),
             bootstrap: BootstrapRunConfig::default(),
         };
         let json = serde_json::to_string(&cfg).unwrap();
@@ -221,6 +267,7 @@ mod tests {
             initial_prompt: "fix the broken cart-total bug".into(),
             bootstrap_parent: None,
             project_context: None,
+            seed_artifacts: Vec::new(),
             bootstrap: BootstrapRunConfig::default(),
         };
         let json = serde_json::to_string(&cfg).unwrap();
@@ -264,10 +311,25 @@ mod tests {
             initial_prompt: String::new(),
             bootstrap_parent: None,
             project_context: None,
+            seed_artifacts: Vec::new(),
             bootstrap: BootstrapRunConfig { edit_loop_cap: 5 },
         };
         let json = serde_json::to_string(&cfg).unwrap();
         let parsed: EngineRunConfig = serde_json::from_str(&json).unwrap();
         assert_eq!(parsed.bootstrap.edit_loop_cap, 5);
+    }
+
+    #[test]
+    fn run_seed_artifact_computes_hash_and_validates_producer() {
+        let seed = RunSeedArtifact::new(
+            "roadmap_amendment",
+            ".surge/roadmap_amendment.md",
+            "## New work",
+            "roadmap_seed",
+        )
+        .unwrap();
+        assert_eq!(seed.name, "roadmap_amendment");
+        assert_eq!(seed.producer.as_ref(), "roadmap_seed");
+        assert_eq!(seed.hash, ContentHash::compute(b"## New work"));
     }
 }

--- a/crates/surge-orchestrator/src/engine/daemon_facade.rs
+++ b/crates/surge-orchestrator/src/engine/daemon_facade.rs
@@ -15,6 +15,7 @@ use crate::engine::ipc::{
     DaemonEvent, DaemonRequest, DaemonResponse, ErrorCode, GlobalDaemonEvent, InboundServerFrame,
     RequestId, read_inbound_server_frame, write_frame,
 };
+use crate::roadmap_amendment::ActiveRunAmendmentOutcome;
 use async_trait::async_trait;
 use interprocess::local_socket::tokio::prelude::*;
 use std::collections::HashMap;
@@ -23,6 +24,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use surge_core::graph::Graph;
 use surge_core::id::RunId;
+use surge_core::roadmap_patch::{RoadmapPatchApplyResult, RoadmapPatchId, RoadmapPatchTarget};
 use tokio::io::{AsyncWriteExt, BufReader};
 use tokio::sync::{Mutex, broadcast, oneshot};
 
@@ -83,8 +85,9 @@ impl DaemonClient {
                             let _ = tx.send(resp);
                         }
                     },
-                    Ok(Some(InboundServerFrame::Event(ev))) => match ev {
+                    Ok(Some(InboundServerFrame::Event(ev))) => match *ev {
                         DaemonEvent::PerRun { run_id, event } => {
+                            let event = *event;
                             let is_terminal = matches!(event, EngineRunEvent::Terminal { .. });
                             if is_terminal {
                                 if let EngineRunEvent::Terminal { outcome } = &event {
@@ -229,7 +232,7 @@ impl EngineFacade for DaemonEngineFacade {
                 run_id,
                 graph: Box::new(graph),
                 worktree_path,
-                run_config,
+                run_config: Box::new(run_config),
             })
             .await?;
         match resp {
@@ -362,6 +365,30 @@ impl EngineFacade for DaemonEngineFacade {
             .await?
         {
             DaemonResponse::StopRunOk { .. } => Ok(()),
+            DaemonResponse::Error { code, message, .. } => Err(map_error(code, &message)),
+            other => Err(EngineError::Internal(format!("unexpected: {other:?}"))),
+        }
+    }
+
+    async fn submit_roadmap_amendment(
+        &self,
+        run_id: RunId,
+        patch_id: RoadmapPatchId,
+        target: RoadmapPatchTarget,
+        patch_result: RoadmapPatchApplyResult,
+    ) -> Result<ActiveRunAmendmentOutcome, EngineError> {
+        match self
+            .inner
+            .rpc(|request_id| DaemonRequest::SubmitRoadmapAmendment {
+                request_id,
+                run_id,
+                patch_id,
+                target,
+                patch_result: Box::new(patch_result),
+            })
+            .await?
+        {
+            DaemonResponse::SubmitRoadmapAmendmentOk { outcome, .. } => Ok(*outcome),
             DaemonResponse::Error { code, message, .. } => Err(map_error(code, &message)),
             other => Err(EngineError::Internal(format!("unexpected: {other:?}"))),
         }

--- a/crates/surge-orchestrator/src/engine/daemon_facade.rs
+++ b/crates/surge-orchestrator/src/engine/daemon_facade.rs
@@ -88,7 +88,7 @@ impl DaemonClient {
                     Ok(Some(InboundServerFrame::Event(ev))) => match *ev {
                         DaemonEvent::PerRun { run_id, event } => {
                             let event = *event;
-                            let is_terminal = matches!(event, EngineRunEvent::Terminal { .. });
+                            let is_terminal = matches!(&event, EngineRunEvent::Terminal { .. });
                             if is_terminal {
                                 if let EngineRunEvent::Terminal { outcome } = &event {
                                     if let Some(tx) =

--- a/crates/surge-orchestrator/src/engine/engine.rs
+++ b/crates/surge-orchestrator/src/engine/engine.rs
@@ -376,6 +376,7 @@ impl Engine {
             resume_memory: None,
             resume_frames: None,
             resume_root_traversal_counts: None,
+            resume_applied_graph_revision_seq: None,
             gate_resolutions,
             tool_resolutions,
             roadmap_amendments: roadmap_amendment_rx,
@@ -606,6 +607,7 @@ impl Engine {
             resume_memory: Some(replayed.memory),
             resume_frames: None,
             resume_root_traversal_counts: None,
+            resume_applied_graph_revision_seq: Some(replayed.applied_graph_revision_seq),
             gate_resolutions,
             tool_resolutions,
             roadmap_amendments: roadmap_amendment_rx,
@@ -861,8 +863,9 @@ pub(crate) async fn synthesise_run_seed_artifact(
         tokio::fs::create_dir_all(parent).await?;
     }
     tokio::fs::write(&absolute_path, seed.content.as_bytes()).await?;
+    let hash = surge_core::ContentHash::compute(seed.content.as_bytes());
     Ok(InitialPromptArtifact {
-        hash: seed.hash,
+        hash,
         relative_path: seed.relative_path.clone(),
         producer: seed.producer.clone(),
     })

--- a/crates/surge-orchestrator/src/engine/engine.rs
+++ b/crates/surge-orchestrator/src/engine/engine.rs
@@ -9,7 +9,7 @@ use crate::engine::tools::ToolDispatcher;
 use crate::profile_loader::ProfileRegistry;
 use crate::roadmap_amendment::ActiveRunAmendmentOutcome;
 use std::collections::HashMap;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use surge_acp::bridge::facade::BridgeFacade;
 use surge_core::graph::Graph;
@@ -165,7 +165,6 @@ impl Engine {
     }
 
     /// Start a new run.
-    #[allow(clippy::too_many_lines)]
     pub async fn start_run(
         &self,
         run_id: RunId,
@@ -176,12 +175,6 @@ impl Engine {
         use crate::engine::handle::RunHandle;
         use crate::engine::run_task::{RunTaskParams, execute};
         use crate::engine::validate::validate_for_m6;
-        use surge_core::approvals::ApprovalPolicy;
-        use surge_core::content_hash::ContentHash;
-        use surge_core::run_event::{
-            EventPayload, RunConfig as CoreRunConfig, VersionedEventPayload,
-        };
-        use surge_core::sandbox::SandboxMode;
         use tokio::sync::broadcast;
         use tokio_util::sync::CancellationToken;
 
@@ -203,128 +196,9 @@ impl Engine {
         let artifact_store =
             surge_persistence::artifacts::ArtifactStore::new(self.storage.home().join("runs"));
 
-        // Emit RunStarted + PipelineMaterialized atomically.
-        let core_run_config = CoreRunConfig {
-            sandbox_default: SandboxMode::WorkspaceWrite,
-            approval_default: ApprovalPolicy::OnRequest,
-            auto_pr: false,
-            mcp_servers: run_config.mcp_servers.clone(),
-        };
-        let graph_bytes = serde_json::to_vec(&graph)
-            .map_err(|e| EngineError::Internal(format!("graph serialize: {e}")))?;
-        let graph_hash = ContentHash::compute(&graph_bytes);
-
-        let mut events = vec![
-            VersionedEventPayload::new(EventPayload::RunStarted {
-                pipeline_template: None,
-                project_path: worktree_path.clone(),
-                initial_prompt: run_config.initial_prompt.clone(),
-                config: core_run_config,
-            }),
-            VersionedEventPayload::new(EventPayload::PipelineMaterialized {
-                graph: Box::new(graph.clone()),
-                graph_hash,
-            }),
-        ];
-
-        if let Some(parent_run_id) = run_config.bootstrap_parent {
-            let inherited = self
-                .bootstrap_parent_artifact_events(&artifact_store, run_id, parent_run_id)
-                .await?;
-            events.extend(inherited);
-        }
-
-        if let Some(seed) = &run_config.project_context {
-            let project_context_artifact = artifact_store
-                .put(
-                    run_id,
-                    PROJECT_CONTEXT_ARTIFACT_NAME,
-                    seed.content.as_bytes(),
-                )
-                .await
-                .map_err(|e| EngineError::Storage(e.to_string()))?;
-            let producer = surge_core::keys::NodeKey::try_from(PROJECT_CONTEXT_PRODUCER_NODE)
-                .map_err(|e| EngineError::Internal(format!("project context producer key: {e}")))?;
-            tracing::debug!(
-                target: "engine::startup",
-                run_id = %run_id,
-                path = %seed.path.display(),
-                bytes = seed.content.len(),
-                hash = %project_context_artifact.hash,
-                "seeded project_context artifact"
-            );
-            tracing::info!(
-                target: "engine::startup",
-                run_id = %run_id,
-                path = %seed.path.display(),
-                hash = %project_context_artifact.hash,
-                "project context captured for run"
-            );
-            events.push(VersionedEventPayload::new(EventPayload::ArtifactProduced {
-                node: producer,
-                artifact: project_context_artifact.hash,
-                path: project_context_artifact.path,
-                name: PROJECT_CONTEXT_ARTIFACT_NAME.to_string(),
-            }));
-        }
-
-        for seed in &run_config.seed_artifacts {
-            let seeded_artifact = synthesise_run_seed_artifact(&worktree_path, seed)
-                .await
-                .map_err(|e| {
-                    EngineError::Internal(format!(
-                        "seed artifact {} synthesis failed: {e}",
-                        seed.name
-                    ))
-                })?;
-            tracing::debug!(
-                target: "engine::startup",
-                run_id = %run_id,
-                name = seed.name.as_str(),
-                path = %seed.relative_path.display(),
-                bytes = seed.content.len(),
-                hash = %seeded_artifact.hash,
-                "seeded run artifact"
-            );
-            events.push(VersionedEventPayload::new(EventPayload::ArtifactProduced {
-                node: seeded_artifact.producer,
-                artifact: seeded_artifact.hash,
-                path: seeded_artifact.relative_path,
-                name: seed.name.clone(),
-            }));
-        }
-
-        // Surface the operator's free-form prompt as a first-class artifact so
-        // bootstrap (or any) agent stage can pull it via the standard binding
-        // path through `ArtifactSource::InitialPrompt` (and equivalently via
-        // `ArtifactSource::RunArtifact { name: "user_prompt" }`). The artifact
-        // body is stored at `<worktree>/.surge/user_prompt.txt`; the
-        // `ArtifactProduced` event records its content hash, relative path,
-        // and a synthetic producer node so the existing fold rule populates
-        // `RunMemory.artifacts["user_prompt"]` deterministically.
-        if !run_config.initial_prompt.is_empty() {
-            let prompt_artifact = synthesise_initial_prompt_artifact(
-                &worktree_path,
-                run_config.initial_prompt.as_bytes(),
-            )
-            .await
-            .map_err(|e| {
-                EngineError::Internal(format!("initial-prompt artifact synthesis failed: {e}"))
-            })?;
-            tracing::debug!(
-                target: "engine::startup",
-                run_id = %run_id,
-                prompt_len = run_config.initial_prompt.len(),
-                "seeded user_prompt artifact",
-            );
-            events.push(VersionedEventPayload::new(EventPayload::ArtifactProduced {
-                node: prompt_artifact.producer,
-                artifact: prompt_artifact.hash,
-                path: prompt_artifact.relative_path,
-                name: INITIAL_PROMPT_ARTIFACT_NAME.to_string(),
-            }));
-        }
-
+        let events = self
+            .build_startup_events(&artifact_store, run_id, &graph, &worktree_path, &run_config)
+            .await?;
         writer
             .append_events(events)
             .await
@@ -397,6 +271,84 @@ impl Engine {
             events: event_rx,
             completion: join,
         })
+    }
+
+    async fn build_startup_events(
+        &self,
+        artifact_store: &surge_persistence::artifacts::ArtifactStore,
+        run_id: RunId,
+        graph: &Graph,
+        worktree_path: &Path,
+        run_config: &EngineRunConfig,
+    ) -> Result<Vec<VersionedEventPayload>, EngineError> {
+        let mut events = Self::startup_run_events(graph, worktree_path, run_config)?;
+        events.extend(
+            self.collect_startup_artifact_events(artifact_store, run_id, worktree_path, run_config)
+                .await?,
+        );
+        Ok(events)
+    }
+
+    fn startup_run_events(
+        graph: &Graph,
+        worktree_path: &Path,
+        run_config: &EngineRunConfig,
+    ) -> Result<Vec<VersionedEventPayload>, EngineError> {
+        use surge_core::approvals::ApprovalPolicy;
+        use surge_core::content_hash::ContentHash;
+        use surge_core::run_event::RunConfig as CoreRunConfig;
+        use surge_core::sandbox::SandboxMode;
+
+        let graph_bytes = serde_json::to_vec(graph)
+            .map_err(|e| EngineError::Internal(format!("graph serialize: {e}")))?;
+        let graph_hash = ContentHash::compute(&graph_bytes);
+        let core_run_config = CoreRunConfig {
+            sandbox_default: SandboxMode::WorkspaceWrite,
+            approval_default: ApprovalPolicy::OnRequest,
+            auto_pr: false,
+            mcp_servers: run_config.mcp_servers.clone(),
+        };
+
+        Ok(vec![
+            VersionedEventPayload::new(EventPayload::RunStarted {
+                pipeline_template: None,
+                project_path: worktree_path.to_path_buf(),
+                initial_prompt: run_config.initial_prompt.clone(),
+                config: core_run_config,
+            }),
+            VersionedEventPayload::new(EventPayload::PipelineMaterialized {
+                graph: Box::new(graph.clone()),
+                graph_hash,
+            }),
+        ])
+    }
+
+    async fn collect_startup_artifact_events(
+        &self,
+        artifact_store: &surge_persistence::artifacts::ArtifactStore,
+        run_id: RunId,
+        worktree_path: &Path,
+        run_config: &EngineRunConfig,
+    ) -> Result<Vec<VersionedEventPayload>, EngineError> {
+        let mut events = Vec::new();
+        if let Some(parent_run_id) = run_config.bootstrap_parent {
+            events.extend(
+                self.bootstrap_parent_artifact_events(artifact_store, run_id, parent_run_id)
+                    .await?,
+            );
+        }
+        if let Some(event) =
+            project_context_artifact_event(artifact_store, run_id, run_config).await?
+        {
+            events.push(event);
+        }
+        events.extend(run_seed_artifact_events(run_id, worktree_path, run_config).await?);
+        if let Some(event) =
+            initial_prompt_artifact_event(run_id, worktree_path, run_config).await?
+        {
+            events.push(event);
+        }
+        Ok(events)
     }
 
     async fn bootstrap_parent_artifact_events(
@@ -772,6 +724,120 @@ impl Engine {
 #[allow(dead_code)]
 fn _engine_config_used(e: &Engine) {
     let _ = &e.config;
+}
+
+async fn project_context_artifact_event(
+    artifact_store: &surge_persistence::artifacts::ArtifactStore,
+    run_id: RunId,
+    run_config: &EngineRunConfig,
+) -> Result<Option<VersionedEventPayload>, EngineError> {
+    let Some(seed) = &run_config.project_context else {
+        return Ok(None);
+    };
+    let project_context_artifact = artifact_store
+        .put(
+            run_id,
+            PROJECT_CONTEXT_ARTIFACT_NAME,
+            seed.content.as_bytes(),
+        )
+        .await
+        .map_err(|e| EngineError::Storage(e.to_string()))?;
+    let producer = surge_core::keys::NodeKey::try_from(PROJECT_CONTEXT_PRODUCER_NODE)
+        .map_err(|e| EngineError::Internal(format!("project context producer key: {e}")))?;
+    tracing::debug!(
+        target: "engine::startup",
+        run_id = %run_id,
+        path = %seed.path.display(),
+        bytes = seed.content.len(),
+        hash = %project_context_artifact.hash,
+        "seeded project_context artifact"
+    );
+    tracing::info!(
+        target: "engine::startup",
+        run_id = %run_id,
+        path = %seed.path.display(),
+        hash = %project_context_artifact.hash,
+        "project context captured for run"
+    );
+    Ok(Some(artifact_produced_event(
+        producer,
+        project_context_artifact.hash,
+        project_context_artifact.path,
+        PROJECT_CONTEXT_ARTIFACT_NAME,
+    )))
+}
+
+async fn run_seed_artifact_events(
+    run_id: RunId,
+    worktree_path: &Path,
+    run_config: &EngineRunConfig,
+) -> Result<Vec<VersionedEventPayload>, EngineError> {
+    let mut events = Vec::with_capacity(run_config.seed_artifacts.len());
+    for seed in &run_config.seed_artifacts {
+        let seeded_artifact = synthesise_run_seed_artifact(worktree_path, seed)
+            .await
+            .map_err(|e| {
+                EngineError::Internal(format!("seed artifact {} synthesis failed: {e}", seed.name))
+            })?;
+        tracing::debug!(
+            target: "engine::startup",
+            run_id = %run_id,
+            name = seed.name.as_str(),
+            path = %seed.relative_path.display(),
+            bytes = seed.content.len(),
+            hash = %seeded_artifact.hash,
+            "seeded run artifact"
+        );
+        events.push(artifact_produced_event(
+            seeded_artifact.producer,
+            seeded_artifact.hash,
+            seeded_artifact.relative_path,
+            &seed.name,
+        ));
+    }
+    Ok(events)
+}
+
+async fn initial_prompt_artifact_event(
+    run_id: RunId,
+    worktree_path: &Path,
+    run_config: &EngineRunConfig,
+) -> Result<Option<VersionedEventPayload>, EngineError> {
+    if run_config.initial_prompt.is_empty() {
+        return Ok(None);
+    }
+    let prompt_artifact =
+        synthesise_initial_prompt_artifact(worktree_path, run_config.initial_prompt.as_bytes())
+            .await
+            .map_err(|e| {
+                EngineError::Internal(format!("initial-prompt artifact synthesis failed: {e}"))
+            })?;
+    tracing::debug!(
+        target: "engine::startup",
+        run_id = %run_id,
+        prompt_len = run_config.initial_prompt.len(),
+        "seeded user_prompt artifact",
+    );
+    Ok(Some(artifact_produced_event(
+        prompt_artifact.producer,
+        prompt_artifact.hash,
+        prompt_artifact.relative_path,
+        INITIAL_PROMPT_ARTIFACT_NAME,
+    )))
+}
+
+fn artifact_produced_event(
+    node: surge_core::keys::NodeKey,
+    artifact: surge_core::content_hash::ContentHash,
+    path: PathBuf,
+    name: &str,
+) -> VersionedEventPayload {
+    VersionedEventPayload::new(EventPayload::ArtifactProduced {
+        node,
+        artifact,
+        path,
+        name: name.to_owned(),
+    })
 }
 
 /// Canonical artifact name under which the run's free-form initial prompt is

--- a/crates/surge-orchestrator/src/engine/engine.rs
+++ b/crates/surge-orchestrator/src/engine/engine.rs
@@ -7,12 +7,14 @@ use crate::engine::error::EngineError;
 use crate::engine::handle::RunHandle;
 use crate::engine::tools::ToolDispatcher;
 use crate::profile_loader::ProfileRegistry;
+use crate::roadmap_amendment::ActiveRunAmendmentOutcome;
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
 use surge_acp::bridge::facade::BridgeFacade;
 use surge_core::graph::Graph;
 use surge_core::id::RunId;
+use surge_core::roadmap_patch::{RoadmapPatchApplyResult, RoadmapPatchId, RoadmapPatchTarget};
 use surge_core::run_event::{EventPayload, VersionedEventPayload};
 
 /// Central orchestration engine. Drives one or more concurrent runs, each
@@ -47,6 +49,8 @@ pub(crate) struct ActiveRun {
     >,
     pub tool_resolutions:
         Arc<tokio::sync::Mutex<HashMap<String, tokio::sync::oneshot::Sender<serde_json::Value>>>>,
+    pub roadmap_amendments:
+        tokio::sync::mpsc::Sender<crate::engine::run_task::RoadmapAmendmentCommand>,
 }
 
 impl Engine {
@@ -264,6 +268,32 @@ impl Engine {
             }));
         }
 
+        for seed in &run_config.seed_artifacts {
+            let seeded_artifact = synthesise_run_seed_artifact(&worktree_path, seed)
+                .await
+                .map_err(|e| {
+                    EngineError::Internal(format!(
+                        "seed artifact {} synthesis failed: {e}",
+                        seed.name
+                    ))
+                })?;
+            tracing::debug!(
+                target: "engine::startup",
+                run_id = %run_id,
+                name = seed.name.as_str(),
+                path = %seed.relative_path.display(),
+                bytes = seed.content.len(),
+                hash = %seeded_artifact.hash,
+                "seeded run artifact"
+            );
+            events.push(VersionedEventPayload::new(EventPayload::ArtifactProduced {
+                node: seeded_artifact.producer,
+                artifact: seeded_artifact.hash,
+                path: seeded_artifact.relative_path,
+                name: seed.name.clone(),
+            }));
+        }
+
         // Surface the operator's free-form prompt as a first-class artifact so
         // bootstrap (or any) agent stage can pull it via the standard binding
         // path through `ArtifactSource::InitialPrompt` (and equivalently via
@@ -321,10 +351,12 @@ impl Engine {
             std::sync::Arc::new(tokio::sync::Mutex::new(std::collections::HashMap::new()));
         let tool_resolutions =
             std::sync::Arc::new(tokio::sync::Mutex::new(std::collections::HashMap::new()));
+        let (roadmap_amendment_tx, roadmap_amendment_rx) = tokio::sync::mpsc::channel(16);
         let active = ActiveRun {
             cancel: cancel.clone(),
             gate_resolutions: gate_resolutions.clone(),
             tool_resolutions: tool_resolutions.clone(),
+            roadmap_amendments: roadmap_amendment_tx,
         };
         self.runs.write().await.insert(run_id, active);
 
@@ -346,6 +378,7 @@ impl Engine {
             resume_root_traversal_counts: None,
             gate_resolutions,
             tool_resolutions,
+            roadmap_amendments: roadmap_amendment_rx,
             mcp_registry: per_run_mcp_registry,
             mcp_servers: mcp_servers_clone,
             profile_registry: self.config.profile_registry.clone(),
@@ -525,11 +558,13 @@ impl Engine {
             std::sync::Arc::new(tokio::sync::Mutex::new(std::collections::HashMap::new()));
         let tool_resolutions =
             std::sync::Arc::new(tokio::sync::Mutex::new(std::collections::HashMap::new()));
+        let (roadmap_amendment_tx, roadmap_amendment_rx) = tokio::sync::mpsc::channel(16);
 
         let active = ActiveRun {
             cancel: cancel.clone(),
             gate_resolutions: gate_resolutions.clone(),
             tool_resolutions: tool_resolutions.clone(),
+            roadmap_amendments: roadmap_amendment_tx,
         };
         self.runs.write().await.insert(run_id, active);
 
@@ -573,6 +608,7 @@ impl Engine {
             resume_root_traversal_counts: None,
             gate_resolutions,
             tool_resolutions,
+            roadmap_amendments: roadmap_amendment_rx,
             mcp_registry: per_run_mcp_registry,
             mcp_servers: mcp_servers_for_resume,
             profile_registry: self.config.profile_registry.clone(),
@@ -590,6 +626,47 @@ impl Engine {
             events: event_rx,
             completion: join,
         })
+    }
+
+    /// Submit an approved roadmap amendment to an active run.
+    pub async fn submit_roadmap_amendment(
+        &self,
+        run_id: RunId,
+        patch_id: RoadmapPatchId,
+        target: RoadmapPatchTarget,
+        patch_result: RoadmapPatchApplyResult,
+    ) -> Result<ActiveRunAmendmentOutcome, EngineError> {
+        if let RoadmapPatchTarget::RunRoadmap {
+            run_id: target_run_id,
+            ..
+        } = target
+            && target_run_id != run_id
+        {
+            return Err(EngineError::Internal(format!(
+                "roadmap amendment target run {target_run_id} does not match active run {run_id}"
+            )));
+        }
+
+        let sender = {
+            let runs = self.runs.read().await;
+            runs.get(&run_id)
+                .map(|active| active.roadmap_amendments.clone())
+                .ok_or(EngineError::RunNotFound(run_id))?
+        };
+        let (reply, result) = tokio::sync::oneshot::channel();
+        sender
+            .send(crate::engine::run_task::RoadmapAmendmentCommand {
+                patch_id,
+                target,
+                patch_result,
+                reply,
+            })
+            .await
+            .map_err(|_| EngineError::Internal("roadmap amendment receiver dropped".into()))?;
+        result
+            .await
+            .map_err(|_| EngineError::Internal("roadmap amendment reply dropped".into()))?
+            .map_err(|error| EngineError::Internal(format!("active roadmap amendment: {error}")))
     }
 
     /// Provide answer to a paused run waiting on human input.
@@ -753,5 +830,40 @@ pub(crate) async fn synthesise_initial_prompt_artifact(
         hash,
         relative_path,
         producer,
+    })
+}
+
+pub(crate) async fn synthesise_run_seed_artifact(
+    worktree_path: &std::path::Path,
+    seed: &crate::engine::config::RunSeedArtifact,
+) -> std::io::Result<InitialPromptArtifact> {
+    use std::path::Component;
+
+    if seed.relative_path.is_absolute()
+        || seed.relative_path.components().any(|component| {
+            matches!(
+                component,
+                Component::ParentDir | Component::Prefix(_) | Component::RootDir
+            )
+        })
+    {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!(
+                "seed artifact path must stay inside the worktree: {}",
+                seed.relative_path.display()
+            ),
+        ));
+    }
+
+    let absolute_path = worktree_path.join(&seed.relative_path);
+    if let Some(parent) = absolute_path.parent() {
+        tokio::fs::create_dir_all(parent).await?;
+    }
+    tokio::fs::write(&absolute_path, seed.content.as_bytes()).await?;
+    Ok(InitialPromptArtifact {
+        hash: seed.hash,
+        relative_path: seed.relative_path.clone(),
+        producer: seed.producer.clone(),
     })
 }

--- a/crates/surge-orchestrator/src/engine/error.rs
+++ b/crates/surge-orchestrator/src/engine/error.rs
@@ -39,6 +39,13 @@ pub enum EngineError {
     #[error("run not found: {0}")]
     RunNotFound(RunId),
 
+    /// The selected engine facade does not support the requested operation.
+    #[error("engine operation is not supported by this facade: {operation}")]
+    OperationNotSupported {
+        /// Stable operation name.
+        operation: &'static str,
+    },
+
     /// The daemon has no per-run channel registered for this `RunId`.
     /// Returned by daemon paths like `Subscribe`. This does NOT
     /// distinguish "the run terminated already" from "the run was

--- a/crates/surge-orchestrator/src/engine/facade.rs
+++ b/crates/surge-orchestrator/src/engine/facade.rs
@@ -49,8 +49,10 @@ pub trait EngineFacade: Send + Sync {
         target: RoadmapPatchTarget,
         patch_result: RoadmapPatchApplyResult,
     ) -> Result<ActiveRunAmendmentOutcome, EngineError> {
-        let _ = (patch_id, target, patch_result);
-        Err(EngineError::RunNotFound(run_id))
+        let _ = (run_id, patch_id, target, patch_result);
+        Err(EngineError::OperationNotSupported {
+            operation: "submit_roadmap_amendment",
+        })
     }
 
     /// Provide an answer to a paused run waiting on human input.

--- a/crates/surge-orchestrator/src/engine/facade.rs
+++ b/crates/surge-orchestrator/src/engine/facade.rs
@@ -7,11 +7,13 @@ use crate::engine::config::EngineRunConfig;
 use crate::engine::engine::Engine;
 use crate::engine::error::EngineError;
 use crate::engine::handle::{RunHandle, RunSummary};
+use crate::roadmap_amendment::ActiveRunAmendmentOutcome;
 use async_trait::async_trait;
 use std::path::PathBuf;
 use std::sync::Arc;
 use surge_core::graph::Graph;
 use surge_core::id::RunId;
+use surge_core::roadmap_patch::{RoadmapPatchApplyResult, RoadmapPatchId, RoadmapPatchTarget};
 
 /// Engine-facing surface used by CLI commands and tests. All futures
 /// are `Send`. Implementations: [`LocalEngineFacade`] (in-process,
@@ -37,6 +39,19 @@ pub trait EngineFacade: Send + Sync {
 
     /// Cancel an in-flight run.
     async fn stop_run(&self, run_id: RunId, reason: String) -> Result<(), EngineError>;
+
+    /// Submit an approved roadmap amendment to a live run. Implementations
+    /// must route this to the run task that owns the target run writer.
+    async fn submit_roadmap_amendment(
+        &self,
+        run_id: RunId,
+        patch_id: RoadmapPatchId,
+        target: RoadmapPatchTarget,
+        patch_result: RoadmapPatchApplyResult,
+    ) -> Result<ActiveRunAmendmentOutcome, EngineError> {
+        let _ = (patch_id, target, patch_result);
+        Err(EngineError::RunNotFound(run_id))
+    }
 
     /// Provide an answer to a paused run waiting on human input.
     async fn resolve_human_input(
@@ -90,6 +105,18 @@ impl EngineFacade for LocalEngineFacade {
 
     async fn stop_run(&self, run_id: RunId, reason: String) -> Result<(), EngineError> {
         self.engine.stop_run(run_id, reason).await
+    }
+
+    async fn submit_roadmap_amendment(
+        &self,
+        run_id: RunId,
+        patch_id: RoadmapPatchId,
+        target: RoadmapPatchTarget,
+        patch_result: RoadmapPatchApplyResult,
+    ) -> Result<ActiveRunAmendmentOutcome, EngineError> {
+        self.engine
+            .submit_roadmap_amendment(run_id, patch_id, target, patch_result)
+            .await
     }
 
     async fn resolve_human_input(

--- a/crates/surge-orchestrator/src/engine/handle.rs
+++ b/crates/surge-orchestrator/src/engine/handle.rs
@@ -42,7 +42,7 @@ pub enum EngineRunEvent {
         /// Monotonically-increasing sequence number assigned to this event.
         seq: u64,
         /// The persisted event payload.
-        payload: EventPayload,
+        payload: Box<EventPayload>,
     },
     /// The run reached a terminal state.
     ///

--- a/crates/surge-orchestrator/src/engine/ipc.rs
+++ b/crates/surge-orchestrator/src/engine/ipc.rs
@@ -5,10 +5,12 @@
 
 use crate::engine::config::EngineRunConfig;
 use crate::engine::handle::{EngineRunEvent, RunOutcome, RunSummary};
+use crate::roadmap_amendment::ActiveRunAmendmentOutcome;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 use surge_core::graph::Graph;
 use surge_core::id::RunId;
+use surge_core::roadmap_patch::{RoadmapPatchApplyResult, RoadmapPatchId, RoadmapPatchTarget};
 
 /// Monotonically-increasing client-side request identifier. Echoed
 /// in the matching [`DaemonResponse`] so the client can multiplex
@@ -76,7 +78,7 @@ pub enum DaemonRequest {
         /// Path to the isolated git worktree the engine will operate in.
         worktree_path: PathBuf,
         /// Per-run engine configuration knobs.
-        run_config: EngineRunConfig,
+        run_config: Box<EngineRunConfig>,
     },
     /// Resume an existing run from its latest snapshot.
     ResumeRun {
@@ -95,6 +97,19 @@ pub enum DaemonRequest {
         run_id: RunId,
         /// Human-readable reason for the cancellation.
         reason: String,
+    },
+    /// Submit an approved roadmap amendment to a live run.
+    SubmitRoadmapAmendment {
+        /// Client-assigned identifier echoed in the response.
+        request_id: RequestId,
+        /// Identifier of the run that should accept the amendment.
+        run_id: RunId,
+        /// Patch that caused the amendment.
+        patch_id: RoadmapPatchId,
+        /// Target being amended.
+        target: RoadmapPatchTarget,
+        /// Validated roadmap patch application result.
+        patch_result: Box<RoadmapPatchApplyResult>,
     },
     /// Provide an answer to a paused run waiting on human input.
     ResolveHumanInput {
@@ -159,6 +174,7 @@ impl DaemonRequest {
             | Self::StartRun { request_id, .. }
             | Self::ResumeRun { request_id, .. }
             | Self::StopRun { request_id, .. }
+            | Self::SubmitRoadmapAmendment { request_id, .. }
             | Self::ResolveHumanInput { request_id, .. }
             | Self::ListRuns { request_id }
             | Self::Subscribe { request_id, .. }
@@ -208,6 +224,13 @@ pub enum DaemonResponse {
     StopRunOk {
         /// Echoed `request_id` from the originating [`DaemonRequest::StopRun`].
         request_id: RequestId,
+    },
+    /// [`DaemonRequest::SubmitRoadmapAmendment`] accepted by the active run.
+    SubmitRoadmapAmendmentOk {
+        /// Echoed `request_id` from the originating request.
+        request_id: RequestId,
+        /// Durable amendment outcome reported by the engine task.
+        outcome: Box<ActiveRunAmendmentOutcome>,
     },
     /// [`DaemonRequest::ResolveHumanInput`] accepted; the run will resume.
     ResolveHumanInputOk {
@@ -268,6 +291,7 @@ impl DaemonResponse {
             | Self::StartRunQueued { request_id, .. }
             | Self::ResumeRunOk { request_id }
             | Self::StopRunOk { request_id }
+            | Self::SubmitRoadmapAmendmentOk { request_id, .. }
             | Self::ResolveHumanInputOk { request_id }
             | Self::ListRunsOk { request_id, .. }
             | Self::SubscribeOk { request_id }
@@ -291,7 +315,7 @@ pub enum DaemonEvent {
         /// Identifier of the run this event belongs to.
         run_id: RunId,
         /// The engine event payload.
-        event: EngineRunEvent,
+        event: Box<EngineRunEvent>,
     },
     /// Daemon-level event delivered to all connected clients.
     Global(GlobalDaemonEvent),
@@ -487,7 +511,7 @@ pub enum InboundServerFrame {
     /// A response to an earlier client request, identified by `request_id`.
     Response(DaemonResponse),
     /// A daemon-pushed notification (no `request_id`).
-    Event(DaemonEvent),
+    Event(Box<DaemonEvent>),
 }
 
 /// Read one server-bound frame and discriminate. Tries
@@ -508,7 +532,7 @@ where
                 return Ok(Some(InboundServerFrame::Response(r)));
             }
             let ev: DaemonEvent = serde_json::from_slice(trimmed)?;
-            Ok(Some(InboundServerFrame::Event(ev)))
+            Ok(Some(InboundServerFrame::Event(Box::new(ev))))
         },
     }
 }

--- a/crates/surge-orchestrator/src/engine/replay.rs
+++ b/crates/surge-orchestrator/src/engine/replay.rs
@@ -16,6 +16,9 @@ pub struct ReplayedState {
     /// Latest graph extracted from `PipelineMaterialized` plus any accepted
     /// graph revision events.
     pub graph: surge_core::graph::Graph,
+    /// Latest graph revision sequence known to have been applied to the
+    /// active graph at a persisted stage boundary.
+    pub applied_graph_revision_seq: u64,
     /// Set when the event log already contains a terminal event
     /// (`RunCompleted`, `RunFailed`, or `RunAborted`). When `Some`, the
     /// caller should return this outcome immediately without re-executing.
@@ -35,16 +38,23 @@ pub struct ReplayedState {
 pub async fn replay(
     reader: &surge_persistence::runs::reader::RunReader,
 ) -> Result<ReplayedState, EngineError> {
-    // Load latest snapshot (if any).
-    let snap = reader
-        .latest_snapshot_at_or_before(EventSeq(u64::MAX))
+    let max_seq = reader
+        .current_seq()
         .await
         .map_err(|e| EngineError::Storage(e.to_string()))?;
 
+    // Load latest snapshot (if any).
+    let snap = reader
+        .latest_snapshot_at_or_before(max_seq)
+        .await
+        .map_err(|e| EngineError::Storage(e.to_string()))?;
+
+    let mut applied_graph_revision_seq = 0;
     let snap_cursor: Option<Cursor> = match snap {
         Some((_seq, blob)) => {
             let snapshot = EngineSnapshot::deserialize(&blob)
                 .map_err(|e| EngineError::Internal(format!("snapshot deserialize: {e}")))?;
+            applied_graph_revision_seq = snapshot.applied_graph_revision_seq;
             let cursor = snapshot
                 .cursor
                 .into_cursor()
@@ -56,18 +66,13 @@ pub async fn replay(
 
     // Read all events from seq 1 onwards. We need ALL events for memory
     // reconstruction (artifacts, outcomes, costs).
-    let max_seq = reader
-        .current_seq()
-        .await
-        .map_err(|e| EngineError::Storage(e.to_string()))?;
-
     let all_events = reader
         .read_events(EventSeq(1)..EventSeq(max_seq.as_u64().saturating_add(1)))
         .await
         .map_err(|e| EngineError::Storage(e.to_string()))?;
 
     // Find the latest graph from PipelineMaterialized plus graph revisions.
-    let graph = latest_graph_from_events(&all_events)?;
+    let graph = latest_graph_from_events(&all_events, applied_graph_revision_seq)?;
 
     // Extract the persisted RunConfig from RunStarted (if any).
     let persisted_run_config = all_events.iter().find_map(|e| match &e.payload.payload {
@@ -116,6 +121,7 @@ pub async fn replay(
         cursor,
         memory,
         graph,
+        applied_graph_revision_seq,
         already_terminal,
         run_config: persisted_run_config,
     })
@@ -123,6 +129,7 @@ pub async fn replay(
 
 fn latest_graph_from_events(
     events: &[surge_persistence::runs::reader::ReadEvent],
+    applied_graph_revision_seq: u64,
 ) -> Result<surge_core::graph::Graph, EngineError> {
     let mut selected = None;
     for event in events {
@@ -138,7 +145,7 @@ fn latest_graph_from_events(
             },
             EventPayload::GraphRevisionAccepted {
                 graph, graph_hash, ..
-            } => {
+            } if event.seq.as_u64() <= applied_graph_revision_seq => {
                 tracing::debug!(
                     target: "engine_replay",
                     seq = event.seq.as_u64(),
@@ -150,9 +157,12 @@ fn latest_graph_from_events(
             _ => {},
         }
     }
-    selected
-        .map(|(_, graph)| graph)
-        .ok_or_else(|| EngineError::Internal("no PipelineMaterialized event in log".into()))
+    selected.map(|(_, graph)| graph).ok_or_else(|| {
+        EngineError::Internal(
+            "no graph-bearing event (PipelineMaterialized or applied GraphRevisionAccepted) in log"
+                .into(),
+        )
+    })
 }
 
 #[cfg(test)]
@@ -173,7 +183,6 @@ mod tests {
     use surge_core::sandbox::SandboxMode;
     use surge_core::terminal_config::{TerminalConfig, TerminalKind};
     use surge_persistence::runs::Storage;
-    use surge_persistence::runs::seq::EventSeq;
 
     fn minimal_graph() -> Graph {
         minimal_graph_with_start("end")
@@ -363,7 +372,7 @@ mod tests {
             mcp_servers: vec![],
         };
 
-        writer
+        let seqs = writer
             .append_events(vec![
                 VersionedEventPayload::new(EventPayload::RunStarted {
                     pipeline_template: None,
@@ -388,16 +397,33 @@ mod tests {
             ])
             .await
             .expect("append_events");
+        let graph_revision_seq = seqs[2];
 
         let snapshot_cursor = Cursor {
             node: NodeKey::try_from("amend_001").unwrap(),
             attempt: 1,
         };
-        let snapshot = EngineSnapshot::new(&snapshot_cursor, 3, 3);
+        let mut snapshot = EngineSnapshot::new(
+            &snapshot_cursor,
+            graph_revision_seq.as_u64(),
+            graph_revision_seq.as_u64(),
+        );
+        snapshot.applied_graph_revision_seq = graph_revision_seq.as_u64();
         writer
-            .write_graph_snapshot(EventSeq(3), serde_json::to_vec(&snapshot).unwrap())
+            .write_graph_snapshot(graph_revision_seq, serde_json::to_vec(&snapshot).unwrap())
             .await
             .expect("write snapshot");
+        let (_, snapshot_blob) = writer
+            .latest_snapshot_at_or_before(graph_revision_seq)
+            .await
+            .expect("read snapshot")
+            .expect("snapshot row");
+        let stored_snapshot =
+            EngineSnapshot::deserialize(&snapshot_blob).expect("deserialize stored snapshot");
+        assert_eq!(
+            stored_snapshot.applied_graph_revision_seq,
+            graph_revision_seq.as_u64()
+        );
 
         let reader = storage
             .open_run_reader(run_id)

--- a/crates/surge-orchestrator/src/engine/replay.rs
+++ b/crates/surge-orchestrator/src/engine/replay.rs
@@ -13,7 +13,8 @@ pub struct ReplayedState {
     pub cursor: Cursor,
     /// Run memory rebuilt by replaying all events from seq 1 onwards.
     pub memory: RunMemory,
-    /// Graph extracted from the `PipelineMaterialized` event.
+    /// Latest graph extracted from `PipelineMaterialized` plus any accepted
+    /// graph revision events.
     pub graph: surge_core::graph::Graph,
     /// Set when the event log already contains a terminal event
     /// (`RunCompleted`, `RunFailed`, or `RunAborted`). When `Some`, the
@@ -29,7 +30,7 @@ pub struct ReplayedState {
 ///
 /// Steps:
 /// 1. Load the latest snapshot (if any) to obtain a base cursor.
-/// 2. Read all events from seq 1 onwards to rebuild memory and find the graph.
+/// 2. Read all events from seq 1 onwards to rebuild memory and find the latest graph.
 /// 3. Return the graph, memory, and cursor (snapshot's cursor or graph.start).
 pub async fn replay(
     reader: &surge_persistence::runs::reader::RunReader,
@@ -65,14 +66,8 @@ pub async fn replay(
         .await
         .map_err(|e| EngineError::Storage(e.to_string()))?;
 
-    // Find the graph from PipelineMaterialized.
-    let graph = all_events
-        .iter()
-        .find_map(|e| match &e.payload.payload {
-            EventPayload::PipelineMaterialized { graph, .. } => Some((**graph).clone()),
-            _ => None,
-        })
-        .ok_or_else(|| EngineError::Internal("no PipelineMaterialized event in log".into()))?;
+    // Find the latest graph from PipelineMaterialized plus graph revisions.
+    let graph = latest_graph_from_events(&all_events)?;
 
     // Extract the persisted RunConfig from RunStarted (if any).
     let persisted_run_config = all_events.iter().find_map(|e| match &e.payload.payload {
@@ -126,6 +121,40 @@ pub async fn replay(
     })
 }
 
+fn latest_graph_from_events(
+    events: &[surge_persistence::runs::reader::ReadEvent],
+) -> Result<surge_core::graph::Graph, EngineError> {
+    let mut selected = None;
+    for event in events {
+        match &event.payload.payload {
+            EventPayload::PipelineMaterialized { graph, graph_hash } => {
+                tracing::debug!(
+                    target: "engine_replay",
+                    seq = event.seq.as_u64(),
+                    graph_hash = %graph_hash,
+                    "replay_pipeline_graph_selected"
+                );
+                selected = Some((event.seq.as_u64(), (**graph).clone()));
+            },
+            EventPayload::GraphRevisionAccepted {
+                graph, graph_hash, ..
+            } => {
+                tracing::debug!(
+                    target: "engine_replay",
+                    seq = event.seq.as_u64(),
+                    graph_hash = %graph_hash,
+                    "replay_graph_revision_selected"
+                );
+                selected = Some((event.seq.as_u64(), (**graph).clone()));
+            },
+            _ => {},
+        }
+    }
+    selected
+        .map(|(_, graph)| graph)
+        .ok_or_else(|| EngineError::Internal("no PipelineMaterialized event in log".into()))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -139,13 +168,19 @@ mod tests {
     use surge_core::keys::NodeKey;
     use surge_core::mcp_config::{McpServerRef, McpTransportConfig};
     use surge_core::node::{Node, NodeConfig, Position};
+    use surge_core::roadmap_patch::{ActivePickupPolicy, RoadmapPatchId, RoadmapPatchTarget};
     use surge_core::run_event::{EventPayload, RunConfig, VersionedEventPayload};
     use surge_core::sandbox::SandboxMode;
     use surge_core::terminal_config::{TerminalConfig, TerminalKind};
     use surge_persistence::runs::Storage;
+    use surge_persistence::runs::seq::EventSeq;
 
     fn minimal_graph() -> Graph {
-        let end = NodeKey::try_from("end").unwrap();
+        minimal_graph_with_start("end")
+    }
+
+    fn minimal_graph_with_start(start: &str) -> Graph {
+        let end = NodeKey::try_from(start).unwrap();
         let mut nodes = BTreeMap::new();
         nodes.insert(
             end.clone(),
@@ -303,5 +338,80 @@ mod tests {
             rc.mcp_servers.is_empty(),
             "expected empty mcp_servers for run without MCP"
         );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn replay_uses_latest_graph_revision_with_snapshot_cursor() {
+        let dir = tempfile::tempdir().unwrap();
+        let storage = Storage::open(dir.path()).await.unwrap();
+        let run_id = RunId::new();
+        let worktree = dir.path().to_path_buf();
+
+        let writer = storage
+            .create_run(run_id, &worktree, None)
+            .await
+            .expect("create_run");
+
+        let base_graph = minimal_graph();
+        let amended_graph = minimal_graph_with_start("amend_001");
+        let previous_graph_hash = ContentHash::compute(b"base-flow");
+        let graph_hash = ContentHash::compute(b"amended-flow");
+        let run_config = RunConfig {
+            sandbox_default: SandboxMode::WorkspaceWrite,
+            approval_default: ApprovalPolicy::OnRequest,
+            auto_pr: false,
+            mcp_servers: vec![],
+        };
+
+        writer
+            .append_events(vec![
+                VersionedEventPayload::new(EventPayload::RunStarted {
+                    pipeline_template: None,
+                    project_path: worktree.clone(),
+                    initial_prompt: String::new(),
+                    config: run_config,
+                }),
+                VersionedEventPayload::new(EventPayload::PipelineMaterialized {
+                    graph: Box::new(base_graph),
+                    graph_hash: previous_graph_hash,
+                }),
+                VersionedEventPayload::new(EventPayload::GraphRevisionAccepted {
+                    patch_id: RoadmapPatchId::new("rpatch-replay").unwrap(),
+                    target: RoadmapPatchTarget::ProjectRoadmap {
+                        roadmap_path: ".ai-factory/ROADMAP.md".into(),
+                    },
+                    previous_graph_hash,
+                    graph: Box::new(amended_graph),
+                    graph_hash,
+                    active_pickup: ActivePickupPolicy::Allowed,
+                }),
+            ])
+            .await
+            .expect("append_events");
+
+        let snapshot_cursor = Cursor {
+            node: NodeKey::try_from("amend_001").unwrap(),
+            attempt: 1,
+        };
+        let snapshot = EngineSnapshot::new(&snapshot_cursor, 3, 3);
+        writer
+            .write_graph_snapshot(EventSeq(3), serde_json::to_vec(&snapshot).unwrap())
+            .await
+            .expect("write snapshot");
+
+        let reader = storage
+            .open_run_reader(run_id)
+            .await
+            .expect("open_run_reader");
+        let replayed = replay(&reader).await.expect("replay");
+
+        assert_eq!(replayed.graph.start, snapshot_cursor.node);
+        assert_eq!(replayed.cursor, snapshot_cursor);
+        let revision = replayed
+            .memory
+            .latest_graph_revision
+            .expect("graph revision memory");
+        assert_eq!(revision.graph_hash, graph_hash);
+        assert_eq!(revision.previous_graph_hash, previous_graph_hash);
     }
 }

--- a/crates/surge-orchestrator/src/engine/run_task.rs
+++ b/crates/surge-orchestrator/src/engine/run_task.rs
@@ -13,20 +13,32 @@ use crate::engine::stage::terminal::{
     TerminalOutcome, TerminalStageParams, execute_terminal_stage,
 };
 use crate::engine::tools::ToolDispatcher;
+use crate::roadmap_amendment::{ActiveRunAmendmentOutcome, apply_active_run_patch};
 use std::path::PathBuf;
 use std::sync::Arc;
 use surge_acp::bridge::facade::BridgeFacade;
+use surge_core::content_hash::ContentHash;
 use surge_core::graph::Graph;
 use surge_core::hooks::HookTrigger;
 use surge_core::id::RunId;
 use surge_core::keys::OutcomeKey;
 use surge_core::node::NodeConfig;
+use surge_core::roadmap_patch::{
+    ActivePickupPolicy, RoadmapPatchApplyResult, RoadmapPatchId, RoadmapPatchTarget,
+};
 use surge_core::run_event::{EventPayload, RunEvent, VersionedEventPayload};
 use surge_core::run_state::{Cursor, RunMemory};
 use surge_notify::NotifyDeliverer;
 use surge_persistence::runs::run_writer::RunWriter;
-use tokio::sync::broadcast;
+use tokio::sync::{broadcast, mpsc, oneshot};
 use tokio_util::sync::CancellationToken;
+
+pub(crate) struct RoadmapAmendmentCommand {
+    pub patch_id: RoadmapPatchId,
+    pub target: RoadmapPatchTarget,
+    pub patch_result: RoadmapPatchApplyResult,
+    pub reply: oneshot::Sender<Result<ActiveRunAmendmentOutcome, String>>,
+}
 
 pub(crate) struct RunTaskParams {
     pub run_id: RunId,
@@ -67,6 +79,10 @@ pub(crate) struct RunTaskParams {
             std::collections::HashMap<String, tokio::sync::oneshot::Sender<serde_json::Value>>,
         >,
     >,
+    /// Approved roadmap amendments submitted to the active run. The run task
+    /// owns the writer, so amendments enter through this queue and are appended
+    /// at safe graph boundaries.
+    pub roadmap_amendments: mpsc::Receiver<RoadmapAmendmentCommand>,
     /// Optional MCP registry. When `Some`, agent stages wrap the
     /// engine dispatcher with `RoutingToolDispatcher` to expose
     /// configured MCP tools alongside engine built-ins.
@@ -85,9 +101,10 @@ pub(crate) struct RunTaskParams {
 }
 
 #[allow(clippy::too_many_lines)]
-pub(crate) async fn execute(params: RunTaskParams) -> RunOutcome {
+pub(crate) async fn execute(mut params: RunTaskParams) -> RunOutcome {
+    let mut active_graph = params.graph.clone();
     let mut cursor = params.resume_cursor.clone().unwrap_or_else(|| Cursor {
-        node: params.graph.start.clone(),
+        node: active_graph.start.clone(),
         attempt: 1,
     });
     // One executor per run task: stateless aside from its spawner, so a
@@ -107,8 +124,41 @@ pub(crate) async fn execute(params: RunTaskParams) -> RunOutcome {
             .resume_root_traversal_counts
             .clone()
             .unwrap_or_default();
+    let mut applied_graph_revision_seq = memory
+        .latest_graph_revision
+        .as_ref()
+        .map_or(0, |revision| revision.updated_seq);
+    let mut pending_graph_revisions = Vec::new();
 
     loop {
+        if frames.is_empty() {
+            let mut roadmap_queue = RoadmapAmendmentQueue {
+                writer: &params.writer,
+                artifact_store: &params.artifact_store,
+                run_id: params.run_id,
+                receiver: &mut params.roadmap_amendments,
+            };
+            if let Err(error) = roadmap_queue
+                .drain(
+                    &mut active_graph,
+                    &cursor,
+                    &mut memory,
+                    &mut pending_graph_revisions,
+                    &mut applied_graph_revision_seq,
+                )
+                .await
+            {
+                return failed(&params, format!("apply queued roadmap amendments: {error}")).await;
+            }
+        }
+        maybe_apply_pending_graph_revision(
+            &mut active_graph,
+            &cursor,
+            &frames,
+            &mut pending_graph_revisions,
+            &mut applied_graph_revision_seq,
+        );
+
         if params.cancel.is_cancelled() {
             let reason = "stop_run requested".to_string();
             let _ = params
@@ -124,7 +174,7 @@ pub(crate) async fn execute(params: RunTaskParams) -> RunOutcome {
             return outcome;
         }
 
-        let node = if let Some(n) = lookup_in_active_frame(&params.graph, &cursor.node, &frames) {
+        let node = if let Some(n) = lookup_in_active_frame(&active_graph, &cursor.node, &frames) {
             n.clone()
         } else {
             let err = format!("cursor at unknown node {}", cursor.node);
@@ -276,7 +326,7 @@ pub(crate) async fn execute(params: RunTaskParams) -> RunOutcome {
 
                         if let Err(e) = crate::engine::stage::loop_stage::on_loop_iteration_done(
                             &just_completed,
-                            &params.graph,
+                            &active_graph,
                             &mut frames,
                             &mut cursor,
                             &params.writer,
@@ -292,7 +342,7 @@ pub(crate) async fn execute(params: RunTaskParams) -> RunOutcome {
                         // outer node referenced by the top frame.
                         let outputs = match frames.last() {
                             Some(crate::engine::frames::Frame::Subgraph(sf)) => {
-                                match params.graph.nodes.get(&sf.outer_node).map(|n| &n.config) {
+                                match active_graph.nodes.get(&sf.outer_node).map(|n| &n.config) {
                                     Some(surge_core::node::NodeConfig::Subgraph(cfg)) => {
                                         cfg.outputs.clone()
                                     },
@@ -360,7 +410,7 @@ pub(crate) async fn execute(params: RunTaskParams) -> RunOutcome {
                 };
                 let return_to =
                     match crate::engine::routing::edge_target_after_outcome_in_active_graph(
-                        &params.graph,
+                        &active_graph,
                         &cursor.node,
                         &completed_outcome,
                         &frames,
@@ -373,7 +423,7 @@ pub(crate) async fn execute(params: RunTaskParams) -> RunOutcome {
                     crate::engine::stage::loop_stage::LoopStageParams {
                         node: &cursor.node,
                         loop_config: cfg,
-                        graph: &params.graph,
+                        graph: &active_graph,
                         run_memory: &memory,
                         writer: &params.writer,
                         frames: &mut frames,
@@ -404,7 +454,7 @@ pub(crate) async fn execute(params: RunTaskParams) -> RunOutcome {
                 };
                 let return_to =
                     match crate::engine::routing::edge_target_after_outcome_in_active_graph(
-                        &params.graph,
+                        &active_graph,
                         &cursor.node,
                         &completed_outcome,
                         &frames,
@@ -417,7 +467,7 @@ pub(crate) async fn execute(params: RunTaskParams) -> RunOutcome {
                     crate::engine::stage::subgraph_stage::SubgraphStageParams {
                         node: &cursor.node,
                         subgraph_config: cfg,
-                        graph: &params.graph,
+                        graph: &active_graph,
                         run_memory: &memory,
                         writer: &params.writer,
                         frames: &mut frames,
@@ -524,12 +574,27 @@ pub(crate) async fn execute(params: RunTaskParams) -> RunOutcome {
             },
         };
 
-        if let Err(e) =
-            apply_memory_events_after(&params.writer, params.run_id, stage_start_seq, &mut memory)
-                .await
+        let applied_events = match apply_memory_events_after(
+            &params.writer,
+            params.run_id,
+            stage_start_seq,
+            &mut memory,
+        )
+        .await
         {
-            return failed(&params, format!("update run memory from event log: {e}")).await;
-        }
+            Ok(events) => events,
+            Err(e) => {
+                return failed(&params, format!("update run memory from event log: {e}")).await;
+            },
+        };
+        pending_graph_revisions.extend(applied_events.graph_revisions);
+        maybe_apply_pending_graph_revision(
+            &mut active_graph,
+            &cursor,
+            &frames,
+            &mut pending_graph_revisions,
+            &mut applied_graph_revision_seq,
+        );
         let stage_events_applied_seq = match params.writer.current_seq().await {
             Ok(seq) => seq,
             Err(e) => {
@@ -539,7 +604,7 @@ pub(crate) async fn execute(params: RunTaskParams) -> RunOutcome {
 
         // Route to next node.
         let routed = match crate::engine::routing::next_node_after_with_counters(
-            &params.graph,
+            &active_graph,
             &cursor.node,
             &outcome,
             &mut frames,
@@ -566,7 +631,7 @@ pub(crate) async fn execute(params: RunTaskParams) -> RunOutcome {
                                 },
                             };
                         match crate::engine::routing::next_node_after_with_counters(
-                            &params.graph,
+                            &active_graph,
                             &cursor.node,
                             &synthetic,
                             &mut frames,
@@ -624,7 +689,7 @@ pub(crate) async fn execute(params: RunTaskParams) -> RunOutcome {
                 outcome: outcome.clone(),
             }))
             .await;
-        if let Err(e) = apply_memory_events_after(
+        let applied_events = match apply_memory_events_after(
             &params.writer,
             params.run_id,
             stage_events_applied_seq,
@@ -632,8 +697,12 @@ pub(crate) async fn execute(params: RunTaskParams) -> RunOutcome {
         )
         .await
         {
-            return failed(&params, format!("update run memory after routing: {e}")).await;
-        }
+            Ok(events) => events,
+            Err(e) => {
+                return failed(&params, format!("update run memory after routing: {e}")).await;
+            },
+        };
+        pending_graph_revisions.extend(applied_events.graph_revisions);
 
         // Snapshot at stage boundary (per spec §2.6, §12).
         let next_cursor = Cursor {
@@ -803,8 +872,24 @@ async fn load_existing_memory(
         .read_events(surge_persistence::runs::EventSeq(1)..current.next())
         .await?;
     let mut memory = RunMemory::default();
-    apply_read_events(run_id, &events, &mut memory);
+    let _ = apply_read_events(run_id, &events, &mut memory);
     Ok(memory)
+}
+
+#[derive(Debug, Clone, Default)]
+struct AppliedEventBatch {
+    graph_revisions: Vec<ObservedGraphRevision>,
+}
+
+#[derive(Debug, Clone)]
+struct ObservedGraphRevision {
+    seq: u64,
+    patch_id: RoadmapPatchId,
+    target: RoadmapPatchTarget,
+    previous_graph_hash: ContentHash,
+    graph: Graph,
+    graph_hash: ContentHash,
+    active_pickup: ActivePickupPolicy,
 }
 
 async fn apply_memory_events_after(
@@ -812,24 +897,102 @@ async fn apply_memory_events_after(
     run_id: RunId,
     after: surge_persistence::runs::EventSeq,
     memory: &mut RunMemory,
-) -> Result<(), surge_persistence::runs::StorageError> {
+) -> Result<AppliedEventBatch, surge_persistence::runs::StorageError> {
     let current = writer.current_seq().await?;
     if current <= after {
-        return Ok(());
+        return Ok(AppliedEventBatch::default());
     }
     let events = writer.read_events(after.next()..current.next()).await?;
-    apply_read_events(run_id, &events, memory);
-    Ok(())
+    Ok(apply_read_events(run_id, &events, memory))
+}
+
+struct RoadmapAmendmentQueue<'a> {
+    writer: &'a surge_persistence::runs::run_writer::RunWriter,
+    artifact_store: &'a surge_persistence::artifacts::ArtifactStore,
+    run_id: RunId,
+    receiver: &'a mut mpsc::Receiver<RoadmapAmendmentCommand>,
+}
+
+impl RoadmapAmendmentQueue<'_> {
+    async fn drain(
+        &mut self,
+        active_graph: &mut Graph,
+        cursor: &Cursor,
+        memory: &mut RunMemory,
+        pending_graph_revisions: &mut Vec<ObservedGraphRevision>,
+        applied_graph_revision_seq: &mut u64,
+    ) -> Result<(), surge_persistence::runs::StorageError> {
+        while let Ok(command) = self.receiver.try_recv() {
+            let after = self.writer.current_seq().await?;
+            match apply_active_run_patch(
+                self.artifact_store,
+                self.writer,
+                self.run_id,
+                active_graph,
+                &command.patch_id,
+                &command.target,
+                &command.patch_result,
+            )
+            .await
+            {
+                Ok(outcome) => {
+                    let applied_events =
+                        apply_memory_events_after(self.writer, self.run_id, after, memory).await?;
+                    pending_graph_revisions.extend(applied_events.graph_revisions);
+                    maybe_apply_pending_graph_revision(
+                        active_graph,
+                        cursor,
+                        &[],
+                        pending_graph_revisions,
+                        applied_graph_revision_seq,
+                    );
+                    let _ = command.reply.send(Ok(outcome));
+                },
+                Err(error) => {
+                    tracing::warn!(
+                        target: "engine::roadmap_update",
+                        run_id = %self.run_id,
+                        patch_id = %command.patch_id,
+                        error = %error,
+                        "active_run_roadmap_patch_failed"
+                    );
+                    let _ = command.reply.send(Err(error.to_string()));
+                },
+            }
+        }
+
+        Ok(())
+    }
 }
 
 fn apply_read_events(
     run_id: RunId,
     events: &[surge_persistence::runs::ReadEvent],
     memory: &mut RunMemory,
-) {
+) -> AppliedEventBatch {
+    let mut batch = AppliedEventBatch::default();
     for event in events {
         let timestamp = chrono::DateTime::<chrono::Utc>::from_timestamp_millis(event.timestamp_ms)
             .unwrap_or_else(chrono::Utc::now);
+        if let EventPayload::GraphRevisionAccepted {
+            patch_id,
+            target,
+            previous_graph_hash,
+            graph,
+            graph_hash,
+            active_pickup,
+        } = &event.payload.payload
+        {
+            batch.graph_revisions.push(ObservedGraphRevision {
+                seq: event.seq.as_u64(),
+                patch_id: patch_id.clone(),
+                target: target.clone(),
+                previous_graph_hash: *previous_graph_hash,
+                graph: graph.as_ref().clone(),
+                graph_hash: *graph_hash,
+                active_pickup: *active_pickup,
+            });
+        }
         memory.apply_event(&RunEvent {
             run_id,
             seq: event.seq.as_u64(),
@@ -837,6 +1000,83 @@ fn apply_read_events(
             payload: event.payload.payload.clone(),
         });
     }
+    batch
+}
+
+fn maybe_apply_pending_graph_revision(
+    active_graph: &mut Graph,
+    cursor: &Cursor,
+    frames: &[crate::engine::frames::Frame],
+    pending: &mut Vec<ObservedGraphRevision>,
+    applied_seq: &mut u64,
+) {
+    pending.retain(|revision| revision.seq > *applied_seq);
+    let Some(revision) = pending.last().cloned() else {
+        return;
+    };
+
+    match revision.active_pickup {
+        ActivePickupPolicy::Allowed => {},
+        ActivePickupPolicy::FollowUpOnly => {
+            tracing::info!(
+                target: "engine::roadmap_update",
+                patch_id = %revision.patch_id,
+                graph_hash = %revision.graph_hash,
+                "graph_revision_requires_follow_up_run"
+            );
+            *applied_seq = revision.seq;
+            pending.clear();
+            return;
+        },
+        ActivePickupPolicy::Disabled => {
+            tracing::warn!(
+                target: "engine::roadmap_update",
+                patch_id = %revision.patch_id,
+                graph_hash = %revision.graph_hash,
+                "graph_revision_pickup_disabled"
+            );
+            *applied_seq = revision.seq;
+            pending.clear();
+            return;
+        },
+    }
+
+    if !frames.is_empty() {
+        tracing::info!(
+            target: "engine::roadmap_update",
+            patch_id = %revision.patch_id,
+            graph_hash = %revision.graph_hash,
+            frame_depth = frames.len(),
+            "graph_revision_deferred_until_outer_boundary"
+        );
+        return;
+    }
+
+    if !revision.graph.nodes.contains_key(&cursor.node) {
+        tracing::warn!(
+            target: "engine::roadmap_update",
+            patch_id = %revision.patch_id,
+            graph_hash = %revision.graph_hash,
+            cursor = %cursor.node,
+            "graph_revision_cannot_preserve_cursor"
+        );
+        *applied_seq = revision.seq;
+        pending.clear();
+        return;
+    }
+
+    tracing::info!(
+        target: "engine::roadmap_update",
+        patch_id = %revision.patch_id,
+        target = ?revision.target,
+        previous_graph_hash = %revision.previous_graph_hash,
+        graph_hash = %revision.graph_hash,
+        cursor = %cursor.node,
+        "graph_revision_picked_up"
+    );
+    *active_graph = revision.graph;
+    *applied_seq = revision.seq;
+    pending.clear();
 }
 
 async fn failed(params: &RunTaskParams, error: String) -> RunOutcome {
@@ -908,6 +1148,148 @@ mod tests {
             timeout_seconds: Some(5),
             inherit: HookInheritance::Extend,
         }
+    }
+
+    fn terminal_graph(name: &str, start: &str) -> Graph {
+        use surge_core::graph::{GraphMetadata, SCHEMA_VERSION};
+        use surge_core::terminal_config::{TerminalConfig, TerminalKind};
+
+        let start = surge_core::keys::NodeKey::try_from(start).unwrap();
+        let mut nodes = std::collections::BTreeMap::new();
+        nodes.insert(
+            start.clone(),
+            Node {
+                id: start.clone(),
+                position: Position::default(),
+                declared_outcomes: vec![],
+                config: NodeConfig::Terminal(TerminalConfig {
+                    kind: TerminalKind::Success,
+                    message: None,
+                }),
+            },
+        );
+        Graph {
+            schema_version: SCHEMA_VERSION,
+            metadata: GraphMetadata::new(name, chrono::Utc::now()),
+            start,
+            nodes,
+            edges: vec![],
+            subgraphs: std::collections::BTreeMap::default(),
+        }
+    }
+
+    fn observed_revision(graph: Graph, policy: ActivePickupPolicy) -> ObservedGraphRevision {
+        ObservedGraphRevision {
+            seq: 7,
+            patch_id: RoadmapPatchId::new("rpatch-active").unwrap(),
+            target: RoadmapPatchTarget::ProjectRoadmap {
+                roadmap_path: ".ai-factory/ROADMAP.md".into(),
+            },
+            previous_graph_hash: ContentHash::compute(b"base"),
+            graph,
+            graph_hash: ContentHash::compute(b"revision"),
+            active_pickup: policy,
+        }
+    }
+
+    fn loop_frame() -> crate::engine::frames::Frame {
+        use crate::engine::frames::LoopFrame;
+        use surge_core::keys::SubgraphKey;
+        use surge_core::loop_config::{
+            ExitCondition, FailurePolicy, IterableSource, LoopConfig, ParallelismMode,
+        };
+
+        crate::engine::frames::Frame::Loop(LoopFrame {
+            loop_node: surge_core::keys::NodeKey::try_from("milestones").unwrap(),
+            config: LoopConfig {
+                iterates_over: IterableSource::Static(vec![]),
+                body: SubgraphKey::try_from("body").unwrap(),
+                iteration_var_name: "item".into(),
+                exit_condition: ExitCondition::AllItems,
+                on_iteration_failure: FailurePolicy::Abort,
+                parallelism: ParallelismMode::Sequential,
+                gate_after_each: false,
+            },
+            items: vec![],
+            current_index: 0,
+            attempts_remaining: 0,
+            return_to: surge_core::keys::NodeKey::try_from("after").unwrap(),
+            traversal_counts: std::collections::HashMap::default(),
+        })
+    }
+
+    #[test]
+    fn graph_revision_waits_until_outer_boundary() {
+        let mut active_graph = terminal_graph("base", "end");
+        let original_graph = active_graph.clone();
+        let mut revised_graph = terminal_graph("revised", "amend_001");
+        let old_cursor_node = surge_core::keys::NodeKey::try_from("end").unwrap();
+        revised_graph.nodes.insert(
+            old_cursor_node.clone(),
+            original_graph.nodes[&old_cursor_node].clone(),
+        );
+        let cursor = Cursor {
+            node: old_cursor_node,
+            attempt: 1,
+        };
+        let mut frames = vec![loop_frame()];
+        let mut pending = vec![observed_revision(
+            revised_graph.clone(),
+            ActivePickupPolicy::Allowed,
+        )];
+        let mut applied_seq = 0;
+
+        maybe_apply_pending_graph_revision(
+            &mut active_graph,
+            &cursor,
+            &frames,
+            &mut pending,
+            &mut applied_seq,
+        );
+        assert_eq!(active_graph, original_graph);
+        assert_eq!(pending.len(), 1);
+        assert_eq!(applied_seq, 0);
+
+        frames.clear();
+        maybe_apply_pending_graph_revision(
+            &mut active_graph,
+            &cursor,
+            &frames,
+            &mut pending,
+            &mut applied_seq,
+        );
+        assert_eq!(active_graph, revised_graph);
+        assert!(pending.is_empty());
+        assert_eq!(applied_seq, 7);
+    }
+
+    #[test]
+    fn graph_revision_without_cursor_preservation_is_consumed_without_mutation() {
+        let mut active_graph = terminal_graph("base", "end");
+        let original_graph = active_graph.clone();
+        let revised_graph = terminal_graph("revised", "amend_001");
+        let cursor = Cursor {
+            node: surge_core::keys::NodeKey::try_from("end").unwrap(),
+            attempt: 1,
+        };
+        let frames = Vec::new();
+        let mut pending = vec![observed_revision(
+            revised_graph,
+            ActivePickupPolicy::Allowed,
+        )];
+        let mut applied_seq = 0;
+
+        maybe_apply_pending_graph_revision(
+            &mut active_graph,
+            &cursor,
+            &frames,
+            &mut pending,
+            &mut applied_seq,
+        );
+
+        assert_eq!(active_graph, original_graph);
+        assert!(pending.is_empty());
+        assert_eq!(applied_seq, 7);
     }
 
     #[tokio::test]

--- a/crates/surge-orchestrator/src/engine/run_task.rs
+++ b/crates/surge-orchestrator/src/engine/run_task.rs
@@ -103,646 +103,758 @@ pub(crate) struct RunTaskParams {
     pub profile_registry: Option<Arc<crate::profile_loader::ProfileRegistry>>,
 }
 
-#[allow(clippy::too_many_lines)]
 pub(crate) async fn execute(mut params: RunTaskParams) -> RunOutcome {
-    let mut active_graph = params.graph.clone();
-    let mut cursor = params.resume_cursor.clone().unwrap_or_else(|| Cursor {
-        node: active_graph.start.clone(),
-        attempt: 1,
-    });
-    // One executor per run task: stateless aside from its spawner, so a
-    // fresh `HookExecutor::new()` is the simplest non-overengineered choice.
-    let hook_executor = HookExecutor::new();
-    let mut memory = match params.resume_memory.clone() {
-        Some(memory) => memory,
-        None => match load_existing_memory(&params.writer, params.run_id).await {
-            Ok(memory) => memory,
-            Err(e) => return failed(&params, format!("load existing memory: {e}")).await,
-        },
-    };
-    let mut frames: Vec<crate::engine::frames::Frame> =
-        params.resume_frames.clone().unwrap_or_default();
-    let mut root_traversal_counts: std::collections::HashMap<surge_core::keys::EdgeKey, u32> =
-        params
-            .resume_root_traversal_counts
-            .clone()
-            .unwrap_or_default();
-    let mut applied_graph_revision_seq = params.resume_applied_graph_revision_seq.unwrap_or(0);
-    let mut processed_graph_revision_seq = applied_graph_revision_seq;
-    let mut pending_graph_revisions = match load_pending_graph_revisions_after(
-        &params.writer,
-        applied_graph_revision_seq,
-    )
-    .await
-    {
-        Ok(revisions) => revisions,
-        Err(e) => {
-            return failed(&params, format!("load pending graph revisions: {e}")).await;
-        },
+    let mut state = match initial_execution_state(&params).await {
+        Ok(state) => state,
+        Err(error) => return failed(&params, error).await,
     };
 
     loop {
-        if frames.is_empty() {
-            let mut roadmap_queue = RoadmapAmendmentQueue {
-                writer: &params.writer,
-                artifact_store: &params.artifact_store,
-                run_id: params.run_id,
-                receiver: &mut params.roadmap_amendments,
-            };
-            if let Err(error) = roadmap_queue
-                .drain(
-                    &mut active_graph,
-                    &cursor,
-                    &mut memory,
-                    &mut pending_graph_revisions,
-                    &mut processed_graph_revision_seq,
-                    &mut applied_graph_revision_seq,
-                )
-                .await
-            {
+        if state.frames.is_empty() {
+            if let Err(error) = drain_roadmap_queue(&mut params, &mut state).await {
                 return failed(&params, format!("apply queued roadmap amendments: {error}")).await;
             }
         }
-        maybe_apply_pending_graph_revision(
-            &mut active_graph,
-            &cursor,
-            &frames,
-            &mut pending_graph_revisions,
-            &mut processed_graph_revision_seq,
-            &mut applied_graph_revision_seq,
-        );
 
-        if params.cancel.is_cancelled() {
-            let reason = "stop_run requested".to_string();
-            let _ = params
-                .writer
-                .append_event(VersionedEventPayload::new(EventPayload::RunAborted {
-                    reason: reason.clone(),
-                }))
-                .await;
-            let outcome = RunOutcome::Aborted { reason };
-            let _ = params.event_tx.send(EngineRunEvent::Terminal {
-                outcome: outcome.clone(),
-            });
+        apply_pending_revisions(&mut state);
+
+        if let Some(outcome) = abort_if_cancelled(&params).await {
             return outcome;
         }
 
-        let node = if let Some(n) = lookup_in_active_frame(&active_graph, &cursor.node, &frames) {
+        let node = if let Some(n) =
+            lookup_in_active_frame(&state.active_graph, &state.cursor.node, &state.frames)
+        {
             n.clone()
         } else {
-            let err = format!("cursor at unknown node {}", cursor.node);
+            let err = format!("cursor at unknown node {}", state.cursor.node);
             return failed(&params, err).await;
         };
 
-        // Emit StageEntered.
-        if let Err(e) = params
-            .writer
-            .append_event(VersionedEventPayload::new(EventPayload::StageEntered {
-                node: cursor.node.clone(),
-                attempt: cursor.attempt,
-            }))
-            .await
-        {
-            return failed(&params, format!("write StageEntered: {e}")).await;
-        }
-        let stage_start_seq = match params.writer.current_seq().await {
+        let stage_start_seq = match enter_stage(&params, &state.cursor).await {
             Ok(seq) => seq,
-            Err(e) => return failed(&params, format!("current_seq after StageEntered: {e}")).await,
+            Err(error) => return failed(&params, error).await,
         };
 
-        // Dispatch.
-        let stage_result: Result<StageOutcome, StageError> = match &node.config {
-            NodeConfig::Agent(cfg) => {
-                let r = execute_agent_stage(AgentStageParams {
-                    node: &cursor.node,
-                    agent_config: cfg,
-                    declared_outcomes: &node.declared_outcomes,
-                    bridge: &params.bridge,
-                    writer: &params.writer,
-                    artifact_store: &params.artifact_store,
-                    worktree_path: &params.worktree_path,
-                    tool_dispatcher: &params.tool_dispatcher,
-                    run_memory: &memory,
-                    run_id: params.run_id,
-                    tool_resolutions: &params.tool_resolutions,
-                    human_input_timeout: params.run_config.human_input_timeout,
-                    mcp_registry: params.mcp_registry.clone(),
-                    mcp_servers: params.mcp_servers.clone(),
-                    profile_registry: params.profile_registry.clone(),
-                    hook_executor: &hook_executor,
-                })
-                .await;
-                // Task 10: Flow Generator post-processing — validate the
-                // produced `flow.toml` and either emit `PipelineMaterialized`
-                // (success) or `BootstrapEditRequested` + a synthetic
-                // `OutcomeReported { outcome: validation_failed }` so routing
-                // takes the bundled bootstrap graph's Backtrack edge back to
-                // the Flow Generator agent.
-                let r = match r {
-                    Ok(outcome)
-                        if crate::engine::bootstrap::is_flow_generator_profile(
-                            cfg.profile.as_str(),
-                        ) =>
-                    {
-                        match crate::engine::bootstrap::run_flow_generator_post_processing(
-                            &cursor.node,
-                            &memory,
-                            params.run_config.bootstrap.edit_loop_cap,
-                            &params.worktree_path,
-                            &params.writer,
-                        )
-                        .await
-                        {
-                            Ok(crate::engine::bootstrap::FlowValidationDecision::Materialized) => {
-                                Ok(outcome)
-                            },
-                            Ok(
-                                crate::engine::bootstrap::FlowValidationDecision::EditRequested {
-                                    ..
-                                },
-                            ) => OutcomeKey::try_from(
-                                crate::engine::bootstrap::VALIDATION_FAILED_OUTCOME,
-                            )
-                            .map_err(|e| {
-                                StageError::Internal(format!("validation retry outcome key: {e}"))
-                            }),
-                            Ok(crate::engine::bootstrap::FlowValidationDecision::CapExceeded {
-                                cap,
-                            }) => Err(StageError::EditLoopCapExceeded {
-                                stage: surge_core::run_event::BootstrapStage::Flow,
-                                cap,
-                            }),
-                            Ok(
-                                crate::engine::bootstrap::FlowValidationDecision::MissingArtifact,
-                            ) => Err(StageError::Internal(
-                                "Flow Generator stage finished without producing flow.toml".into(),
-                            )),
-                            Err(e) => Err(e),
-                        }
-                    },
-                    other => other,
-                };
-                r.map(StageOutcome::Routed)
-            },
-            NodeConfig::Branch(cfg) => execute_branch_stage(BranchStageParams {
-                node: &cursor.node,
-                branch_config: cfg,
-                writer: &params.writer,
-                run_memory: &memory,
-                worktree_root: &params.worktree_path,
-            })
-            .await
-            .map(StageOutcome::Routed),
-            NodeConfig::Notify(cfg) => execute_notify_stage(NotifyStageParams {
-                node: &cursor.node,
-                notify_config: cfg,
-                declared_outcomes: &node.declared_outcomes,
-                writer: &params.writer,
-                run_memory: &memory,
-                run_id: params.run_id,
-                deliverer: params.notify_deliverer.clone(),
-            })
-            .await
-            .map(StageOutcome::Routed),
-            NodeConfig::Terminal(cfg) => {
-                use crate::engine::frames::TerminalSignal;
-                match crate::engine::frames::on_terminal_decision(&frames, &cursor) {
-                    TerminalSignal::OuterComplete => {
-                        let r = execute_terminal_stage(TerminalStageParams {
-                            node: &cursor.node,
-                            terminal_config: cfg,
-                            writer: &params.writer,
-                        })
-                        .await;
-                        r.map(StageOutcome::Terminal)
-                    },
-                    TerminalSignal::LoopIterDone => {
-                        // The most recent OutcomeReported event drives the iteration's outcome.
-                        let just_completed = if let Some(record) = memory
-                            .outcomes
-                            .get(&cursor.node)
-                            .and_then(|recs| recs.last())
-                        {
-                            record.outcome.clone()
-                        } else {
-                            match surge_core::keys::OutcomeKey::try_from("completed") {
-                                Ok(outcome) => outcome,
-                                Err(e) => {
-                                    return failed(
-                                        &params,
-                                        format!("loop default outcome key: {e}"),
-                                    )
-                                    .await;
-                                },
-                            }
-                        };
-
-                        if let Err(e) = crate::engine::stage::loop_stage::on_loop_iteration_done(
-                            &just_completed,
-                            &active_graph,
-                            &mut frames,
-                            &mut cursor,
-                            &params.writer,
-                        )
-                        .await
-                        {
-                            return failed(&params, format!("loop iter done: {e}")).await;
-                        }
-                        continue;
-                    },
-                    TerminalSignal::SubgraphDone => {
-                        // Look up the outer SubgraphConfig::outputs by walking back to the
-                        // outer node referenced by the top frame.
-                        let outputs = match frames.last() {
-                            Some(crate::engine::frames::Frame::Subgraph(sf)) => {
-                                match active_graph.nodes.get(&sf.outer_node).map(|n| &n.config) {
-                                    Some(surge_core::node::NodeConfig::Subgraph(cfg)) => {
-                                        cfg.outputs.clone()
-                                    },
-                                    _ => {
-                                        return failed(
-                                            &params,
-                                            format!(
-                                                "outer subgraph node {} missing or wrong kind",
-                                                sf.outer_node
-                                            ),
-                                        )
-                                        .await;
-                                    },
-                                }
-                            },
-                            _ => {
-                                return failed(
-                                    &params,
-                                    "SubgraphDone signal but no Subgraph frame on top".into(),
-                                )
-                                .await;
-                            },
-                        };
-
-                        if let Err(e) = crate::engine::stage::subgraph_stage::on_subgraph_done(
-                            &outputs,
-                            &memory,
-                            &mut frames,
-                            &mut cursor,
-                            &params.writer,
-                        )
-                        .await
-                        {
-                            return failed(&params, format!("subgraph done: {e}")).await;
-                        }
-                        continue;
-                    },
-                }
-            },
-            NodeConfig::HumanGate(cfg) => {
-                let (tx, rx) = tokio::sync::oneshot::channel();
-                params
-                    .gate_resolutions
-                    .lock()
-                    .await
-                    .insert(cursor.node.clone(), tx);
-                let r = execute_human_gate_stage(HumanGateStageParams {
-                    node: &cursor.node,
-                    gate_config: cfg,
-                    writer: &params.writer,
-                    run_memory: &memory,
-                    resolution_rx: Some(rx),
-                    default_timeout: params.run_config.human_input_timeout,
-                    bootstrap_edit_loop_cap: params.run_config.bootstrap.edit_loop_cap,
-                })
-                .await;
-                params.gate_resolutions.lock().await.remove(&cursor.node);
-                r.map(StageOutcome::Routed)
-            },
-            NodeConfig::Loop(cfg) => {
-                // Compute return_to (outer-graph node to advance to when loop completes).
-                let completed_outcome = match surge_core::keys::OutcomeKey::try_from("completed") {
-                    Ok(o) => o,
-                    Err(e) => return failed(&params, format!("'completed' outcome: {e}")).await,
-                };
-                let return_to =
-                    match crate::engine::routing::edge_target_after_outcome_in_active_graph(
-                        &active_graph,
-                        &cursor.node,
-                        &completed_outcome,
-                        &frames,
-                    ) {
-                        Ok(n) => n,
-                        Err(e) => return failed(&params, format!("loop return_to: {e}")).await,
-                    };
-
-                let effect = match crate::engine::stage::loop_stage::execute_loop_entry(
-                    crate::engine::stage::loop_stage::LoopStageParams {
-                        node: &cursor.node,
-                        loop_config: cfg,
-                        graph: &active_graph,
-                        run_memory: &memory,
-                        writer: &params.writer,
-                        frames: &mut frames,
-                        return_to,
-                    },
-                )
-                .await
-                {
-                    Ok(e) => e,
-                    Err(e) => return failed(&params, format!("loop entry: {e}")).await,
-                };
-
-                match effect {
-                    crate::engine::stage::loop_stage::LoopEntryEffect::Skipped(outcome) => {
-                        Ok(StageOutcome::Routed(outcome))
-                    },
-                    crate::engine::stage::loop_stage::LoopEntryEffect::Entered(body_start) => {
-                        cursor.node = body_start;
-                        cursor.attempt = 1;
-                        continue; // Skip the routing block below — we're in a fresh frame's body.
-                    },
-                }
-            },
-            NodeConfig::Subgraph(cfg) => {
-                let completed_outcome = match surge_core::keys::OutcomeKey::try_from("completed") {
-                    Ok(o) => o,
-                    Err(e) => return failed(&params, format!("'completed' outcome: {e}")).await,
-                };
-                let return_to =
-                    match crate::engine::routing::edge_target_after_outcome_in_active_graph(
-                        &active_graph,
-                        &cursor.node,
-                        &completed_outcome,
-                        &frames,
-                    ) {
-                        Ok(n) => n,
-                        Err(e) => return failed(&params, format!("subgraph return_to: {e}")).await,
-                    };
-
-                let effect = match crate::engine::stage::subgraph_stage::execute_subgraph_entry(
-                    crate::engine::stage::subgraph_stage::SubgraphStageParams {
-                        node: &cursor.node,
-                        subgraph_config: cfg,
-                        graph: &active_graph,
-                        run_memory: &memory,
-                        writer: &params.writer,
-                        frames: &mut frames,
-                        return_to,
-                    },
-                )
-                .await
-                {
-                    Ok(e) => e,
-                    Err(e) => return failed(&params, format!("subgraph entry: {e}")).await,
-                };
-
-                cursor.node = effect.inner_start;
-                cursor.attempt = 1;
-                continue; // Skip routing block — we're now in the inner subgraph's body.
-            },
+        let stage_result = match dispatch_node_stage(&params, &mut state, &node).await {
+            StageDispatch::StageResult(result) => result,
+            StageDispatch::Continue => continue,
+            StageDispatch::Failed(error) => return failed(&params, error).await,
         };
 
-        let outcome: OutcomeKey = match stage_result {
-            Ok(StageOutcome::Routed(k)) => k,
-            Ok(StageOutcome::Terminal(TerminalOutcome::Completed { node: n })) => {
-                let outcome = RunOutcome::Completed { terminal: n };
-                let _ = params.event_tx.send(EngineRunEvent::Terminal {
-                    outcome: outcome.clone(),
-                });
-                return outcome;
-            },
-            Ok(StageOutcome::Terminal(TerminalOutcome::Failed { error })) => {
-                let outcome = RunOutcome::Failed { error };
-                let _ = params.event_tx.send(EngineRunEvent::Terminal {
-                    outcome: outcome.clone(),
-                });
-                return outcome;
-            },
-            Ok(StageOutcome::Terminal(TerminalOutcome::Aborted { reason })) => {
-                let outcome = RunOutcome::Aborted { reason };
-                let _ = params.event_tx.send(EngineRunEvent::Terminal {
-                    outcome: outcome.clone(),
-                });
-                return outcome;
-            },
-            Err(e) => {
-                let raw_reason = format!("stage error at {}: {e}", cursor.node);
-                tracing::warn!(
-                    target: "engine::stage::error",
-                    node = %cursor.node,
-                    err = %e,
-                    "stage error captured; running on_error hooks"
-                );
-
-                // on_error hooks may suppress the failure into an outcome the
-                // node already declares.
-                let on_error_resolution = run_on_error_hooks(
-                    &hook_executor,
-                    &node,
-                    &cursor.node,
-                    &raw_reason,
-                    &params.worktree_path,
-                    params.profile_registry.as_deref(),
-                )
-                .await;
-                // Persist a HookExecuted event for every hook invoked on
-                // the on_error chain so the audit trail matches the
-                // pre/post_tool_use and on_outcome paths.
-                for record in &on_error_resolution.records {
-                    crate::engine::hooks::record_hook_executed(&params.writer, record).await;
-                }
-                let on_error_outcome = on_error_resolution.outcome;
-
-                if let Some(suppressed) = on_error_outcome {
-                    tracing::info!(
-                        target: "engine::stage::error",
-                        node = %cursor.node,
-                        outcome = %suppressed,
-                        "on_error hook suppressed failure; recording OutcomeReported"
-                    );
-                    if let Err(write_err) = params
-                        .writer
-                        .append_event(VersionedEventPayload::new(EventPayload::OutcomeReported {
-                            node: cursor.node.clone(),
-                            outcome: suppressed.clone(),
-                            summary: format!("on_error hook suppressed: {raw_reason}"),
-                        }))
-                        .await
-                    {
-                        return failed(
-                            &params,
-                            format!("write OutcomeReported (suppressed): {write_err}"),
-                        )
-                        .await;
-                    }
-                    suppressed
-                } else {
-                    let _ = params
-                        .writer
-                        .append_event(VersionedEventPayload::new(EventPayload::StageFailed {
-                            node: cursor.node.clone(),
-                            reason: raw_reason.clone(),
-                            retry_available: false,
-                        }))
-                        .await;
-                    return failed(&params, raw_reason).await;
-                }
-            },
-        };
-
-        let applied_events = match apply_memory_events_after(
-            &params.writer,
-            params.run_id,
-            stage_start_seq,
-            &mut memory,
-        )
-        .await
+        let resolution = match resolve_stage_result(&params, &mut state, &node, stage_result).await
         {
-            Ok(events) => events,
-            Err(e) => {
-                return failed(&params, format!("update run memory from event log: {e}")).await;
-            },
-        };
-        pending_graph_revisions.extend(applied_events.graph_revisions);
-        maybe_apply_pending_graph_revision(
-            &mut active_graph,
-            &cursor,
-            &frames,
-            &mut pending_graph_revisions,
-            &mut processed_graph_revision_seq,
-            &mut applied_graph_revision_seq,
-        );
-        let stage_events_applied_seq = match params.writer.current_seq().await {
-            Ok(seq) => seq,
-            Err(e) => {
-                return failed(&params, format!("current_seq after memory update: {e}")).await;
-            },
+            Ok(resolution) => resolution,
+            Err(outcome) => return outcome,
         };
 
-        // Route to next node.
-        let routed = match crate::engine::routing::next_node_after_with_counters(
-            &active_graph,
-            &cursor.node,
-            &outcome,
-            &mut frames,
-            &mut root_traversal_counts,
-        ) {
-            Ok(r) => r,
-            Err(crate::engine::routing::RoutingError::ExceededTraversal {
-                edge,
-                action,
-                count: _,
-                max: _,
-            }) => {
-                use surge_core::edge::ExceededAction;
-                match action {
-                    ExceededAction::Escalate => {
-                        // Synthesise a max_traversals_exceeded outcome and re-route.
-                        let synthetic =
-                            match surge_core::keys::OutcomeKey::try_from("max_traversals_exceeded")
-                            {
-                                Ok(o) => o,
-                                Err(e) => {
-                                    return failed(&params, format!("synthetic outcome: {e}"))
-                                        .await;
-                                },
-                            };
-                        match crate::engine::routing::next_node_after_with_counters(
-                            &active_graph,
-                            &cursor.node,
-                            &synthetic,
-                            &mut frames,
-                            &mut root_traversal_counts,
-                        ) {
-                            Ok(r) => r,
-                            Err(_) => {
-                                return failed(
-                                    &params,
-                                    format!(
-                                        "max_traversals exceeded on edge {edge} and no escalate route declared"
-                                    ),
-                                )
-                                .await;
-                            },
-                        }
-                    },
-                    ExceededAction::Fail => {
-                        return failed(
-                            &params,
-                            format!("max_traversals exceeded on edge {edge} (action: Fail)"),
-                        )
-                        .await;
-                    },
+        match resolution {
+            StageResolution::Terminal(outcome) => return outcome,
+            StageResolution::Outcome(outcome) => {
+                if let Err(error) =
+                    route_and_snapshot(&params, &mut state, &outcome, stage_start_seq).await
+                {
+                    return failed(&params, error).await;
                 }
             },
-            Err(e) => return failed(&params, format!("routing: {e}")).await,
-        };
-        let next = routed.target.clone();
-
-        tracing::debug!(
-            target: "engine::routing",
-            from = %cursor.node,
-            to = %next,
-            kind = ?routed.kind,
-            "traversing edge",
-        );
-
-        // Emit the EdgeTraversed event with the actual routed kind so fold
-        // can drive `RunMemory.node_visits` deterministically (Backtrack
-        // edges increment the target's visit counter).
-        let _ = params
-            .writer
-            .append_event(VersionedEventPayload::new(EventPayload::EdgeTraversed {
-                edge: routed.edge_id,
-                from: cursor.node.clone(),
-                to: next.clone(),
-                kind: routed.kind,
-            }))
-            .await;
-        let _ = params
-            .writer
-            .append_event(VersionedEventPayload::new(EventPayload::StageCompleted {
-                node: cursor.node.clone(),
-                outcome: outcome.clone(),
-            }))
-            .await;
-        let applied_events = match apply_memory_events_after(
-            &params.writer,
-            params.run_id,
-            stage_events_applied_seq,
-            &mut memory,
-        )
-        .await
-        {
-            Ok(events) => events,
-            Err(e) => {
-                return failed(&params, format!("update run memory after routing: {e}")).await;
-            },
-        };
-        pending_graph_revisions.extend(applied_events.graph_revisions);
-
-        // Snapshot at stage boundary (per spec §2.6, §12).
-        let next_cursor = Cursor {
-            node: next.clone(),
-            attempt: 1,
-        };
-        let current_seq = match params.writer.current_seq().await {
-            Ok(s) => s,
-            Err(e) => return failed(&params, format!("current_seq: {e}")).await,
-        };
-        let mut snapshot = crate::engine::snapshot::EngineSnapshot::new(
-            &next_cursor,
-            current_seq.as_u64(),
-            current_seq.as_u64(),
-        );
-        snapshot.applied_graph_revision_seq = applied_graph_revision_seq;
-        let blob = match serde_json::to_vec(&snapshot) {
-            Ok(b) => b,
-            Err(e) => return failed(&params, format!("snapshot serialize: {e}")).await,
-        };
-        if let Err(e) = params.writer.write_graph_snapshot(current_seq, blob).await {
-            return failed(&params, format!("write_graph_snapshot: {e}")).await;
         }
-
-        cursor = next_cursor;
     }
+}
+
+struct RunExecutionState {
+    active_graph: Graph,
+    cursor: Cursor,
+    hook_executor: HookExecutor,
+    memory: RunMemory,
+    frames: Vec<crate::engine::frames::Frame>,
+    root_traversal_counts: std::collections::HashMap<surge_core::keys::EdgeKey, u32>,
+    applied_graph_revision_seq: u64,
+    processed_graph_revision_seq: u64,
+    pending_graph_revisions: Vec<ObservedGraphRevision>,
+}
+
+async fn initial_execution_state(params: &RunTaskParams) -> Result<RunExecutionState, String> {
+    let active_graph = params.graph.clone();
+    let cursor = params.resume_cursor.clone().unwrap_or_else(|| Cursor {
+        node: active_graph.start.clone(),
+        attempt: 1,
+    });
+    let memory = match params.resume_memory.clone() {
+        Some(memory) => memory,
+        None => load_existing_memory(&params.writer, params.run_id)
+            .await
+            .map_err(|e| format!("load existing memory: {e}"))?,
+    };
+    let applied_graph_revision_seq = params.resume_applied_graph_revision_seq.unwrap_or(0);
+    let pending_graph_revisions =
+        load_pending_graph_revisions_after(&params.writer, applied_graph_revision_seq)
+            .await
+            .map_err(|e| format!("load pending graph revisions: {e}"))?;
+
+    Ok(RunExecutionState {
+        active_graph,
+        cursor,
+        hook_executor: HookExecutor::new(),
+        memory,
+        frames: params.resume_frames.clone().unwrap_or_default(),
+        root_traversal_counts: params
+            .resume_root_traversal_counts
+            .clone()
+            .unwrap_or_default(),
+        applied_graph_revision_seq,
+        processed_graph_revision_seq: applied_graph_revision_seq,
+        pending_graph_revisions,
+    })
+}
+
+async fn drain_roadmap_queue(
+    params: &mut RunTaskParams,
+    state: &mut RunExecutionState,
+) -> Result<(), surge_persistence::runs::StorageError> {
+    let mut roadmap_queue = RoadmapAmendmentQueue {
+        writer: &params.writer,
+        artifact_store: &params.artifact_store,
+        run_id: params.run_id,
+        receiver: &mut params.roadmap_amendments,
+    };
+    roadmap_queue
+        .drain(
+            &mut state.active_graph,
+            &state.cursor,
+            &mut state.memory,
+            &mut state.pending_graph_revisions,
+            &mut state.processed_graph_revision_seq,
+            &mut state.applied_graph_revision_seq,
+        )
+        .await
+}
+
+fn apply_pending_revisions(state: &mut RunExecutionState) {
+    maybe_apply_pending_graph_revision(
+        &mut state.active_graph,
+        &state.cursor,
+        &state.frames,
+        &mut state.pending_graph_revisions,
+        &mut state.processed_graph_revision_seq,
+        &mut state.applied_graph_revision_seq,
+    );
+}
+
+async fn abort_if_cancelled(params: &RunTaskParams) -> Option<RunOutcome> {
+    if !params.cancel.is_cancelled() {
+        return None;
+    }
+
+    let reason = "stop_run requested".to_string();
+    let _ = params
+        .writer
+        .append_event(VersionedEventPayload::new(EventPayload::RunAborted {
+            reason: reason.clone(),
+        }))
+        .await;
+    let outcome = RunOutcome::Aborted { reason };
+    let _ = params.event_tx.send(EngineRunEvent::Terminal {
+        outcome: outcome.clone(),
+    });
+    Some(outcome)
+}
+
+async fn enter_stage(
+    params: &RunTaskParams,
+    cursor: &Cursor,
+) -> Result<surge_persistence::runs::EventSeq, String> {
+    params
+        .writer
+        .append_event(VersionedEventPayload::new(EventPayload::StageEntered {
+            node: cursor.node.clone(),
+            attempt: cursor.attempt,
+        }))
+        .await
+        .map_err(|e| format!("write StageEntered: {e}"))?;
+    params
+        .writer
+        .current_seq()
+        .await
+        .map_err(|e| format!("current_seq after StageEntered: {e}"))
+}
+
+enum StageDispatch {
+    StageResult(Result<StageOutcome, StageError>),
+    Continue,
+    Failed(String),
+}
+
+async fn dispatch_node_stage(
+    params: &RunTaskParams,
+    state: &mut RunExecutionState,
+    node: &surge_core::node::Node,
+) -> StageDispatch {
+    let stage_result = match &node.config {
+        NodeConfig::Agent(cfg) => execute_agent_node(params, state, node, cfg).await,
+        NodeConfig::Branch(cfg) => execute_branch_stage(BranchStageParams {
+            node: &state.cursor.node,
+            branch_config: cfg,
+            writer: &params.writer,
+            run_memory: &state.memory,
+            worktree_root: &params.worktree_path,
+        })
+        .await
+        .map(StageOutcome::Routed),
+        NodeConfig::Notify(cfg) => execute_notify_stage(NotifyStageParams {
+            node: &state.cursor.node,
+            notify_config: cfg,
+            declared_outcomes: &node.declared_outcomes,
+            writer: &params.writer,
+            run_memory: &state.memory,
+            run_id: params.run_id,
+            deliverer: params.notify_deliverer.clone(),
+        })
+        .await
+        .map(StageOutcome::Routed),
+        NodeConfig::Terminal(cfg) => return dispatch_terminal_node(params, state, cfg).await,
+        NodeConfig::HumanGate(cfg) => execute_human_gate_node(params, state, cfg).await,
+        NodeConfig::Loop(cfg) => return enter_loop_node(params, state, cfg).await,
+        NodeConfig::Subgraph(cfg) => return enter_subgraph_node(params, state, cfg).await,
+    };
+    StageDispatch::StageResult(stage_result)
+}
+
+async fn execute_agent_node(
+    params: &RunTaskParams,
+    state: &RunExecutionState,
+    node: &surge_core::node::Node,
+    cfg: &surge_core::agent_config::AgentConfig,
+) -> Result<StageOutcome, StageError> {
+    let stage_result = execute_agent_stage(AgentStageParams {
+        node: &state.cursor.node,
+        agent_config: cfg,
+        declared_outcomes: &node.declared_outcomes,
+        bridge: &params.bridge,
+        writer: &params.writer,
+        artifact_store: &params.artifact_store,
+        worktree_path: &params.worktree_path,
+        tool_dispatcher: &params.tool_dispatcher,
+        run_memory: &state.memory,
+        run_id: params.run_id,
+        tool_resolutions: &params.tool_resolutions,
+        human_input_timeout: params.run_config.human_input_timeout,
+        mcp_registry: params.mcp_registry.clone(),
+        mcp_servers: params.mcp_servers.clone(),
+        profile_registry: params.profile_registry.clone(),
+        hook_executor: &state.hook_executor,
+    })
+    .await;
+
+    let stage_result = if crate::engine::bootstrap::is_flow_generator_profile(cfg.profile.as_str())
+    {
+        handle_flow_generator_result(params, state, stage_result).await
+    } else {
+        stage_result
+    };
+    stage_result.map(StageOutcome::Routed)
+}
+
+async fn handle_flow_generator_result(
+    params: &RunTaskParams,
+    state: &RunExecutionState,
+    stage_result: Result<OutcomeKey, StageError>,
+) -> Result<OutcomeKey, StageError> {
+    let Ok(outcome) = stage_result else {
+        return stage_result;
+    };
+    match crate::engine::bootstrap::run_flow_generator_post_processing(
+        &state.cursor.node,
+        &state.memory,
+        params.run_config.bootstrap.edit_loop_cap,
+        &params.worktree_path,
+        &params.writer,
+    )
+    .await
+    {
+        Ok(crate::engine::bootstrap::FlowValidationDecision::Materialized) => Ok(outcome),
+        Ok(crate::engine::bootstrap::FlowValidationDecision::EditRequested { .. }) => {
+            OutcomeKey::try_from(crate::engine::bootstrap::VALIDATION_FAILED_OUTCOME)
+                .map_err(|e| StageError::Internal(format!("validation retry outcome key: {e}")))
+        },
+        Ok(crate::engine::bootstrap::FlowValidationDecision::CapExceeded { cap }) => {
+            Err(StageError::EditLoopCapExceeded {
+                stage: surge_core::run_event::BootstrapStage::Flow,
+                cap,
+            })
+        },
+        Ok(crate::engine::bootstrap::FlowValidationDecision::MissingArtifact) => {
+            Err(StageError::Internal(
+                "Flow Generator stage finished without producing flow.toml".into(),
+            ))
+        },
+        Err(error) => Err(error),
+    }
+}
+
+async fn dispatch_terminal_node(
+    params: &RunTaskParams,
+    state: &mut RunExecutionState,
+    cfg: &surge_core::terminal_config::TerminalConfig,
+) -> StageDispatch {
+    use crate::engine::frames::TerminalSignal;
+
+    match crate::engine::frames::on_terminal_decision(&state.frames, &state.cursor) {
+        TerminalSignal::OuterComplete => {
+            let result = execute_terminal_stage(TerminalStageParams {
+                node: &state.cursor.node,
+                terminal_config: cfg,
+                writer: &params.writer,
+            })
+            .await
+            .map(StageOutcome::Terminal);
+            StageDispatch::StageResult(result)
+        },
+        TerminalSignal::LoopIterDone => finish_loop_iteration(params, state).await,
+        TerminalSignal::SubgraphDone => finish_subgraph_frame(params, state).await,
+    }
+}
+
+async fn finish_loop_iteration(
+    params: &RunTaskParams,
+    state: &mut RunExecutionState,
+) -> StageDispatch {
+    let just_completed = match latest_loop_outcome(state) {
+        Ok(outcome) => outcome,
+        Err(error) => return StageDispatch::Failed(error),
+    };
+    match crate::engine::stage::loop_stage::on_loop_iteration_done(
+        &just_completed,
+        &state.active_graph,
+        &mut state.frames,
+        &mut state.cursor,
+        &params.writer,
+    )
+    .await
+    {
+        Ok(()) => StageDispatch::Continue,
+        Err(error) => StageDispatch::Failed(format!("loop iter done: {error}")),
+    }
+}
+
+fn latest_loop_outcome(state: &RunExecutionState) -> Result<OutcomeKey, String> {
+    if let Some(record) = state
+        .memory
+        .outcomes
+        .get(&state.cursor.node)
+        .and_then(|records| records.last())
+    {
+        return Ok(record.outcome.clone());
+    }
+    OutcomeKey::try_from("completed").map_err(|e| format!("loop default outcome key: {e}"))
+}
+
+async fn finish_subgraph_frame(
+    params: &RunTaskParams,
+    state: &mut RunExecutionState,
+) -> StageDispatch {
+    let outputs = match current_subgraph_outputs(state) {
+        Ok(outputs) => outputs,
+        Err(error) => return StageDispatch::Failed(error),
+    };
+    match crate::engine::stage::subgraph_stage::on_subgraph_done(
+        &outputs,
+        &state.memory,
+        &mut state.frames,
+        &mut state.cursor,
+        &params.writer,
+    )
+    .await
+    {
+        Ok(()) => StageDispatch::Continue,
+        Err(error) => StageDispatch::Failed(format!("subgraph done: {error}")),
+    }
+}
+
+fn current_subgraph_outputs(
+    state: &RunExecutionState,
+) -> Result<Vec<surge_core::subgraph_config::SubgraphOutput>, String> {
+    let Some(crate::engine::frames::Frame::Subgraph(frame)) = state.frames.last() else {
+        return Err("SubgraphDone signal but no Subgraph frame on top".into());
+    };
+    match state
+        .active_graph
+        .nodes
+        .get(&frame.outer_node)
+        .map(|node| &node.config)
+    {
+        Some(NodeConfig::Subgraph(cfg)) => Ok(cfg.outputs.clone()),
+        _ => Err(format!(
+            "outer subgraph node {} missing or wrong kind",
+            frame.outer_node
+        )),
+    }
+}
+
+async fn execute_human_gate_node(
+    params: &RunTaskParams,
+    state: &RunExecutionState,
+    cfg: &surge_core::human_gate_config::HumanGateConfig,
+) -> Result<StageOutcome, StageError> {
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    params
+        .gate_resolutions
+        .lock()
+        .await
+        .insert(state.cursor.node.clone(), tx);
+    let result = execute_human_gate_stage(HumanGateStageParams {
+        node: &state.cursor.node,
+        gate_config: cfg,
+        writer: &params.writer,
+        run_memory: &state.memory,
+        resolution_rx: Some(rx),
+        default_timeout: params.run_config.human_input_timeout,
+        bootstrap_edit_loop_cap: params.run_config.bootstrap.edit_loop_cap,
+    })
+    .await;
+    params
+        .gate_resolutions
+        .lock()
+        .await
+        .remove(&state.cursor.node);
+    result.map(StageOutcome::Routed)
+}
+
+async fn enter_loop_node(
+    params: &RunTaskParams,
+    state: &mut RunExecutionState,
+    cfg: &surge_core::loop_config::LoopConfig,
+) -> StageDispatch {
+    let return_to =
+        match return_to_after_completed(&state.active_graph, &state.cursor, &state.frames) {
+            Ok(node) => node,
+            Err(error) => return StageDispatch::Failed(format!("loop return_to: {error}")),
+        };
+    let effect = crate::engine::stage::loop_stage::execute_loop_entry(
+        crate::engine::stage::loop_stage::LoopStageParams {
+            node: &state.cursor.node,
+            loop_config: cfg,
+            graph: &state.active_graph,
+            run_memory: &state.memory,
+            writer: &params.writer,
+            frames: &mut state.frames,
+            return_to,
+        },
+    )
+    .await;
+
+    match effect {
+        Ok(crate::engine::stage::loop_stage::LoopEntryEffect::Skipped(outcome)) => {
+            StageDispatch::StageResult(Ok(StageOutcome::Routed(outcome)))
+        },
+        Ok(crate::engine::stage::loop_stage::LoopEntryEffect::Entered(body_start)) => {
+            state.cursor.node = body_start;
+            state.cursor.attempt = 1;
+            StageDispatch::Continue
+        },
+        Err(error) => StageDispatch::Failed(format!("loop entry: {error}")),
+    }
+}
+
+async fn enter_subgraph_node(
+    params: &RunTaskParams,
+    state: &mut RunExecutionState,
+    cfg: &surge_core::subgraph_config::SubgraphConfig,
+) -> StageDispatch {
+    let return_to =
+        match return_to_after_completed(&state.active_graph, &state.cursor, &state.frames) {
+            Ok(node) => node,
+            Err(error) => return StageDispatch::Failed(format!("subgraph return_to: {error}")),
+        };
+    let effect = crate::engine::stage::subgraph_stage::execute_subgraph_entry(
+        crate::engine::stage::subgraph_stage::SubgraphStageParams {
+            node: &state.cursor.node,
+            subgraph_config: cfg,
+            graph: &state.active_graph,
+            run_memory: &state.memory,
+            writer: &params.writer,
+            frames: &mut state.frames,
+            return_to,
+        },
+    )
+    .await;
+
+    match effect {
+        Ok(effect) => {
+            state.cursor.node = effect.inner_start;
+            state.cursor.attempt = 1;
+            StageDispatch::Continue
+        },
+        Err(error) => StageDispatch::Failed(format!("subgraph entry: {error}")),
+    }
+}
+
+fn return_to_after_completed(
+    graph: &Graph,
+    cursor: &Cursor,
+    frames: &[crate::engine::frames::Frame],
+) -> Result<surge_core::keys::NodeKey, String> {
+    let completed =
+        OutcomeKey::try_from("completed").map_err(|e| format!("'completed' outcome: {e}"))?;
+    crate::engine::routing::edge_target_after_outcome_in_active_graph(
+        graph,
+        &cursor.node,
+        &completed,
+        frames,
+    )
+    .map_err(|e| e.to_string())
+}
+
+enum StageResolution {
+    Outcome(OutcomeKey),
+    Terminal(RunOutcome),
+}
+
+async fn resolve_stage_result(
+    params: &RunTaskParams,
+    state: &mut RunExecutionState,
+    node: &surge_core::node::Node,
+    stage_result: Result<StageOutcome, StageError>,
+) -> Result<StageResolution, RunOutcome> {
+    match stage_result {
+        Ok(StageOutcome::Routed(outcome)) => Ok(StageResolution::Outcome(outcome)),
+        Ok(StageOutcome::Terminal(terminal)) => {
+            let outcome = terminal_run_outcome(terminal);
+            let _ = params.event_tx.send(EngineRunEvent::Terminal {
+                outcome: outcome.clone(),
+            });
+            Ok(StageResolution::Terminal(outcome))
+        },
+        Err(error) => resolve_stage_error(params, state, node, error)
+            .await
+            .map(StageResolution::Outcome),
+    }
+}
+
+fn terminal_run_outcome(terminal: TerminalOutcome) -> RunOutcome {
+    match terminal {
+        TerminalOutcome::Completed { node } => RunOutcome::Completed { terminal: node },
+        TerminalOutcome::Failed { error } => RunOutcome::Failed { error },
+        TerminalOutcome::Aborted { reason } => RunOutcome::Aborted { reason },
+    }
+}
+
+async fn resolve_stage_error(
+    params: &RunTaskParams,
+    state: &RunExecutionState,
+    node: &surge_core::node::Node,
+    error: StageError,
+) -> Result<OutcomeKey, RunOutcome> {
+    let raw_reason = format!("stage error at {}: {error}", state.cursor.node);
+    tracing::warn!(
+        target: "engine::stage::error",
+        node = %state.cursor.node,
+        err = %error,
+        "stage error captured; running on_error hooks"
+    );
+
+    let on_error_resolution = run_on_error_hooks(
+        &state.hook_executor,
+        node,
+        &state.cursor.node,
+        &raw_reason,
+        &params.worktree_path,
+        params.profile_registry.as_deref(),
+    )
+    .await;
+    for record in &on_error_resolution.records {
+        crate::engine::hooks::record_hook_executed(&params.writer, record).await;
+    }
+
+    if let Some(suppressed) = on_error_resolution.outcome {
+        return record_suppressed_error(params, state, suppressed, &raw_reason).await;
+    }
+
+    let _ = params
+        .writer
+        .append_event(VersionedEventPayload::new(EventPayload::StageFailed {
+            node: state.cursor.node.clone(),
+            reason: raw_reason.clone(),
+            retry_available: false,
+        }))
+        .await;
+    Err(failed(params, raw_reason).await)
+}
+
+async fn record_suppressed_error(
+    params: &RunTaskParams,
+    state: &RunExecutionState,
+    suppressed: OutcomeKey,
+    raw_reason: &str,
+) -> Result<OutcomeKey, RunOutcome> {
+    tracing::info!(
+        target: "engine::stage::error",
+        node = %state.cursor.node,
+        outcome = %suppressed,
+        "on_error hook suppressed failure; recording OutcomeReported"
+    );
+    if let Err(write_err) = params
+        .writer
+        .append_event(VersionedEventPayload::new(EventPayload::OutcomeReported {
+            node: state.cursor.node.clone(),
+            outcome: suppressed.clone(),
+            summary: format!("on_error hook suppressed: {raw_reason}"),
+        }))
+        .await
+    {
+        return Err(failed(
+            params,
+            format!("write OutcomeReported (suppressed): {write_err}"),
+        )
+        .await);
+    }
+    Ok(suppressed)
+}
+
+async fn route_and_snapshot(
+    params: &RunTaskParams,
+    state: &mut RunExecutionState,
+    outcome: &OutcomeKey,
+    stage_start_seq: surge_persistence::runs::EventSeq,
+) -> Result<(), String> {
+    let applied_events = apply_memory_events_after(
+        &params.writer,
+        params.run_id,
+        stage_start_seq,
+        &mut state.memory,
+    )
+    .await
+    .map_err(|e| format!("update run memory from event log: {e}"))?;
+    state
+        .pending_graph_revisions
+        .extend(applied_events.graph_revisions);
+    apply_pending_revisions(state);
+    let stage_events_applied_seq = params
+        .writer
+        .current_seq()
+        .await
+        .map_err(|e| format!("current_seq after memory update: {e}"))?;
+
+    let routed = route_stage_outcome(state, outcome)?;
+    write_routing_events(params, state, outcome, &routed).await;
+    let post_route_events = apply_memory_events_after(
+        &params.writer,
+        params.run_id,
+        stage_events_applied_seq,
+        &mut state.memory,
+    )
+    .await
+    .map_err(|e| format!("update run memory after routing: {e}"))?;
+    state
+        .pending_graph_revisions
+        .extend(post_route_events.graph_revisions);
+
+    let next_cursor = Cursor {
+        node: routed.target,
+        attempt: 1,
+    };
+    write_stage_boundary_snapshot(params, state, &next_cursor).await?;
+    state.cursor = next_cursor;
+    Ok(())
+}
+
+fn route_stage_outcome(
+    state: &mut RunExecutionState,
+    outcome: &OutcomeKey,
+) -> Result<crate::engine::routing::RoutedEdge, String> {
+    match crate::engine::routing::next_node_after_with_counters(
+        &state.active_graph,
+        &state.cursor.node,
+        outcome,
+        &mut state.frames,
+        &mut state.root_traversal_counts,
+    ) {
+        Ok(routed) => Ok(routed),
+        Err(crate::engine::routing::RoutingError::ExceededTraversal { edge, action, .. }) => {
+            route_after_max_traversal(state, &edge, action)
+        },
+        Err(error) => Err(format!("routing: {error}")),
+    }
+}
+
+fn route_after_max_traversal(
+    state: &mut RunExecutionState,
+    edge: &surge_core::keys::EdgeKey,
+    action: surge_core::edge::ExceededAction,
+) -> Result<crate::engine::routing::RoutedEdge, String> {
+    match action {
+        surge_core::edge::ExceededAction::Escalate => {
+            let synthetic = OutcomeKey::try_from("max_traversals_exceeded")
+                .map_err(|e| format!("synthetic outcome: {e}"))?;
+            crate::engine::routing::next_node_after_with_counters(
+                &state.active_graph,
+                &state.cursor.node,
+                &synthetic,
+                &mut state.frames,
+                &mut state.root_traversal_counts,
+            )
+            .map_err(|_| {
+                format!("max_traversals exceeded on edge {edge} and no escalate route declared")
+            })
+        },
+        surge_core::edge::ExceededAction::Fail => Err(format!(
+            "max_traversals exceeded on edge {edge} (action: Fail)"
+        )),
+    }
+}
+
+async fn write_routing_events(
+    params: &RunTaskParams,
+    state: &RunExecutionState,
+    outcome: &OutcomeKey,
+    routed: &crate::engine::routing::RoutedEdge,
+) {
+    tracing::debug!(
+        target: "engine::routing",
+        from = %state.cursor.node,
+        to = %routed.target,
+        kind = ?routed.kind,
+        "traversing edge",
+    );
+    let _ = params
+        .writer
+        .append_event(VersionedEventPayload::new(EventPayload::EdgeTraversed {
+            edge: routed.edge_id.clone(),
+            from: state.cursor.node.clone(),
+            to: routed.target.clone(),
+            kind: routed.kind,
+        }))
+        .await;
+    let _ = params
+        .writer
+        .append_event(VersionedEventPayload::new(EventPayload::StageCompleted {
+            node: state.cursor.node.clone(),
+            outcome: outcome.clone(),
+        }))
+        .await;
+}
+
+async fn write_stage_boundary_snapshot(
+    params: &RunTaskParams,
+    state: &RunExecutionState,
+    next_cursor: &Cursor,
+) -> Result<(), String> {
+    let current_seq = params
+        .writer
+        .current_seq()
+        .await
+        .map_err(|e| format!("current_seq: {e}"))?;
+    let mut snapshot = crate::engine::snapshot::EngineSnapshot::new(
+        next_cursor,
+        current_seq.as_u64(),
+        current_seq.as_u64(),
+    );
+    snapshot.applied_graph_revision_seq = state.applied_graph_revision_seq;
+    let blob = serde_json::to_vec(&snapshot).map_err(|e| format!("snapshot serialize: {e}"))?;
+    params
+        .writer
+        .write_graph_snapshot(current_seq, blob)
+        .await
+        .map_err(|e| format!("write_graph_snapshot: {e}"))
 }
 
 enum StageOutcome {

--- a/crates/surge-orchestrator/src/engine/run_task.rs
+++ b/crates/surge-orchestrator/src/engine/run_task.rs
@@ -61,6 +61,9 @@ pub(crate) struct RunTaskParams {
     /// Resume from existing root traversal counts; if None, start fresh.
     pub resume_root_traversal_counts:
         Option<std::collections::HashMap<surge_core::keys::EdgeKey, u32>>,
+    /// Latest accepted graph revision sequence that was durably applied to
+    /// the active graph at a stage boundary.
+    pub resume_applied_graph_revision_seq: Option<u64>,
     /// Map of `node_key → oneshot::Sender<HumanGateResolution>`.
     /// Engine's `resolve_human_input` finds the sender and fires it.
     pub gate_resolutions: std::sync::Arc<
@@ -124,11 +127,19 @@ pub(crate) async fn execute(mut params: RunTaskParams) -> RunOutcome {
             .resume_root_traversal_counts
             .clone()
             .unwrap_or_default();
-    let mut applied_graph_revision_seq = memory
-        .latest_graph_revision
-        .as_ref()
-        .map_or(0, |revision| revision.updated_seq);
-    let mut pending_graph_revisions = Vec::new();
+    let mut applied_graph_revision_seq = params.resume_applied_graph_revision_seq.unwrap_or(0);
+    let mut processed_graph_revision_seq = applied_graph_revision_seq;
+    let mut pending_graph_revisions = match load_pending_graph_revisions_after(
+        &params.writer,
+        applied_graph_revision_seq,
+    )
+    .await
+    {
+        Ok(revisions) => revisions,
+        Err(e) => {
+            return failed(&params, format!("load pending graph revisions: {e}")).await;
+        },
+    };
 
     loop {
         if frames.is_empty() {
@@ -144,6 +155,7 @@ pub(crate) async fn execute(mut params: RunTaskParams) -> RunOutcome {
                     &cursor,
                     &mut memory,
                     &mut pending_graph_revisions,
+                    &mut processed_graph_revision_seq,
                     &mut applied_graph_revision_seq,
                 )
                 .await
@@ -156,6 +168,7 @@ pub(crate) async fn execute(mut params: RunTaskParams) -> RunOutcome {
             &cursor,
             &frames,
             &mut pending_graph_revisions,
+            &mut processed_graph_revision_seq,
             &mut applied_graph_revision_seq,
         );
 
@@ -593,6 +606,7 @@ pub(crate) async fn execute(mut params: RunTaskParams) -> RunOutcome {
             &cursor,
             &frames,
             &mut pending_graph_revisions,
+            &mut processed_graph_revision_seq,
             &mut applied_graph_revision_seq,
         );
         let stage_events_applied_seq = match params.writer.current_seq().await {
@@ -713,11 +727,12 @@ pub(crate) async fn execute(mut params: RunTaskParams) -> RunOutcome {
             Ok(s) => s,
             Err(e) => return failed(&params, format!("current_seq: {e}")).await,
         };
-        let snapshot = crate::engine::snapshot::EngineSnapshot::new(
+        let mut snapshot = crate::engine::snapshot::EngineSnapshot::new(
             &next_cursor,
             current_seq.as_u64(),
             current_seq.as_u64(),
         );
+        snapshot.applied_graph_revision_seq = applied_graph_revision_seq;
         let blob = match serde_json::to_vec(&snapshot) {
             Ok(b) => b,
             Err(e) => return failed(&params, format!("snapshot serialize: {e}")).await,
@@ -906,6 +921,19 @@ async fn apply_memory_events_after(
     Ok(apply_read_events(run_id, &events, memory))
 }
 
+async fn load_pending_graph_revisions_after(
+    writer: &surge_persistence::runs::run_writer::RunWriter,
+    applied_seq: u64,
+) -> Result<Vec<ObservedGraphRevision>, surge_persistence::runs::StorageError> {
+    let current = writer.current_seq().await?;
+    let after = surge_persistence::runs::EventSeq(applied_seq);
+    if current <= after {
+        return Ok(Vec::new());
+    }
+    let events = writer.read_events(after.next()..current.next()).await?;
+    Ok(graph_revisions_from_events(&events))
+}
+
 struct RoadmapAmendmentQueue<'a> {
     writer: &'a surge_persistence::runs::run_writer::RunWriter,
     artifact_store: &'a surge_persistence::artifacts::ArtifactStore,
@@ -920,6 +948,7 @@ impl RoadmapAmendmentQueue<'_> {
         cursor: &Cursor,
         memory: &mut RunMemory,
         pending_graph_revisions: &mut Vec<ObservedGraphRevision>,
+        processed_graph_revision_seq: &mut u64,
         applied_graph_revision_seq: &mut u64,
     ) -> Result<(), surge_persistence::runs::StorageError> {
         while let Ok(command) = self.receiver.try_recv() {
@@ -944,6 +973,7 @@ impl RoadmapAmendmentQueue<'_> {
                         cursor,
                         &[],
                         pending_graph_revisions,
+                        processed_graph_revision_seq,
                         applied_graph_revision_seq,
                     );
                     let _ = command.reply.send(Ok(outcome));
@@ -970,29 +1000,12 @@ fn apply_read_events(
     events: &[surge_persistence::runs::ReadEvent],
     memory: &mut RunMemory,
 ) -> AppliedEventBatch {
-    let mut batch = AppliedEventBatch::default();
+    let batch = AppliedEventBatch {
+        graph_revisions: graph_revisions_from_events(events),
+    };
     for event in events {
         let timestamp = chrono::DateTime::<chrono::Utc>::from_timestamp_millis(event.timestamp_ms)
             .unwrap_or_else(chrono::Utc::now);
-        if let EventPayload::GraphRevisionAccepted {
-            patch_id,
-            target,
-            previous_graph_hash,
-            graph,
-            graph_hash,
-            active_pickup,
-        } = &event.payload.payload
-        {
-            batch.graph_revisions.push(ObservedGraphRevision {
-                seq: event.seq.as_u64(),
-                patch_id: patch_id.clone(),
-                target: target.clone(),
-                previous_graph_hash: *previous_graph_hash,
-                graph: graph.as_ref().clone(),
-                graph_hash: *graph_hash,
-                active_pickup: *active_pickup,
-            });
-        }
         memory.apply_event(&RunEvent {
             run_id,
             seq: event.seq.as_u64(),
@@ -1003,14 +1016,46 @@ fn apply_read_events(
     batch
 }
 
+fn graph_revisions_from_events(
+    events: &[surge_persistence::runs::ReadEvent],
+) -> Vec<ObservedGraphRevision> {
+    events
+        .iter()
+        .filter_map(|event| {
+            if let EventPayload::GraphRevisionAccepted {
+                patch_id,
+                target,
+                previous_graph_hash,
+                graph,
+                graph_hash,
+                active_pickup,
+            } = &event.payload.payload
+            {
+                Some(ObservedGraphRevision {
+                    seq: event.seq.as_u64(),
+                    patch_id: patch_id.clone(),
+                    target: target.clone(),
+                    previous_graph_hash: *previous_graph_hash,
+                    graph: graph.as_ref().clone(),
+                    graph_hash: *graph_hash,
+                    active_pickup: *active_pickup,
+                })
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
 fn maybe_apply_pending_graph_revision(
     active_graph: &mut Graph,
     cursor: &Cursor,
     frames: &[crate::engine::frames::Frame],
     pending: &mut Vec<ObservedGraphRevision>,
+    processed_seq: &mut u64,
     applied_seq: &mut u64,
 ) {
-    pending.retain(|revision| revision.seq > *applied_seq);
+    pending.retain(|revision| revision.seq > *processed_seq);
     let Some(revision) = pending.last().cloned() else {
         return;
     };
@@ -1024,7 +1069,7 @@ fn maybe_apply_pending_graph_revision(
                 graph_hash = %revision.graph_hash,
                 "graph_revision_requires_follow_up_run"
             );
-            *applied_seq = revision.seq;
+            *processed_seq = revision.seq;
             pending.clear();
             return;
         },
@@ -1035,7 +1080,7 @@ fn maybe_apply_pending_graph_revision(
                 graph_hash = %revision.graph_hash,
                 "graph_revision_pickup_disabled"
             );
-            *applied_seq = revision.seq;
+            *processed_seq = revision.seq;
             pending.clear();
             return;
         },
@@ -1060,7 +1105,7 @@ fn maybe_apply_pending_graph_revision(
             cursor = %cursor.node,
             "graph_revision_cannot_preserve_cursor"
         );
-        *applied_seq = revision.seq;
+        *processed_seq = revision.seq;
         pending.clear();
         return;
     }
@@ -1075,6 +1120,7 @@ fn maybe_apply_pending_graph_revision(
         "graph_revision_picked_up"
     );
     *active_graph = revision.graph;
+    *processed_seq = revision.seq;
     *applied_seq = revision.seq;
     pending.clear();
 }
@@ -1237,6 +1283,7 @@ mod tests {
             revised_graph.clone(),
             ActivePickupPolicy::Allowed,
         )];
+        let mut processed_seq = 0;
         let mut applied_seq = 0;
 
         maybe_apply_pending_graph_revision(
@@ -1244,10 +1291,12 @@ mod tests {
             &cursor,
             &frames,
             &mut pending,
+            &mut processed_seq,
             &mut applied_seq,
         );
         assert_eq!(active_graph, original_graph);
         assert_eq!(pending.len(), 1);
+        assert_eq!(processed_seq, 0);
         assert_eq!(applied_seq, 0);
 
         frames.clear();
@@ -1256,10 +1305,12 @@ mod tests {
             &cursor,
             &frames,
             &mut pending,
+            &mut processed_seq,
             &mut applied_seq,
         );
         assert_eq!(active_graph, revised_graph);
         assert!(pending.is_empty());
+        assert_eq!(processed_seq, 7);
         assert_eq!(applied_seq, 7);
     }
 
@@ -1277,6 +1328,7 @@ mod tests {
             revised_graph,
             ActivePickupPolicy::Allowed,
         )];
+        let mut processed_seq = 0;
         let mut applied_seq = 0;
 
         maybe_apply_pending_graph_revision(
@@ -1284,12 +1336,14 @@ mod tests {
             &cursor,
             &frames,
             &mut pending,
+            &mut processed_seq,
             &mut applied_seq,
         );
 
         assert_eq!(active_graph, original_graph);
         assert!(pending.is_empty());
-        assert_eq!(applied_seq, 7);
+        assert_eq!(processed_seq, 7);
+        assert_eq!(applied_seq, 0);
     }
 
     #[tokio::test]

--- a/crates/surge-orchestrator/src/engine/snapshot.rs
+++ b/crates/surge-orchestrator/src/engine/snapshot.rs
@@ -7,6 +7,10 @@ use surge_core::run_state::Cursor;
 
 /// Opaque blob persisted at every stage boundary so a crashed run can be
 /// resumed without replaying the entire event log.
+///
+/// The executable graph is intentionally not stored here. Replay reconstructs
+/// it from `PipelineMaterialized` and any later `GraphRevisionAccepted` events,
+/// so snapshots stay small and graph history remains append-only.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct EngineSnapshot {
     /// Layout version; bump on any breaking schema change.

--- a/crates/surge-orchestrator/src/engine/snapshot.rs
+++ b/crates/surge-orchestrator/src/engine/snapshot.rs
@@ -28,6 +28,10 @@ pub struct EngineSnapshot {
     pub at_seq: u64,
     /// Sequence number of the last completed stage boundary.
     pub stage_boundary_seq: u64,
+    /// Latest `GraphRevisionAccepted` seq that had actually been applied to
+    /// the active graph when this snapshot was written.
+    #[serde(default)]
+    pub applied_graph_revision_seq: u64,
     /// Non-`None` when the run was paused waiting for human input.
     pub pending_human_input: Option<PendingHumanInputSnapshot>,
 }
@@ -389,6 +393,7 @@ impl EngineSnapshot {
             root_traversal_counts: HashMap::new(),
             at_seq,
             stage_boundary_seq,
+            applied_graph_revision_seq: 0,
             pending_human_input: None,
         }
     }
@@ -421,6 +426,7 @@ impl EngineSnapshot {
                     root_traversal_counts: HashMap::new(),
                     at_seq: v1.at_seq,
                     stage_boundary_seq: v1.stage_boundary_seq,
+                    applied_graph_revision_seq: 0,
                     pending_human_input: v1.pending_human_input,
                 })
             },

--- a/crates/surge-orchestrator/src/engine/stage/agent.rs
+++ b/crates/surge-orchestrator/src/engine/stage/agent.rs
@@ -230,8 +230,16 @@ pub async fn execute_agent_stage(p: AgentStageParams<'_>) -> StageResult {
 
     // Build the effective sandbox config (needed both for session creation and
     // for the MCP sandbox heuristic below).
-    let sandbox_cfg: surge_core::sandbox::SandboxConfig =
-        p.agent_config.sandbox_override.clone().unwrap_or_default();
+    let sandbox_cfg: surge_core::sandbox::SandboxConfig = p
+        .agent_config
+        .sandbox_override
+        .clone()
+        .or_else(|| {
+            resolved_profile
+                .as_ref()
+                .map(|resolved| resolved.profile.sandbox.clone())
+        })
+        .unwrap_or_default();
 
     // Build the session-scoped tool dispatcher. When an MCP registry is
     // configured, wrap the engine dispatcher with RoutingToolDispatcher so the

--- a/crates/surge-orchestrator/src/feature_driver.rs
+++ b/crates/surge-orchestrator/src/feature_driver.rs
@@ -1,0 +1,248 @@
+//! Feature Planner driver for `surge feature describe`.
+//!
+//! The driver intentionally delegates execution to the normal Agent stage so
+//! profile resolution, sandbox selection, hooks, produced artifact declarations,
+//! and artifact contract validation stay on the same path as graph execution.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::Duration;
+
+use surge_acp::bridge::facade::BridgeFacade;
+use surge_core::agent_config::{AgentConfig, ArtifactSource, Binding, TemplateVar};
+use surge_core::keys::{NodeKey, ProfileKey};
+use surge_core::node::OutcomeDecl;
+use surge_core::profile::keyref::parse_key_ref;
+use surge_core::run_state::RunMemory;
+use surge_core::{
+    McpServerRef, ROADMAP_PATCH_SCHEMA_VERSION, RoadmapPatch, RoadmapPatchValidationIssue, RunId,
+};
+use surge_mcp::McpRegistry;
+use surge_persistence::artifacts::ArtifactStore;
+use surge_persistence::runs::RunWriter;
+use tokio::sync::{Mutex, oneshot};
+
+use crate::engine::hooks::HookExecutor;
+use crate::engine::stage::StageError;
+use crate::engine::stage::agent::{AgentStageParams, execute_agent_stage};
+use crate::engine::tools::ToolDispatcher;
+use crate::profile_loader::ProfileRegistry;
+
+const FEATURE_PLANNER_PROFILE: &str = "feature-planner@1.0";
+const FEATURE_PLANNER_NODE: &str = "feature_planner";
+const PATCHED_OUTCOME: &str = "patched";
+const OUT_OF_SCOPE_OUTCOME: &str = "out_of_scope";
+const ROADMAP_PATCH_PATH: &str = "roadmap-patch.toml";
+
+/// Shared map used by injected human-input tool calls.
+pub type ToolResolutionMap = Arc<Mutex<HashMap<String, oneshot::Sender<serde_json::Value>>>>;
+
+/// Parameters for one Feature Planner run.
+pub struct FeaturePlannerParams<'a> {
+    /// Free-form user feature request.
+    pub request: String,
+    /// Current roadmap text passed into the profile prompt.
+    pub roadmap: String,
+    /// Bridge facade for ACP session lifecycle.
+    pub bridge: &'a Arc<dyn BridgeFacade>,
+    /// Run writer for stage events.
+    pub writer: &'a RunWriter,
+    /// Content-addressed artifact store.
+    pub artifact_store: &'a ArtifactStore,
+    /// Worktree where `roadmap-patch.toml` is produced.
+    pub worktree_path: &'a Path,
+    /// Dispatcher for non-injected tools.
+    pub tool_dispatcher: &'a Arc<dyn ToolDispatcher>,
+    /// Current run memory for binding/tool context.
+    pub run_memory: &'a RunMemory,
+    /// Current run id.
+    pub run_id: RunId,
+    /// Human-input tool resolution map.
+    pub tool_resolutions: &'a ToolResolutionMap,
+    /// Timeout for human-input tool calls.
+    pub human_input_timeout: Duration,
+    /// Optional MCP registry.
+    pub mcp_registry: Option<Arc<McpRegistry>>,
+    /// Run-level MCP server refs.
+    pub mcp_servers: Vec<McpServerRef>,
+    /// Profile registry used to resolve Feature Planner.
+    pub profile_registry: Arc<ProfileRegistry>,
+    /// Hook executor used by the underlying agent stage.
+    pub hook_executor: &'a HookExecutor,
+}
+
+/// Result of a Feature Planner run.
+#[derive(Debug, Clone, PartialEq)]
+pub enum FeaturePlannerResult {
+    /// A valid roadmap patch was produced.
+    Patched {
+        /// Parsed patch.
+        patch: Box<RoadmapPatch>,
+        /// Path to the produced worktree artifact.
+        patch_path: PathBuf,
+    },
+    /// Request does not belong to this roadmap.
+    OutOfScope,
+}
+
+/// Errors from the Feature Planner driver.
+#[derive(Debug, thiserror::Error)]
+pub enum FeaturePlannerError {
+    /// Profile reference failed to parse or resolve.
+    #[error("feature planner profile error: {0}")]
+    Profile(String),
+    /// Underlying agent stage failed.
+    #[error("feature planner stage failed: {0}")]
+    Stage(#[from] StageError),
+    /// Patch artifact could not be read from the worktree.
+    #[error("read roadmap patch artifact failed: {0}")]
+    Io(#[from] std::io::Error),
+    /// Patch artifact did not parse as typed TOML.
+    #[error("parse roadmap patch artifact failed: {0}")]
+    Toml(#[from] toml::de::Error),
+    /// Feature Planner reported an unexpected outcome.
+    #[error("feature planner returned unexpected outcome: {0}")]
+    UnexpectedOutcome(String),
+    /// Patch parsed but failed pure shape validation.
+    #[error("feature planner returned invalid roadmap patch: {issue_count} issue(s)")]
+    InvalidPatch {
+        /// Number of validation issues.
+        issue_count: usize,
+        /// Stable validation issues.
+        issues: Vec<RoadmapPatchValidationIssue>,
+    },
+}
+
+/// Run Feature Planner and return a typed patch result.
+///
+/// # Errors
+/// Returns [`FeaturePlannerError`] if the profile cannot resolve, the agent
+/// stage fails, the produced patch is missing, or the patch does not parse.
+#[must_use = "await the driver result and handle failures"]
+pub async fn run_feature_planner(
+    params: FeaturePlannerParams<'_>,
+) -> Result<FeaturePlannerResult, FeaturePlannerError> {
+    tracing::debug!(
+        target: "feature_driver",
+        run_id = %params.run_id,
+        "feature_planner_start"
+    );
+
+    let resolved_profile = resolve_feature_planner_profile(&params.profile_registry)?;
+    let declared_outcomes = declared_outcomes(&resolved_profile.profile.outcomes);
+    let node = NodeKey::try_from(FEATURE_PLANNER_NODE)
+        .map_err(|error| FeaturePlannerError::Profile(error.to_string()))?;
+    let agent_config = feature_planner_agent_config(params.request, params.roadmap)?;
+
+    let outcome = execute_agent_stage(AgentStageParams {
+        node: &node,
+        agent_config: &agent_config,
+        declared_outcomes: &declared_outcomes,
+        bridge: params.bridge,
+        writer: params.writer,
+        artifact_store: params.artifact_store,
+        worktree_path: params.worktree_path,
+        tool_dispatcher: params.tool_dispatcher,
+        run_memory: params.run_memory,
+        run_id: params.run_id,
+        tool_resolutions: params.tool_resolutions,
+        human_input_timeout: params.human_input_timeout,
+        mcp_registry: params.mcp_registry,
+        mcp_servers: params.mcp_servers,
+        profile_registry: Some(params.profile_registry.clone()),
+        hook_executor: params.hook_executor,
+    })
+    .await?;
+
+    match outcome.as_ref() {
+        PATCHED_OUTCOME => read_validated_patch(params.worktree_path).await,
+        OUT_OF_SCOPE_OUTCOME => {
+            tracing::warn!(
+                target: "feature_driver",
+                run_id = %params.run_id,
+                "feature_planner_out_of_scope"
+            );
+            Ok(FeaturePlannerResult::OutOfScope)
+        },
+        other => Err(FeaturePlannerError::UnexpectedOutcome(other.to_owned())),
+    }
+}
+
+fn resolve_feature_planner_profile(
+    registry: &ProfileRegistry,
+) -> Result<surge_core::profile::registry::ResolvedProfile, FeaturePlannerError> {
+    let key_ref = parse_key_ref(FEATURE_PLANNER_PROFILE)
+        .map_err(|error| FeaturePlannerError::Profile(error.to_string()))?;
+    registry
+        .resolve(&key_ref)
+        .map_err(|error| FeaturePlannerError::Profile(error.to_string()))
+}
+
+fn declared_outcomes(outcomes: &[surge_core::ProfileOutcome]) -> Vec<OutcomeDecl> {
+    outcomes
+        .iter()
+        .map(|outcome| OutcomeDecl {
+            id: outcome.id.clone(),
+            description: outcome.description.clone(),
+            edge_kind_hint: outcome.edge_kind_hint,
+            is_terminal: false,
+        })
+        .collect()
+}
+
+fn feature_planner_agent_config(
+    request: String,
+    roadmap: String,
+) -> Result<AgentConfig, FeaturePlannerError> {
+    Ok(AgentConfig {
+        profile: ProfileKey::try_from(FEATURE_PLANNER_PROFILE)
+            .map_err(|error| FeaturePlannerError::Profile(error.to_string()))?,
+        prompt_overrides: None,
+        tool_overrides: None,
+        sandbox_override: None,
+        approvals_override: None,
+        bindings: vec![
+            Binding {
+                source: ArtifactSource::Static { content: request },
+                target: TemplateVar("request".into()),
+                optional: false,
+            },
+            Binding {
+                source: ArtifactSource::Static { content: roadmap },
+                target: TemplateVar("roadmap".into()),
+                optional: false,
+            },
+        ],
+        rules_overrides: None,
+        limits: Default::default(),
+        hooks: Vec::new(),
+        custom_fields: Default::default(),
+    })
+}
+
+async fn read_validated_patch(
+    worktree_path: &Path,
+) -> Result<FeaturePlannerResult, FeaturePlannerError> {
+    let patch_path = worktree_path.join(ROADMAP_PATCH_PATH);
+    let content = tokio::fs::read_to_string(&patch_path).await?;
+    let patch: RoadmapPatch = toml::from_str(&content)?;
+    let issues = patch.validate_shape();
+    if !issues.is_empty() {
+        return Err(FeaturePlannerError::InvalidPatch {
+            issue_count: issues.len(),
+            issues,
+        });
+    }
+    tracing::info!(
+        target: "feature_driver",
+        patch_id = %patch.id,
+        schema_version = patch.schema_version,
+        expected_schema_version = ROADMAP_PATCH_SCHEMA_VERSION,
+        "feature_planner_patch_loaded"
+    );
+    Ok(FeaturePlannerResult::Patched {
+        patch: Box::new(patch),
+        patch_path,
+    })
+}

--- a/crates/surge-orchestrator/src/flow_amendment.rs
+++ b/crates/surge-orchestrator/src/flow_amendment.rs
@@ -1,0 +1,516 @@
+//! Flow graph amendment helpers for approved roadmap patches.
+//!
+//! The helper keeps graph mutation conservative: clone the existing graph,
+//! insert a linear chain of Agent nodes for the appended/reworked roadmap
+//! items, validate the clone, and only then return it to the caller.
+
+use std::collections::BTreeSet;
+
+use crate::engine::validate::validate_for_m6;
+use chrono::{DateTime, Utc};
+use surge_core::agent_config::{AgentConfig, ArtifactSource, Binding, TemplateVar};
+use surge_core::content_hash::ContentHash;
+use surge_core::edge::{Edge, EdgeKind, EdgePolicy, PortRef};
+use surge_core::graph::{Graph, GraphMetadata, SCHEMA_VERSION};
+use surge_core::keys::{EdgeKey, KeyParseError, NodeKey, OutcomeKey, ProfileKey};
+use surge_core::node::{Node, NodeConfig, OutcomeDecl, Position};
+use surge_core::roadmap_patch::{RoadmapItemRef, RoadmapPatchApplyResult};
+use surge_core::terminal_config::{TerminalConfig, TerminalKind};
+
+const IMPLEMENTER_PROFILE: &str = "implementer@1.0";
+const IMPLEMENTED_OUTCOME: &str = "implemented";
+const END_NODE: &str = "end";
+const SPEC_TEMPLATE_VAR: &str = "spec";
+
+/// Result of generating an amended flow graph.
+#[derive(Debug, Clone, PartialEq)]
+pub struct FlowAmendmentResult {
+    /// Validated amended graph.
+    pub graph: Graph,
+    /// TOML representation of `graph`.
+    pub flow_toml: String,
+    /// Content hash of `flow_toml`.
+    pub graph_hash: ContentHash,
+    /// Nodes inserted for amendment work, in execution order.
+    pub inserted_nodes: Vec<NodeKey>,
+}
+
+/// Errors from flow amendment generation.
+#[derive(Debug, thiserror::Error)]
+pub enum FlowAmendmentError {
+    /// No roadmap work items were available to turn into stages.
+    #[error("roadmap patch apply result contains no flow amendment items")]
+    NoAmendmentItems,
+    /// Active graph has no success terminal to append before.
+    #[error("active flow has no success terminal append point")]
+    NoSuccessAppendPoint,
+    /// Generated key violated graph key rules.
+    #[error("invalid generated graph key: {0}")]
+    Key(#[from] KeyParseError),
+    /// Generated graph exhausted the deterministic key range.
+    #[error("generated graph key space exhausted for prefix {prefix}")]
+    KeySpaceExhausted {
+        /// Key prefix that ran out of deterministic slots.
+        prefix: &'static str,
+    },
+    /// Generated graph failed M6 validation.
+    #[error("amended flow failed validation: {0}")]
+    Validation(String),
+    /// TOML serialization failed.
+    #[error("failed to serialize amended flow: {0}")]
+    Serialize(#[from] toml::ser::Error),
+}
+
+/// Insert amendment stages into an active graph before its success terminal.
+///
+/// # Errors
+/// Returns [`FlowAmendmentError`] when no safe append point exists, generated
+/// keys are invalid, validation fails, or TOML serialization fails.
+pub fn amend_active_flow(
+    base: &Graph,
+    patch_result: &RoadmapPatchApplyResult,
+) -> Result<FlowAmendmentResult, FlowAmendmentError> {
+    tracing::debug!(
+        target: "flow_amendment",
+        base_nodes = base.nodes.len(),
+        base_edges = base.edges.len(),
+        inserted_milestones = patch_result.inserted_milestones.len(),
+        inserted_tasks = patch_result.inserted_tasks.len(),
+        replaced_items = patch_result.replaced_items.len(),
+        "active_flow_amendment_start"
+    );
+    let old_graph_hash = graph_content_hash(base)?;
+    let specs = amendment_stage_specs(patch_result)?;
+    let mut graph = base.clone();
+    let append = success_append_point(&graph).ok_or(FlowAmendmentError::NoSuccessAppendPoint)?;
+    let chain = insert_stage_chain(
+        &mut graph,
+        &specs,
+        append.terminal.clone(),
+        &patch_result.markdown,
+    )?;
+    for edge_index in append.incoming_edge_indices {
+        let edge = graph
+            .edges
+            .get_mut(edge_index)
+            .ok_or(FlowAmendmentError::NoSuccessAppendPoint)?;
+        tracing::debug!(
+            target: "flow_amendment",
+            edge_id = %edge.id,
+            from_node = %edge.from.node,
+            from_outcome = %edge.from.outcome,
+            old_target = %append.terminal,
+            new_target = %chain.first,
+            "active_flow_rewire_success_edge"
+        );
+        edge.to = chain.first.clone();
+    }
+    if append.start_is_terminal {
+        tracing::debug!(
+            target: "flow_amendment",
+            old_start = %append.terminal,
+            new_start = %chain.first,
+            "active_flow_rewire_start"
+        );
+        graph.start = chain.first.clone();
+    }
+    let result = finalize_graph(graph, chain.inserted_nodes);
+    match &result {
+        Ok(result) => tracing::info!(
+            target: "flow_amendment",
+            old_graph_hash = %old_graph_hash,
+            new_graph_hash = %result.graph_hash,
+            inserted_nodes = result.inserted_nodes.len(),
+            "active_flow_amendment_succeeded"
+        ),
+        Err(error) => tracing::warn!(
+            target: "flow_amendment",
+            old_graph_hash = %old_graph_hash,
+            error = %error,
+            "active_flow_amendment_rolled_back"
+        ),
+    }
+    result
+}
+
+/// Create a standalone follow-up flow from appended roadmap work.
+///
+/// # Errors
+/// Returns [`FlowAmendmentError`] when generated keys are invalid, validation
+/// fails, or TOML serialization fails.
+pub fn create_follow_up_flow(
+    patch_result: &RoadmapPatchApplyResult,
+    created_at: DateTime<Utc>,
+) -> Result<FlowAmendmentResult, FlowAmendmentError> {
+    tracing::debug!(
+        target: "flow_amendment",
+        inserted_milestones = patch_result.inserted_milestones.len(),
+        inserted_tasks = patch_result.inserted_tasks.len(),
+        replaced_items = patch_result.replaced_items.len(),
+        "follow_up_flow_amendment_start"
+    );
+    let specs = amendment_stage_specs(patch_result)?;
+    let end = NodeKey::try_from(END_NODE)?;
+    let mut graph = Graph {
+        schema_version: SCHEMA_VERSION,
+        metadata: GraphMetadata::new("roadmap-amendment-follow-up", created_at),
+        start: end.clone(),
+        nodes: [(end.clone(), success_terminal(end.clone()))].into(),
+        edges: Vec::new(),
+        subgraphs: Default::default(),
+    };
+    let chain = insert_stage_chain(&mut graph, &specs, end, &patch_result.markdown)?;
+    graph.start = chain.first;
+    let result = finalize_graph(graph, chain.inserted_nodes)?;
+    tracing::info!(
+        target: "flow_amendment",
+        new_graph_hash = %result.graph_hash,
+        inserted_nodes = result.inserted_nodes.len(),
+        "follow_up_flow_amendment_succeeded"
+    );
+    Ok(result)
+}
+
+fn finalize_graph(
+    graph: Graph,
+    inserted_nodes: Vec<NodeKey>,
+) -> Result<FlowAmendmentResult, FlowAmendmentError> {
+    tracing::debug!(
+        target: "flow_amendment",
+        node_count = graph.nodes.len(),
+        edge_count = graph.edges.len(),
+        "flow_amendment_validation_start"
+    );
+    if let Err(error) = validate_for_m6(&graph) {
+        let diagnostic = error.to_string();
+        tracing::warn!(
+            target: "flow_amendment",
+            diagnostic = %diagnostic,
+            "flow_amendment_validation_failed"
+        );
+        return Err(FlowAmendmentError::Validation(diagnostic));
+    }
+    tracing::debug!(
+        target: "flow_amendment",
+        node_count = graph.nodes.len(),
+        edge_count = graph.edges.len(),
+        "flow_amendment_validation_succeeded"
+    );
+    let flow_toml = toml::to_string(&graph)?;
+    let graph_hash = ContentHash::compute(flow_toml.as_bytes());
+    Ok(FlowAmendmentResult {
+        graph,
+        flow_toml,
+        graph_hash,
+        inserted_nodes,
+    })
+}
+
+struct AppendPoint {
+    terminal: NodeKey,
+    incoming_edge_indices: Vec<usize>,
+    start_is_terminal: bool,
+}
+
+struct InsertedChain {
+    first: NodeKey,
+    inserted_nodes: Vec<NodeKey>,
+}
+
+#[derive(Debug, Clone)]
+struct AmendmentStageSpec {
+    label: String,
+}
+
+fn amendment_stage_specs(
+    patch_result: &RoadmapPatchApplyResult,
+) -> Result<Vec<AmendmentStageSpec>, FlowAmendmentError> {
+    let mut specs = Vec::new();
+    specs.extend(
+        patch_result
+            .inserted_milestones
+            .iter()
+            .map(|id| AmendmentStageSpec {
+                label: milestone_label(patch_result, id),
+            }),
+    );
+    specs.extend(
+        patch_result
+            .inserted_tasks
+            .iter()
+            .map(|reference| AmendmentStageSpec {
+                label: task_label(patch_result, reference),
+            }),
+    );
+    specs.extend(
+        patch_result
+            .replaced_items
+            .iter()
+            .map(|reference| AmendmentStageSpec {
+                label: format!("Rework roadmap item {}", item_ref_label(reference)),
+            }),
+    );
+    if specs.is_empty() {
+        return Err(FlowAmendmentError::NoAmendmentItems);
+    }
+    Ok(specs)
+}
+
+fn success_append_point(graph: &Graph) -> Option<AppendPoint> {
+    if is_success_terminal(graph, &graph.start) {
+        return Some(AppendPoint {
+            terminal: graph.start.clone(),
+            incoming_edge_indices: Vec::new(),
+            start_is_terminal: true,
+        });
+    }
+    let mut candidates = graph
+        .nodes
+        .keys()
+        .filter(|node_key| is_success_terminal(graph, node_key))
+        .filter_map(|terminal| {
+            let incoming_edge_indices = graph
+                .edges
+                .iter()
+                .enumerate()
+                .filter_map(|(index, edge)| (&edge.to == terminal).then_some(index))
+                .collect::<Vec<_>>();
+            (!incoming_edge_indices.is_empty()).then(|| AppendPoint {
+                terminal: terminal.clone(),
+                incoming_edge_indices,
+                start_is_terminal: false,
+            })
+        })
+        .collect::<Vec<_>>();
+    if candidates.len() == 1 {
+        candidates.pop()
+    } else {
+        None
+    }
+}
+
+fn is_success_terminal(graph: &Graph, node_key: &NodeKey) -> bool {
+    matches!(
+        graph.nodes.get(node_key).map(|node| &node.config),
+        Some(NodeConfig::Terminal(TerminalConfig {
+            kind: TerminalKind::Success,
+            ..
+        }))
+    )
+}
+
+fn insert_stage_chain(
+    graph: &mut Graph,
+    specs: &[AmendmentStageSpec],
+    tail: NodeKey,
+    roadmap_markdown: &str,
+) -> Result<InsertedChain, FlowAmendmentError> {
+    let mut existing_nodes = graph.nodes.keys().cloned().collect::<BTreeSet<_>>();
+    let mut existing_edges = graph
+        .edges
+        .iter()
+        .map(|edge| edge.id.clone())
+        .collect::<BTreeSet<_>>();
+    let implemented = OutcomeKey::try_from(IMPLEMENTED_OUTCOME)?;
+    let profile = ProfileKey::try_from(IMPLEMENTER_PROFILE)?;
+    let mut node_keys = Vec::with_capacity(specs.len());
+    for (index, spec) in specs.iter().enumerate() {
+        let key = next_node_key(&mut existing_nodes)?;
+        tracing::debug!(
+            target: "flow_amendment",
+            node_id = %key,
+            stage_label = %spec.label,
+            "flow_amendment_insert_node"
+        );
+        graph.nodes.insert(
+            key.clone(),
+            amendment_agent_node(
+                key.clone(),
+                spec,
+                index as f32,
+                roadmap_markdown,
+                &implemented,
+                &profile,
+            ),
+        );
+        node_keys.push(key);
+    }
+    for (index, node) in node_keys.iter().enumerate() {
+        let to = node_keys
+            .get(index + 1)
+            .cloned()
+            .unwrap_or_else(|| tail.clone());
+        let edge_id = next_edge_key(&mut existing_edges)?;
+        tracing::debug!(
+            target: "flow_amendment",
+            edge_id = %edge_id,
+            from_node = %node,
+            from_outcome = %implemented,
+            to_node = %to,
+            "flow_amendment_insert_edge"
+        );
+        graph.edges.push(Edge {
+            id: edge_id,
+            from: PortRef {
+                node: node.clone(),
+                outcome: implemented.clone(),
+            },
+            to,
+            kind: EdgeKind::Forward,
+            policy: EdgePolicy::default(),
+        });
+    }
+    let first = node_keys
+        .first()
+        .cloned()
+        .ok_or(FlowAmendmentError::NoAmendmentItems)?;
+    Ok(InsertedChain {
+        first,
+        inserted_nodes: node_keys,
+    })
+}
+
+fn amendment_agent_node(
+    key: NodeKey,
+    spec: &AmendmentStageSpec,
+    index: f32,
+    roadmap_markdown: &str,
+    implemented: &OutcomeKey,
+    profile: &ProfileKey,
+) -> Node {
+    Node {
+        id: key,
+        position: Position {
+            x: 240.0,
+            y: 160.0 + index * 120.0,
+        },
+        declared_outcomes: vec![OutcomeDecl {
+            id: implemented.clone(),
+            description: "Amendment item completed".into(),
+            edge_kind_hint: EdgeKind::Forward,
+            is_terminal: false,
+        }],
+        config: NodeConfig::Agent(AgentConfig {
+            profile: profile.clone(),
+            prompt_overrides: None,
+            tool_overrides: None,
+            sandbox_override: None,
+            approvals_override: None,
+            bindings: vec![Binding {
+                source: ArtifactSource::Static {
+                    content: amendment_spec_text(&spec.label, roadmap_markdown),
+                },
+                target: TemplateVar(SPEC_TEMPLATE_VAR.into()),
+                optional: false,
+            }],
+            rules_overrides: None,
+            limits: Default::default(),
+            hooks: Vec::new(),
+            custom_fields: Default::default(),
+        }),
+    }
+}
+
+fn success_terminal(key: NodeKey) -> Node {
+    Node {
+        id: key,
+        position: Position { x: 480.0, y: 160.0 },
+        declared_outcomes: Vec::new(),
+        config: NodeConfig::Terminal(TerminalConfig {
+            kind: TerminalKind::Success,
+            message: Some("follow-up roadmap amendment complete".into()),
+        }),
+    }
+}
+
+fn next_node_key(existing: &mut BTreeSet<NodeKey>) -> Result<NodeKey, FlowAmendmentError> {
+    for index in 1..=999 {
+        let key = NodeKey::try_from(format!("amend_{index:03}"))?;
+        if existing.insert(key.clone()) {
+            return Ok(key);
+        }
+    }
+    Err(FlowAmendmentError::KeySpaceExhausted { prefix: "amend" })
+}
+
+fn next_edge_key(existing: &mut BTreeSet<EdgeKey>) -> Result<EdgeKey, FlowAmendmentError> {
+    for index in 1..=999 {
+        let key = EdgeKey::try_from(format!("e_amend_{index:03}"))?;
+        if existing.insert(key.clone()) {
+            return Ok(key);
+        }
+    }
+    Err(FlowAmendmentError::KeySpaceExhausted { prefix: "e_amend" })
+}
+
+fn item_ref_label(reference: &RoadmapItemRef) -> String {
+    match reference {
+        RoadmapItemRef::Milestone { milestone_id } => milestone_id.clone(),
+        RoadmapItemRef::Task {
+            milestone_id,
+            task_id,
+        } => {
+            format!("{milestone_id}/{task_id}")
+        },
+    }
+}
+
+fn milestone_label(patch_result: &RoadmapPatchApplyResult, milestone_id: &str) -> String {
+    let title = patch_result
+        .roadmap
+        .milestones
+        .iter()
+        .find(|milestone| milestone.id == milestone_id)
+        .map(|milestone| milestone.title.as_str());
+    match title {
+        Some(title) => format!("Implement roadmap milestone {milestone_id}: {title}"),
+        None => format!("Implement roadmap milestone {milestone_id}"),
+    }
+}
+
+fn task_label(patch_result: &RoadmapPatchApplyResult, reference: &RoadmapItemRef) -> String {
+    let RoadmapItemRef::Task {
+        milestone_id,
+        task_id,
+    } = reference
+    else {
+        return format!("Implement roadmap item {}", item_ref_label(reference));
+    };
+    let title = patch_result
+        .roadmap
+        .milestones
+        .iter()
+        .find(|milestone| milestone.id == milestone_id.as_str())
+        .and_then(|milestone| {
+            milestone
+                .tasks
+                .iter()
+                .find(|task| task.id == task_id.as_str())
+                .map(|task| task.title.as_str())
+        });
+    match title {
+        Some(title) => format!("Implement roadmap task {milestone_id}/{task_id}: {title}"),
+        None => format!("Implement roadmap task {milestone_id}/{task_id}"),
+    }
+}
+
+fn amendment_spec_text(label: &str, roadmap_markdown: &str) -> String {
+    format!(
+        "# Roadmap Amendment Item\n\n\
+         ## Context\n\
+         This stage was generated from an approved roadmap amendment.\n\n\
+         ## What needs to be done\n\
+         - {label}\n\n\
+         ## Acceptance criteria\n\
+         - Implement the requested roadmap amendment item using existing project patterns.\n\
+         - Preserve completed roadmap history and avoid unrelated refactors.\n\
+         - Run the focused verification that matches the touched code.\n\n\
+         ## Amended roadmap\n\n\
+         {roadmap_markdown}"
+    )
+}
+
+pub(crate) fn graph_content_hash(graph: &Graph) -> Result<ContentHash, toml::ser::Error> {
+    let toml = toml::to_string(graph)?;
+    Ok(ContentHash::compute(toml.as_bytes()))
+}

--- a/crates/surge-orchestrator/src/lib.rs
+++ b/crates/surge-orchestrator/src/lib.rs
@@ -59,6 +59,8 @@ pub mod conflict;
 pub mod context;
 pub mod engine;
 pub mod executor;
+pub mod feature_driver;
+pub mod flow_amendment;
 pub mod gates;
 pub mod parallel;
 pub mod phases;
@@ -70,6 +72,9 @@ pub mod project_context;
 pub mod prompt;
 pub mod qa;
 pub mod retry;
+pub mod roadmap_amendment;
+pub mod roadmap_document;
+pub mod roadmap_target;
 pub mod schedule;
 pub mod triage;
 

--- a/crates/surge-orchestrator/src/roadmap_amendment.rs
+++ b/crates/surge-orchestrator/src/roadmap_amendment.rs
@@ -1,0 +1,1295 @@
+//! Roadmap amendment orchestration helpers.
+//!
+//! This module owns the application-layer glue for storing amendment artifacts
+//! and appending compact lifecycle events. Pure patch modeling stays in
+//! `surge-core`; durable bytes stay in the content-addressed artifact store.
+
+use std::collections::BTreeSet;
+
+use serde::{Deserialize, Serialize};
+use surge_core::ContentHash;
+use surge_core::approvals::{ApprovalChannel, ApprovalChannelKind};
+use surge_core::keys::NodeKey;
+use surge_core::roadmap_patch::{
+    ActivePickupPolicy, InsertionPoint, OperatorConflictChoice, RoadmapItemRef,
+    RoadmapPatchApplyConflict, RoadmapPatchApplyResult, RoadmapPatchApprovalDecision,
+    RoadmapPatchConflict, RoadmapPatchDependency, RoadmapPatchId, RoadmapPatchItem,
+    RoadmapPatchOperation, RoadmapPatchStatus, RoadmapPatchTarget,
+};
+use surge_core::run_event::{EventPayload, VersionedEventPayload};
+use surge_core::{Graph, RoadmapArtifact, RoadmapMilestone, RoadmapPatch, RoadmapStatus, RunId};
+use surge_notify::{
+    NotifyMessage, RoadmapAmendmentNotificationKind, RoadmapAmendmentNotificationPayload,
+};
+use surge_persistence::artifacts::{ArtifactStore, ArtifactStoreError};
+use surge_persistence::runs::{RunWriter, StorageError};
+
+use crate::engine::config::{EngineRunConfig, ProjectContextSeed, RunSeedArtifact};
+use crate::engine::facade::EngineFacade;
+use crate::engine::handle::RunHandle;
+use crate::flow_amendment::{
+    FlowAmendmentError, amend_active_flow, create_follow_up_flow, graph_content_hash,
+};
+
+const ROADMAP_PATCH_ARTIFACT_NAME: &str = "roadmap-patch.toml";
+const AMENDED_ROADMAP_ARTIFACT_NAME: &str = "amended-roadmap.toml";
+const AMENDED_FLOW_ARTIFACT_NAME: &str = "amended-flow.toml";
+const FOLLOW_UP_ROADMAP_ARTIFACT_NAME: &str = "roadmap_amendment";
+const FOLLOW_UP_ROADMAP_ARTIFACT_RELPATH: &str = ".surge/roadmap_amendment.md";
+const FOLLOW_UP_ROADMAP_PRODUCER_NODE: &str = "roadmap_amendment_seed";
+const APPROVE_DECISION: &str = "approve";
+const EDIT_DECISION: &str = "edit";
+const REJECT_DECISION: &str = "reject";
+
+/// Stored artifact refs for an applied roadmap amendment.
+#[derive(Debug, Clone, PartialEq)]
+pub struct StoredAmendmentArtifacts {
+    /// Stored amended roadmap artifact.
+    pub roadmap: surge_core::run_state::ArtifactRef,
+    /// Stored amended flow artifact, when a flow was generated.
+    pub flow: Option<surge_core::run_state::ArtifactRef>,
+}
+
+/// Materialized inputs for starting a follow-up amendment run.
+#[derive(Debug, Clone)]
+pub struct FollowUpRunRequest {
+    /// Newly allocated follow-up run id.
+    pub run_id: RunId,
+    /// Patch that caused the follow-up run.
+    pub patch_id: RoadmapPatchId,
+    /// Target being followed up.
+    pub target: RoadmapPatchTarget,
+    /// Validated follow-up graph.
+    pub graph: Graph,
+    /// Hash of the serialized follow-up graph.
+    pub graph_hash: ContentHash,
+    /// Worktree path for the follow-up run.
+    pub worktree_path: std::path::PathBuf,
+    /// Run config including project context and amendment seed artifacts.
+    pub run_config: EngineRunConfig,
+}
+
+/// Result of applying an approved roadmap patch to an active run boundary.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ActiveRunAmendmentOutcome {
+    /// Run that accepted the amendment.
+    pub run_id: RunId,
+    /// Patch that caused the amendment.
+    pub patch_id: RoadmapPatchId,
+    /// Hash of the graph before applying the amendment.
+    pub previous_graph_hash: ContentHash,
+    /// Hash of the amended graph.
+    pub graph_hash: ContentHash,
+    /// Nodes inserted for amendment work.
+    pub inserted_nodes: Vec<NodeKey>,
+    /// Stored amended roadmap artifact hash.
+    pub roadmap_artifact: ContentHash,
+    /// Stored amended flow artifact hash.
+    pub flow_artifact: ContentHash,
+}
+
+/// Operator-facing prompt data for a roadmap patch approval card.
+#[derive(Debug, Clone, PartialEq)]
+pub struct RoadmapPatchApprovalPrompt {
+    /// Patch being reviewed.
+    pub patch_id: RoadmapPatchId,
+    /// Target roadmap/run being amended.
+    pub target: RoadmapPatchTarget,
+    /// Stable, concise summary for human review.
+    pub summary: String,
+    /// Hash of `summary`, stored in lifecycle events.
+    pub summary_hash: ContentHash,
+    /// JSON response schema mirroring the existing HumanGate response shape.
+    pub schema: serde_json::Value,
+}
+
+/// Operator response to a roadmap patch approval prompt.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RoadmapPatchApprovalResolution {
+    /// Requested lifecycle decision.
+    pub decision: RoadmapPatchApprovalDecision,
+    /// Optional operator comment or edit feedback.
+    pub comment: Option<String>,
+    /// Optional conflict resolution selected by the operator.
+    pub conflict_choice: Option<OperatorConflictChoice>,
+}
+
+/// Next action selected by the roadmap patch approval loop.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RoadmapPatchApprovalAction {
+    /// Patch is approved and can be applied.
+    Apply,
+    /// Patch needs another Feature Planner draft using this feedback.
+    Redraft {
+        /// Operator feedback passed back into Feature Planner.
+        feedback: String,
+        /// 1-based edit attempt count.
+        attempt: u32,
+    },
+    /// Patch is rejected and should not be applied.
+    Rejected,
+}
+
+/// Bounded approval-loop state for one roadmap patch.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RoadmapPatchApprovalLoop {
+    max_edit_rounds: u32,
+    edit_rounds: u32,
+}
+
+impl RoadmapPatchApprovalLoop {
+    /// Create a bounded approval loop. `0` disables the edit-loop cap.
+    #[must_use]
+    pub const fn new(max_edit_rounds: u32) -> Self {
+        Self {
+            max_edit_rounds,
+            edit_rounds: 0,
+        }
+    }
+
+    /// Number of edit decisions already accepted.
+    #[must_use]
+    pub const fn edit_rounds(&self) -> u32 {
+        self.edit_rounds
+    }
+
+    /// Maximum accepted edit decisions before escalation. `0` means unbounded.
+    #[must_use]
+    pub const fn max_edit_rounds(&self) -> u32 {
+        self.max_edit_rounds
+    }
+
+    /// Append an approval-request event and return the prompt payload that a
+    /// CLI, UI, or notification channel can render.
+    ///
+    /// # Errors
+    /// Returns [`RoadmapAmendmentError`] when the event writer fails.
+    pub async fn request_approval(
+        &self,
+        writer: &RunWriter,
+        patch: &RoadmapPatch,
+        channel: ApprovalChannel,
+    ) -> Result<RoadmapPatchApprovalPrompt, RoadmapAmendmentError> {
+        request_patch_approval(writer, patch, channel).await
+    }
+
+    /// Persist an operator decision and translate it to the next loop action.
+    ///
+    /// # Errors
+    /// Returns [`RoadmapAmendmentError`] when the event writer fails, an edit
+    /// response lacks feedback, or the edit-loop cap has been exceeded.
+    pub async fn record_decision(
+        &mut self,
+        writer: &RunWriter,
+        patch_id: &RoadmapPatchId,
+        channel_used: ApprovalChannelKind,
+        resolution: RoadmapPatchApprovalResolution,
+    ) -> Result<RoadmapPatchApprovalAction, RoadmapAmendmentError> {
+        record_patch_approval_decision(writer, patch_id, channel_used, &resolution).await?;
+        match resolution.decision {
+            RoadmapPatchApprovalDecision::Approve => Ok(RoadmapPatchApprovalAction::Apply),
+            RoadmapPatchApprovalDecision::Reject => Ok(RoadmapPatchApprovalAction::Rejected),
+            RoadmapPatchApprovalDecision::Edit => {
+                let feedback = edit_feedback(patch_id, resolution.comment.as_deref())?;
+                self.accept_edit_or_escalate(writer, patch_id, feedback)
+                    .await
+            },
+        }
+    }
+
+    async fn accept_edit_or_escalate(
+        &mut self,
+        writer: &RunWriter,
+        patch_id: &RoadmapPatchId,
+        feedback: String,
+    ) -> Result<RoadmapPatchApprovalAction, RoadmapAmendmentError> {
+        if self.max_edit_rounds > 0 && self.edit_rounds >= self.max_edit_rounds {
+            append_edit_loop_escalation(writer, patch_id, self.max_edit_rounds).await?;
+            tracing::warn!(
+                target: "roadmap_amendment",
+                patch_id = %patch_id,
+                max_edit_rounds = self.max_edit_rounds,
+                "roadmap_patch_approval_edit_loop_exceeded"
+            );
+            return Err(RoadmapAmendmentError::ApprovalLoopExceeded {
+                patch_id: patch_id.clone(),
+                max_edit_rounds: self.max_edit_rounds,
+            });
+        }
+
+        self.edit_rounds += 1;
+        tracing::info!(
+            target: "roadmap_amendment",
+            patch_id = %patch_id,
+            attempt = self.edit_rounds,
+            "roadmap_patch_redraft_requested"
+        );
+        Ok(RoadmapPatchApprovalAction::Redraft {
+            feedback,
+            attempt: self.edit_rounds,
+        })
+    }
+}
+
+/// Errors from roadmap amendment artifact helpers.
+#[derive(Debug, thiserror::Error)]
+pub enum RoadmapAmendmentError {
+    /// Artifact store failed.
+    #[error("artifact store failed: {0}")]
+    ArtifactStore(#[from] ArtifactStoreError),
+    /// Event writer failed.
+    #[error("event writer failed: {0}")]
+    Storage(#[from] StorageError),
+    /// Flow generation failed.
+    #[error("flow amendment failed: {0}")]
+    Flow(#[from] FlowAmendmentError),
+    /// Engine start failed.
+    #[error("engine failed to start follow-up run: {0}")]
+    Engine(#[from] crate::engine::error::EngineError),
+    /// Generated key was not valid.
+    #[error("invalid generated key: {0}")]
+    Key(#[from] surge_core::keys::KeyParseError),
+    /// Active amendment storage did not return an amended flow artifact.
+    #[error("active amendment did not store an amended flow artifact")]
+    MissingActiveFlowArtifact,
+    /// Operator selected edit without useful feedback.
+    #[error("roadmap patch {patch_id} edit decision requires feedback")]
+    MissingEditFeedback {
+        /// Patch that needs feedback.
+        patch_id: RoadmapPatchId,
+    },
+    /// Edit loop exceeded the configured cap.
+    #[error("roadmap patch {patch_id} approval edit-loop exceeded cap {max_edit_rounds}")]
+    ApprovalLoopExceeded {
+        /// Patch whose edit loop exceeded the cap.
+        patch_id: RoadmapPatchId,
+        /// Configured maximum accepted edit rounds.
+        max_edit_rounds: u32,
+    },
+}
+
+/// Build the graph and run configuration for a follow-up amendment run.
+///
+/// # Errors
+/// Returns [`RoadmapAmendmentError`] if follow-up graph generation fails or
+/// the synthetic seed producer key is invalid.
+pub fn build_follow_up_run_request(
+    patch_id: &RoadmapPatchId,
+    target: &RoadmapPatchTarget,
+    patch_result: &RoadmapPatchApplyResult,
+    worktree_path: impl Into<std::path::PathBuf>,
+    project_context: Option<ProjectContextSeed>,
+    created_at: chrono::DateTime<chrono::Utc>,
+) -> Result<FollowUpRunRequest, RoadmapAmendmentError> {
+    let flow = create_follow_up_flow(patch_result, created_at)?;
+    let amendment_seed = RunSeedArtifact::new(
+        FOLLOW_UP_ROADMAP_ARTIFACT_NAME,
+        FOLLOW_UP_ROADMAP_ARTIFACT_RELPATH,
+        follow_up_roadmap_seed_markdown(patch_id, patch_result),
+        FOLLOW_UP_ROADMAP_PRODUCER_NODE,
+    )?;
+    let run_id = RunId::new();
+    let run_config = EngineRunConfig {
+        initial_prompt: format!(
+            "Follow-up roadmap amendment {patch_id}. Use the `{FOLLOW_UP_ROADMAP_ARTIFACT_NAME}` run artifact as the appended work seed."
+        ),
+        project_context,
+        seed_artifacts: vec![amendment_seed],
+        ..EngineRunConfig::default()
+    };
+
+    tracing::info!(
+        target: "roadmap_amendment",
+        patch_id = %patch_id,
+        target = ?target,
+        run_id = %run_id,
+        graph_hash = %flow.graph_hash,
+        "follow_up_run_request_materialized"
+    );
+    Ok(FollowUpRunRequest {
+        run_id,
+        patch_id: patch_id.clone(),
+        target: target.clone(),
+        graph: flow.graph,
+        graph_hash: flow.graph_hash,
+        worktree_path: worktree_path.into(),
+        run_config,
+    })
+}
+
+/// Start a materialized follow-up amendment run through the engine facade.
+///
+/// # Errors
+/// Returns [`RoadmapAmendmentError`] when the engine facade rejects the run.
+#[must_use = "await the follow-up run start and handle failures"]
+pub async fn start_follow_up_run(
+    engine: &dyn EngineFacade,
+    request: FollowUpRunRequest,
+) -> Result<RunHandle, RoadmapAmendmentError> {
+    tracing::info!(
+        target: "roadmap_amendment",
+        patch_id = %request.patch_id,
+        target = ?request.target,
+        run_id = %request.run_id,
+        graph_hash = %request.graph_hash,
+        "follow_up_run_starting"
+    );
+    let handle = engine
+        .start_run(
+            request.run_id,
+            request.graph,
+            request.worktree_path,
+            request.run_config,
+        )
+        .await?;
+    tracing::info!(
+        target: "roadmap_amendment",
+        patch_id = %request.patch_id,
+        run_id = %handle.run_id,
+        "follow_up_run_started"
+    );
+    Ok(handle)
+}
+
+/// Apply an approved patch to an active run's durable log.
+///
+/// The caller supplies the currently active graph. This helper generates the
+/// amended graph, stores roadmap/flow artifacts, and appends both the roadmap
+/// update and graph revision events to the target run writer. The engine task
+/// can then pick up the revision at a safe boundary.
+///
+/// # Errors
+/// Returns [`RoadmapAmendmentError`] when graph amendment, artifact storage, or
+/// event appends fail.
+#[must_use = "await active run amendment application and handle failures"]
+pub async fn apply_active_run_patch(
+    artifact_store: &ArtifactStore,
+    writer: &RunWriter,
+    run_id: RunId,
+    active_graph: &Graph,
+    patch_id: &RoadmapPatchId,
+    target: &RoadmapPatchTarget,
+    patch_result: &RoadmapPatchApplyResult,
+) -> Result<ActiveRunAmendmentOutcome, RoadmapAmendmentError> {
+    let previous_graph_hash = graph_content_hash(active_graph).map_err(FlowAmendmentError::from)?;
+    let amendment = amend_active_flow(active_graph, patch_result)?;
+    let artifacts = store_applied_artifacts(
+        artifact_store,
+        writer,
+        run_id,
+        patch_id,
+        target,
+        patch_result.markdown.as_bytes(),
+        Some(amendment.flow_toml.as_bytes()),
+    )
+    .await?;
+    record_roadmap_updated(
+        writer,
+        patch_id,
+        target,
+        &artifacts,
+        ActivePickupPolicy::Allowed,
+    )
+    .await?;
+    record_graph_revision_accepted(
+        writer,
+        patch_id,
+        target,
+        previous_graph_hash,
+        &amendment.graph,
+        amendment.graph_hash,
+        ActivePickupPolicy::Allowed,
+    )
+    .await?;
+
+    let Some(flow_artifact) = artifacts.flow.as_ref().map(|artifact| artifact.hash) else {
+        return Err(RoadmapAmendmentError::MissingActiveFlowArtifact);
+    };
+
+    tracing::info!(
+        target: "roadmap_amendment",
+        run_id = %run_id,
+        patch_id = %patch_id,
+        previous_graph_hash = %previous_graph_hash,
+        graph_hash = %amendment.graph_hash,
+        inserted_nodes = amendment.inserted_nodes.len(),
+        "active_run_roadmap_patch_applied"
+    );
+    Ok(ActiveRunAmendmentOutcome {
+        run_id,
+        patch_id: patch_id.clone(),
+        previous_graph_hash,
+        graph_hash: amendment.graph_hash,
+        inserted_nodes: amendment.inserted_nodes,
+        roadmap_artifact: artifacts.roadmap.hash,
+        flow_artifact,
+    })
+}
+
+/// Convert apply-time conflicts into operator-facing patch conflicts.
+#[must_use]
+pub fn apply_conflicts_as_patch_conflicts(
+    conflicts: &[RoadmapPatchApplyConflict],
+) -> Vec<RoadmapPatchConflict> {
+    conflicts
+        .iter()
+        .map(RoadmapPatchApplyConflict::to_patch_conflict)
+        .collect()
+}
+
+/// Build a standalone follow-up roadmap result directly from patch operations.
+///
+/// This is used when an operator resolves a running/completed-roadmap conflict
+/// by choosing a follow-up run. The original roadmap is intentionally not
+/// mutated; the follow-up seed contains only the new or replacement work.
+#[must_use]
+pub fn follow_up_result_from_patch(patch: &RoadmapPatch) -> RoadmapPatchApplyResult {
+    let mut roadmap = RoadmapArtifact::default();
+    let mut used_milestone_ids = BTreeSet::new();
+    let mut inserted_milestones = Vec::new();
+    let mut inserted_tasks = Vec::new();
+    let mut replaced_items = Vec::new();
+
+    for operation in &patch.operations {
+        match operation {
+            RoadmapPatchOperation::AddMilestone { milestone, .. } => {
+                let mut milestone = pending_follow_up_milestone(milestone);
+                milestone.id = unique_id(&milestone.id, &mut used_milestone_ids);
+                inserted_milestones.push(milestone.id.clone());
+                roadmap.milestones.push(milestone);
+            },
+            RoadmapPatchOperation::AddTask {
+                milestone_id, task, ..
+            } => {
+                let synthetic_id = unique_id(
+                    &format!("{milestone_id}-follow-up"),
+                    &mut used_milestone_ids,
+                );
+                let mut milestone = RoadmapMilestone::new(
+                    synthetic_id.clone(),
+                    format!("Follow-up for {milestone_id}"),
+                );
+                let mut task = task.clone();
+                task.status = RoadmapStatus::Pending;
+                let task_id = task.id.clone();
+                milestone.tasks.push(task);
+                inserted_milestones.push(synthetic_id.clone());
+                inserted_tasks.push(RoadmapItemRef::Task {
+                    milestone_id: synthetic_id,
+                    task_id,
+                });
+                roadmap.milestones.push(milestone);
+            },
+            RoadmapPatchOperation::ReplaceDraftItem {
+                target,
+                replacement,
+                ..
+            } => {
+                replaced_items.push(target.clone());
+                match replacement {
+                    RoadmapPatchItem::Milestone { milestone } => {
+                        let mut milestone = pending_follow_up_milestone(milestone);
+                        milestone.id = unique_id(&milestone.id, &mut used_milestone_ids);
+                        inserted_milestones.push(milestone.id.clone());
+                        roadmap.milestones.push(milestone);
+                    },
+                    RoadmapPatchItem::Task { task } => {
+                        let milestone_seed = match target {
+                            RoadmapItemRef::Milestone { milestone_id }
+                            | RoadmapItemRef::Task { milestone_id, .. } => milestone_id,
+                        };
+                        let synthetic_id = unique_id(
+                            &format!("{milestone_seed}-follow-up"),
+                            &mut used_milestone_ids,
+                        );
+                        let mut milestone = RoadmapMilestone::new(
+                            synthetic_id.clone(),
+                            format!("Follow-up rework for {milestone_seed}"),
+                        );
+                        let mut task = task.clone();
+                        task.status = RoadmapStatus::Pending;
+                        let task_id = task.id.clone();
+                        milestone.tasks.push(task);
+                        inserted_milestones.push(synthetic_id.clone());
+                        inserted_tasks.push(RoadmapItemRef::Task {
+                            milestone_id: synthetic_id,
+                            task_id,
+                        });
+                        roadmap.milestones.push(milestone);
+                    },
+                }
+            },
+        }
+    }
+
+    RoadmapPatchApplyResult {
+        markdown: roadmap.to_markdown(),
+        roadmap,
+        inserted_milestones,
+        inserted_tasks,
+        replaced_items,
+        dependencies_added: Vec::new(),
+    }
+}
+
+/// Build a notification message for a patch approval request.
+#[must_use]
+pub fn patch_approval_requested_notification(prompt: &RoadmapPatchApprovalPrompt) -> NotifyMessage {
+    NotifyMessage::RoadmapAmendment(Box::new(RoadmapAmendmentNotificationPayload {
+        kind: RoadmapAmendmentNotificationKind::ApprovalRequested,
+        patch_id: prompt.patch_id.clone(),
+        target: prompt.target.clone(),
+        run_id: target_run_id(&prompt.target),
+        follow_up_run_id: None,
+        status: Some(RoadmapPatchStatus::PendingApproval),
+        summary: "Roadmap patch needs approval".into(),
+        detail: Some(prompt.summary.clone()),
+        conflict_codes: Vec::new(),
+        conflict_choices: Vec::new(),
+        artifact_paths: Vec::new(),
+    }))
+}
+
+/// Build a notification message for a successfully applied patch.
+#[must_use]
+pub fn patch_applied_notification(
+    patch_id: &RoadmapPatchId,
+    target: &RoadmapPatchTarget,
+    artifacts: &StoredAmendmentArtifacts,
+) -> NotifyMessage {
+    NotifyMessage::RoadmapAmendment(Box::new(RoadmapAmendmentNotificationPayload {
+        kind: RoadmapAmendmentNotificationKind::PatchApplied,
+        patch_id: patch_id.clone(),
+        target: target.clone(),
+        run_id: target_run_id(target),
+        follow_up_run_id: None,
+        status: Some(RoadmapPatchStatus::Applied),
+        summary: "Roadmap patch applied".into(),
+        detail: None,
+        conflict_codes: Vec::new(),
+        conflict_choices: Vec::new(),
+        artifact_paths: applied_artifact_paths(artifacts),
+    }))
+}
+
+/// Build a notification message when an active runner sees an amendment.
+#[must_use]
+pub fn runner_pickup_notification(
+    patch_id: &RoadmapPatchId,
+    target: &RoadmapPatchTarget,
+    active_pickup: ActivePickupPolicy,
+) -> NotifyMessage {
+    NotifyMessage::RoadmapAmendment(Box::new(RoadmapAmendmentNotificationPayload {
+        kind: RoadmapAmendmentNotificationKind::RunnerPickup,
+        patch_id: patch_id.clone(),
+        target: target.clone(),
+        run_id: target_run_id(target),
+        follow_up_run_id: None,
+        status: Some(RoadmapPatchStatus::Applied),
+        summary: "Runner observed roadmap amendment".into(),
+        detail: Some(format!("active_pickup={}", pickup_label(active_pickup))),
+        conflict_codes: Vec::new(),
+        conflict_choices: Vec::new(),
+        artifact_paths: Vec::new(),
+    }))
+}
+
+/// Build a notification message for a materialized follow-up run.
+#[must_use]
+pub fn follow_up_run_created_notification(request: &FollowUpRunRequest) -> NotifyMessage {
+    NotifyMessage::RoadmapAmendment(Box::new(RoadmapAmendmentNotificationPayload {
+        kind: RoadmapAmendmentNotificationKind::FollowUpRunCreated,
+        patch_id: request.patch_id.clone(),
+        target: request.target.clone(),
+        run_id: target_run_id(&request.target),
+        follow_up_run_id: Some(request.run_id),
+        status: Some(RoadmapPatchStatus::Approved),
+        summary: "Follow-up run created for roadmap amendment".into(),
+        detail: Some(format!("graph_hash={}", request.graph_hash)),
+        conflict_codes: Vec::new(),
+        conflict_choices: Vec::new(),
+        artifact_paths: request
+            .run_config
+            .seed_artifacts
+            .iter()
+            .map(|seed| seed.relative_path.clone())
+            .collect(),
+    }))
+}
+
+/// Build a notification message for conflicts requiring operator choice.
+#[must_use]
+pub fn patch_conflict_notification(
+    patch_id: &RoadmapPatchId,
+    target: &RoadmapPatchTarget,
+    conflicts: &[RoadmapPatchConflict],
+) -> NotifyMessage {
+    let mut choices = Vec::new();
+    for conflict in conflicts {
+        choices.extend(conflict.choices.iter().copied());
+    }
+    choices.sort_by_key(|choice| conflict_choice_label(*choice));
+    choices.dedup();
+    NotifyMessage::RoadmapAmendment(Box::new(RoadmapAmendmentNotificationPayload {
+        kind: RoadmapAmendmentNotificationKind::ConflictDetected,
+        patch_id: patch_id.clone(),
+        target: target.clone(),
+        run_id: target_run_id(target),
+        follow_up_run_id: None,
+        status: None,
+        summary: "Roadmap patch has conflicts".into(),
+        detail: Some(
+            conflicts
+                .iter()
+                .map(|conflict| conflict.message.as_str())
+                .collect::<Vec<_>>()
+                .join("\n"),
+        ),
+        conflict_codes: conflicts
+            .iter()
+            .map(|conflict| format!("{:?}", conflict.code))
+            .collect(),
+        conflict_choices: choices,
+        artifact_paths: Vec::new(),
+    }))
+}
+
+/// Build a notification message for a rejected patch.
+#[must_use]
+pub fn patch_rejected_notification(
+    patch_id: &RoadmapPatchId,
+    target: &RoadmapPatchTarget,
+    comment: Option<&str>,
+) -> NotifyMessage {
+    NotifyMessage::RoadmapAmendment(Box::new(RoadmapAmendmentNotificationPayload {
+        kind: RoadmapAmendmentNotificationKind::PatchRejected,
+        patch_id: patch_id.clone(),
+        target: target.clone(),
+        run_id: target_run_id(target),
+        follow_up_run_id: None,
+        status: Some(RoadmapPatchStatus::Rejected),
+        summary: "Roadmap patch rejected".into(),
+        detail: comment.map(str::to_owned),
+        conflict_codes: Vec::new(),
+        conflict_choices: Vec::new(),
+        artifact_paths: Vec::new(),
+    }))
+}
+
+/// Store a drafted roadmap patch and append `RoadmapPatchDrafted`.
+///
+/// # Errors
+/// Returns [`RoadmapAmendmentError`] when artifact storage or event append
+/// fails.
+#[must_use = "await the store operation and handle failures"]
+pub async fn store_patch_draft(
+    artifact_store: &ArtifactStore,
+    writer: &RunWriter,
+    run_id: RunId,
+    patch: &RoadmapPatch,
+    patch_bytes: &[u8],
+) -> Result<surge_core::run_state::ArtifactRef, RoadmapAmendmentError> {
+    let artifact = artifact_store
+        .put(run_id, ROADMAP_PATCH_ARTIFACT_NAME, patch_bytes)
+        .await?;
+    tracing::info!(
+        target: "roadmap_amendment",
+        run_id = %run_id,
+        patch_id = %patch.id,
+        hash = %artifact.hash,
+        path = %artifact.path.display(),
+        "roadmap_patch_stored"
+    );
+    writer
+        .append_event(VersionedEventPayload::new(
+            EventPayload::RoadmapPatchDrafted {
+                patch_id: patch.id.clone(),
+                target: patch.target.clone(),
+                patch_artifact: artifact.hash,
+                patch_path: artifact.path.clone(),
+            },
+        ))
+        .await?;
+    Ok(artifact)
+}
+
+/// Store amended roadmap/flow artifacts and append `RoadmapPatchApplied`.
+///
+/// # Errors
+/// Returns [`RoadmapAmendmentError`] when artifact storage or event append
+/// fails.
+#[must_use = "await the store operation and handle failures"]
+pub async fn store_applied_artifacts(
+    artifact_store: &ArtifactStore,
+    writer: &RunWriter,
+    run_id: RunId,
+    patch_id: &RoadmapPatchId,
+    target: &RoadmapPatchTarget,
+    roadmap_bytes: &[u8],
+    flow_bytes: Option<&[u8]>,
+) -> Result<StoredAmendmentArtifacts, RoadmapAmendmentError> {
+    let roadmap = artifact_store
+        .put(run_id, AMENDED_ROADMAP_ARTIFACT_NAME, roadmap_bytes)
+        .await?;
+    let flow = match flow_bytes {
+        Some(bytes) => Some(
+            artifact_store
+                .put(run_id, AMENDED_FLOW_ARTIFACT_NAME, bytes)
+                .await?,
+        ),
+        None => None,
+    };
+    tracing::info!(
+        target: "roadmap_amendment",
+        run_id = %run_id,
+        patch_id = %patch_id,
+        roadmap_hash = %roadmap.hash,
+        flow_hash = flow.as_ref().map(|artifact| artifact.hash.to_string()).as_deref(),
+        "roadmap_amendment_artifacts_stored"
+    );
+    writer
+        .append_event(VersionedEventPayload::new(
+            EventPayload::RoadmapPatchApplied {
+                patch_id: patch_id.clone(),
+                target: target.clone(),
+                amended_roadmap_artifact: roadmap.hash,
+                amended_roadmap_path: roadmap.path.clone(),
+                amended_flow_artifact: flow.as_ref().map(|artifact| artifact.hash),
+                amended_flow_path: flow.as_ref().map(|artifact| artifact.path.clone()),
+            },
+        ))
+        .await?;
+    Ok(StoredAmendmentArtifacts { roadmap, flow })
+}
+
+/// Append `RoadmapUpdated` after an amended roadmap/flow has become visible.
+///
+/// # Errors
+/// Returns [`RoadmapAmendmentError`] when the event append fails.
+#[must_use = "await the update record and handle failures"]
+pub async fn record_roadmap_updated(
+    writer: &RunWriter,
+    patch_id: &RoadmapPatchId,
+    target: &RoadmapPatchTarget,
+    artifacts: &StoredAmendmentArtifacts,
+    active_pickup: ActivePickupPolicy,
+) -> Result<(), RoadmapAmendmentError> {
+    writer
+        .append_event(VersionedEventPayload::new(EventPayload::RoadmapUpdated {
+            patch_id: patch_id.clone(),
+            target: target.clone(),
+            roadmap_artifact: artifacts.roadmap.hash,
+            roadmap_path: artifacts.roadmap.path.clone(),
+            flow_artifact: artifacts.flow.as_ref().map(|artifact| artifact.hash),
+            flow_path: artifacts
+                .flow
+                .as_ref()
+                .map(|artifact| artifact.path.clone()),
+            active_pickup,
+        }))
+        .await?;
+    Ok(())
+}
+
+/// Append `GraphRevisionAccepted` for an active amendment graph update.
+///
+/// # Errors
+/// Returns [`RoadmapAmendmentError`] when the event append fails.
+#[must_use = "await the graph revision record and handle failures"]
+pub async fn record_graph_revision_accepted(
+    writer: &RunWriter,
+    patch_id: &RoadmapPatchId,
+    target: &RoadmapPatchTarget,
+    previous_graph_hash: ContentHash,
+    graph: &Graph,
+    graph_hash: ContentHash,
+    active_pickup: ActivePickupPolicy,
+) -> Result<(), RoadmapAmendmentError> {
+    tracing::info!(
+        target: "roadmap_amendment",
+        patch_id = %patch_id,
+        previous_graph_hash = %previous_graph_hash,
+        graph_hash = %graph_hash,
+        active_pickup = ?active_pickup,
+        "graph_revision_accepted"
+    );
+    writer
+        .append_event(VersionedEventPayload::new(
+            EventPayload::GraphRevisionAccepted {
+                patch_id: patch_id.clone(),
+                target: target.clone(),
+                previous_graph_hash,
+                graph: Box::new(graph.clone()),
+                graph_hash,
+                active_pickup,
+            },
+        ))
+        .await?;
+    Ok(())
+}
+
+/// Append `RoadmapPatchApprovalRequested` and return a renderable prompt.
+///
+/// # Errors
+/// Returns [`RoadmapAmendmentError`] when the event append fails.
+pub async fn request_patch_approval(
+    writer: &RunWriter,
+    patch: &RoadmapPatch,
+    channel: ApprovalChannel,
+) -> Result<RoadmapPatchApprovalPrompt, RoadmapAmendmentError> {
+    let summary = render_patch_approval_summary(patch);
+    let summary_hash = ContentHash::compute(summary.as_bytes());
+    tracing::info!(
+        target: "roadmap_amendment",
+        patch_id = %patch.id,
+        channel = channel.kind().as_str(),
+        summary_hash = %summary_hash,
+        "roadmap_patch_approval_requested"
+    );
+    writer
+        .append_event(VersionedEventPayload::new(
+            EventPayload::RoadmapPatchApprovalRequested {
+                patch_id: patch.id.clone(),
+                target: patch.target.clone(),
+                channel,
+                summary_hash,
+            },
+        ))
+        .await?;
+    Ok(RoadmapPatchApprovalPrompt {
+        patch_id: patch.id.clone(),
+        target: patch.target.clone(),
+        summary,
+        summary_hash,
+        schema: approval_response_schema(),
+    })
+}
+
+/// Append `RoadmapPatchApprovalDecided`.
+///
+/// # Errors
+/// Returns [`RoadmapAmendmentError`] when the event append fails.
+pub async fn record_patch_approval_decision(
+    writer: &RunWriter,
+    patch_id: &RoadmapPatchId,
+    channel_used: ApprovalChannelKind,
+    resolution: &RoadmapPatchApprovalResolution,
+) -> Result<(), RoadmapAmendmentError> {
+    tracing::info!(
+        target: "roadmap_amendment",
+        patch_id = %patch_id,
+        decision = approval_decision_label(resolution.decision),
+        channel = channel_used.as_str(),
+        conflict_choice = resolution.conflict_choice.map(conflict_choice_label),
+        "roadmap_patch_approval_decided"
+    );
+    writer
+        .append_event(VersionedEventPayload::new(
+            EventPayload::RoadmapPatchApprovalDecided {
+                patch_id: patch_id.clone(),
+                decision: resolution.decision,
+                channel_used,
+                comment: resolution.comment.clone(),
+                conflict_choice: resolution.conflict_choice,
+            },
+        ))
+        .await?;
+    Ok(())
+}
+
+/// Render a concise operator-facing approval summary.
+#[must_use]
+pub fn render_patch_approval_summary(patch: &RoadmapPatch) -> String {
+    let mut summary = String::new();
+    summary.push_str(&format!("Roadmap patch: {}\n", patch.id));
+    summary.push_str(&format!("Target: {}\n", target_label(&patch.target)));
+    if !patch.rationale.trim().is_empty() {
+        summary.push_str(&format!("Rationale: {}\n", patch.rationale.trim()));
+    }
+    push_operations_summary(&mut summary, &patch.operations);
+    push_dependencies_summary(&mut summary, &patch.dependencies);
+    push_conflicts_summary(&mut summary, &patch.conflicts);
+    summary
+}
+
+fn approval_response_schema() -> serde_json::Value {
+    serde_json::json!({
+        "type": "object",
+        "properties": {
+            "decision": {
+                "type": "string",
+                "enum": [APPROVE_DECISION, EDIT_DECISION, REJECT_DECISION],
+            },
+            "comment": { "type": "string" },
+            "conflict_choice": {
+                "type": "string",
+                "enum": [
+                    "defer_to_next_milestone",
+                    "abort_current_run",
+                    "create_follow_up_run",
+                    "reject_patch",
+                ],
+            },
+        },
+        "required": ["decision"],
+    })
+}
+
+fn edit_feedback(
+    patch_id: &RoadmapPatchId,
+    comment: Option<&str>,
+) -> Result<String, RoadmapAmendmentError> {
+    let feedback = comment.map(str::trim).filter(|value| !value.is_empty());
+    match feedback {
+        Some(value) => Ok(value.to_owned()),
+        None => Err(RoadmapAmendmentError::MissingEditFeedback {
+            patch_id: patch_id.clone(),
+        }),
+    }
+}
+
+async fn append_edit_loop_escalation(
+    writer: &RunWriter,
+    patch_id: &RoadmapPatchId,
+    max_edit_rounds: u32,
+) -> Result<(), RoadmapAmendmentError> {
+    let reason = format!(
+        "roadmap patch approval edit-loop exceeded for {patch_id} (cap = {max_edit_rounds})"
+    );
+    writer
+        .append_event(VersionedEventPayload::new(
+            EventPayload::EscalationRequested {
+                stage: None,
+                reason,
+            },
+        ))
+        .await?;
+    Ok(())
+}
+
+fn push_operations_summary(summary: &mut String, operations: &[RoadmapPatchOperation]) {
+    if operations.is_empty() {
+        summary.push_str("Operations: none\n");
+        return;
+    }
+    summary.push_str("Operations:\n");
+    for operation in operations {
+        summary.push_str("- ");
+        summary.push_str(&operation_label(operation));
+        summary.push('\n');
+    }
+}
+
+fn push_dependencies_summary(summary: &mut String, dependencies: &[RoadmapPatchDependency]) {
+    if dependencies.is_empty() {
+        return;
+    }
+    summary.push_str("Dependencies:\n");
+    for dependency in dependencies {
+        summary.push_str("- ");
+        summary.push_str(&dependency_label(dependency));
+        summary.push('\n');
+    }
+}
+
+fn push_conflicts_summary(summary: &mut String, conflicts: &[RoadmapPatchConflict]) {
+    if conflicts.is_empty() {
+        return;
+    }
+    summary.push_str("Conflicts:\n");
+    for conflict in conflicts {
+        summary.push_str("- ");
+        summary.push_str(&format!("{:?}: {}", conflict.code, conflict.message));
+        if !conflict.choices.is_empty() {
+            let choices = conflict
+                .choices
+                .iter()
+                .map(|choice| conflict_choice_label(*choice))
+                .collect::<Vec<_>>()
+                .join(", ");
+            summary.push_str(&format!(" (choices: {choices})"));
+        }
+        summary.push('\n');
+    }
+}
+
+fn target_run_id(target: &RoadmapPatchTarget) -> Option<RunId> {
+    match target {
+        RoadmapPatchTarget::ProjectRoadmap { .. } => None,
+        RoadmapPatchTarget::RunRoadmap { run_id, .. } => Some(*run_id),
+    }
+}
+
+fn applied_artifact_paths(artifacts: &StoredAmendmentArtifacts) -> Vec<std::path::PathBuf> {
+    let mut paths = vec![artifacts.roadmap.path.clone()];
+    if let Some(flow) = &artifacts.flow {
+        paths.push(flow.path.clone());
+    }
+    paths
+}
+
+fn pending_follow_up_milestone(milestone: &RoadmapMilestone) -> RoadmapMilestone {
+    let mut milestone = milestone.clone();
+    milestone.status = RoadmapStatus::Pending;
+    for task in &mut milestone.tasks {
+        task.status = RoadmapStatus::Pending;
+    }
+    milestone
+}
+
+fn unique_id(base: &str, used: &mut BTreeSet<String>) -> String {
+    let base = if base.trim().is_empty() {
+        "follow-up".to_owned()
+    } else {
+        base.to_owned()
+    };
+    if used.insert(base.clone()) {
+        return base;
+    }
+
+    let mut suffix = 2_u32;
+    loop {
+        let candidate = format!("{base}-{suffix}");
+        if used.insert(candidate.clone()) {
+            return candidate;
+        }
+        suffix += 1;
+    }
+}
+
+fn follow_up_roadmap_seed_markdown(
+    patch_id: &RoadmapPatchId,
+    patch_result: &RoadmapPatchApplyResult,
+) -> String {
+    let mut out = String::new();
+    out.push_str("# Follow-up Roadmap Amendment\n\n");
+    out.push_str(&format!("Patch: {patch_id}\n\n"));
+
+    if !patch_result.inserted_milestones.is_empty() {
+        out.push_str("## Inserted milestones\n");
+        for milestone_id in &patch_result.inserted_milestones {
+            let title = patch_result
+                .roadmap
+                .milestones
+                .iter()
+                .find(|milestone| milestone.id == milestone_id.as_str())
+                .map(|milestone| milestone.title.as_str())
+                .unwrap_or("");
+            if title.is_empty() {
+                out.push_str(&format!("- {milestone_id}\n"));
+            } else {
+                out.push_str(&format!("- {milestone_id}: {title}\n"));
+            }
+        }
+        out.push('\n');
+    }
+
+    if !patch_result.inserted_tasks.is_empty() {
+        out.push_str("## Inserted tasks\n");
+        for task_ref in &patch_result.inserted_tasks {
+            out.push_str("- ");
+            out.push_str(&task_seed_label(patch_result, task_ref));
+            out.push('\n');
+        }
+        out.push('\n');
+    }
+
+    if !patch_result.replaced_items.is_empty() {
+        out.push_str("## Reworked draft items\n");
+        for item in &patch_result.replaced_items {
+            out.push_str("- ");
+            out.push_str(&item_ref_label(item));
+            out.push('\n');
+        }
+        out.push('\n');
+    }
+
+    out.push_str("## Amended roadmap\n\n");
+    out.push_str(&patch_result.markdown);
+    out
+}
+
+fn task_seed_label(patch_result: &RoadmapPatchApplyResult, task_ref: &RoadmapItemRef) -> String {
+    let RoadmapItemRef::Task {
+        milestone_id,
+        task_id,
+    } = task_ref
+    else {
+        return item_ref_label(task_ref);
+    };
+    let title = patch_result
+        .roadmap
+        .milestones
+        .iter()
+        .find(|milestone| milestone.id == milestone_id.as_str())
+        .and_then(|milestone| {
+            milestone
+                .tasks
+                .iter()
+                .find(|task| task.id == task_id.as_str())
+                .map(|task| task.title.as_str())
+        })
+        .unwrap_or("");
+    if title.is_empty() {
+        format!("{milestone_id}/{task_id}")
+    } else {
+        format!("{milestone_id}/{task_id}: {title}")
+    }
+}
+
+fn operation_label(operation: &RoadmapPatchOperation) -> String {
+    match operation {
+        RoadmapPatchOperation::AddMilestone {
+            milestone,
+            insertion,
+        } => format!(
+            "add milestone {} ({}) at {}",
+            milestone.id,
+            milestone.title,
+            insertion_label(insertion.as_ref())
+        ),
+        RoadmapPatchOperation::AddTask {
+            milestone_id,
+            task,
+            insertion,
+        } => format!(
+            "add task {} ({}) to milestone {} at {}",
+            task.id,
+            task.title,
+            milestone_id,
+            insertion_label(insertion.as_ref())
+        ),
+        RoadmapPatchOperation::ReplaceDraftItem {
+            target,
+            replacement,
+            reason,
+        } => {
+            let reason = reason.trim();
+            if reason.is_empty() {
+                format!(
+                    "replace draft {} with {}",
+                    item_ref_label(target),
+                    replacement_label(replacement)
+                )
+            } else {
+                format!(
+                    "replace draft {} with {} because {}",
+                    item_ref_label(target),
+                    replacement_label(replacement),
+                    reason
+                )
+            }
+        },
+    }
+}
+
+fn dependency_label(dependency: &RoadmapPatchDependency) -> String {
+    let reason = dependency.reason.trim();
+    if reason.is_empty() {
+        format!(
+            "{} -> {}",
+            item_ref_label(&dependency.from),
+            item_ref_label(&dependency.to)
+        )
+    } else {
+        format!(
+            "{} -> {} because {}",
+            item_ref_label(&dependency.from),
+            item_ref_label(&dependency.to),
+            reason
+        )
+    }
+}
+
+fn target_label(target: &RoadmapPatchTarget) -> String {
+    match target {
+        RoadmapPatchTarget::ProjectRoadmap { roadmap_path } => {
+            format!("project roadmap {roadmap_path}")
+        },
+        RoadmapPatchTarget::RunRoadmap {
+            run_id,
+            roadmap_artifact,
+            flow_artifact,
+            active_pickup,
+        } => format!(
+            "run {run_id} roadmap={:?} flow={:?} pickup={}",
+            roadmap_artifact,
+            flow_artifact,
+            pickup_label(*active_pickup)
+        ),
+    }
+}
+
+fn insertion_label(insertion: Option<&InsertionPoint>) -> String {
+    match insertion {
+        Some(InsertionPoint::AppendToRoadmap) => "append to roadmap".to_owned(),
+        Some(InsertionPoint::BeforeMilestone { milestone_id }) => {
+            format!("before milestone {milestone_id}")
+        },
+        Some(InsertionPoint::AfterMilestone { milestone_id }) => {
+            format!("after milestone {milestone_id}")
+        },
+        Some(InsertionPoint::AppendToMilestone { milestone_id }) => {
+            format!("append to milestone {milestone_id}")
+        },
+        Some(InsertionPoint::BeforeTask {
+            milestone_id,
+            task_id,
+        }) => {
+            format!("before task {milestone_id}/{task_id}")
+        },
+        Some(InsertionPoint::AfterTask {
+            milestone_id,
+            task_id,
+        }) => {
+            format!("after task {milestone_id}/{task_id}")
+        },
+        None => "unspecified".to_owned(),
+    }
+}
+
+fn item_ref_label(reference: &RoadmapItemRef) -> String {
+    match reference {
+        RoadmapItemRef::Milestone { milestone_id } => format!("milestone {milestone_id}"),
+        RoadmapItemRef::Task {
+            milestone_id,
+            task_id,
+        } => {
+            format!("task {milestone_id}/{task_id}")
+        },
+    }
+}
+
+fn replacement_label(replacement: &RoadmapPatchItem) -> String {
+    match replacement {
+        RoadmapPatchItem::Milestone { milestone } => {
+            format!("milestone {} ({})", milestone.id, milestone.title)
+        },
+        RoadmapPatchItem::Task { task } => format!("task {} ({})", task.id, task.title),
+    }
+}
+
+const fn approval_decision_label(decision: RoadmapPatchApprovalDecision) -> &'static str {
+    match decision {
+        RoadmapPatchApprovalDecision::Approve => APPROVE_DECISION,
+        RoadmapPatchApprovalDecision::Edit => EDIT_DECISION,
+        RoadmapPatchApprovalDecision::Reject => REJECT_DECISION,
+    }
+}
+
+const fn conflict_choice_label(choice: OperatorConflictChoice) -> &'static str {
+    match choice {
+        OperatorConflictChoice::DeferToNextMilestone => "defer_to_next_milestone",
+        OperatorConflictChoice::AbortCurrentRun => "abort_current_run",
+        OperatorConflictChoice::CreateFollowUpRun => "create_follow_up_run",
+        OperatorConflictChoice::RejectPatch => "reject_patch",
+    }
+}
+
+const fn pickup_label(policy: ActivePickupPolicy) -> &'static str {
+    match policy {
+        ActivePickupPolicy::Allowed => "allowed",
+        ActivePickupPolicy::FollowUpOnly => "follow_up_only",
+        ActivePickupPolicy::Disabled => "disabled",
+    }
+}

--- a/crates/surge-orchestrator/src/roadmap_amendment.rs
+++ b/crates/surge-orchestrator/src/roadmap_amendment.rs
@@ -383,6 +383,9 @@ pub async fn apply_active_run_patch(
         Some(amendment.flow_toml.as_bytes()),
     )
     .await?;
+    let Some(flow_artifact) = artifacts.flow.as_ref().map(|artifact| artifact.hash) else {
+        return Err(RoadmapAmendmentError::MissingActiveFlowArtifact);
+    };
     record_roadmap_updated(
         writer,
         patch_id,
@@ -401,10 +404,6 @@ pub async fn apply_active_run_patch(
         ActivePickupPolicy::Allowed,
     )
     .await?;
-
-    let Some(flow_artifact) = artifacts.flow.as_ref().map(|artifact| artifact.hash) else {
-        return Err(RoadmapAmendmentError::MissingActiveFlowArtifact);
-    };
 
     tracing::info!(
         target: "roadmap_amendment",

--- a/crates/surge-orchestrator/src/roadmap_document.rs
+++ b/crates/surge-orchestrator/src/roadmap_document.rs
@@ -1,0 +1,542 @@
+//! Roadmap document parsing and rendering.
+//!
+//! Roadmap planning works with structured [`RoadmapArtifact`] values, while
+//! users usually edit `.ai-factory/ROADMAP.md`. This module is the boundary
+//! between those formats so command code does not need to guess whether a
+//! roadmap is TOML or Markdown.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::Path;
+
+use surge_core::roadmap::{RoadmapArtifact, RoadmapMilestone, RoadmapStatus, RoadmapTask};
+use surge_core::roadmap_patch::{RoadmapItemRef, RoadmapPatchApplyResult};
+use thiserror::Error;
+
+/// Format detected for a roadmap document.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RoadmapDocumentFormat {
+    /// Structured TOML roadmap artifact.
+    Toml,
+    /// Human-authored Markdown roadmap.
+    Markdown,
+}
+
+/// Parsed roadmap document plus enough metadata to render amendments back.
+#[derive(Debug, Clone)]
+pub struct ParsedRoadmapDocument {
+    /// Structured roadmap used by amendment planning and patch application.
+    pub roadmap: RoadmapArtifact,
+    /// Original document format.
+    pub format: RoadmapDocumentFormat,
+    markdown: Option<MarkdownRoadmapDocument>,
+}
+
+/// Errors while parsing or rendering roadmap documents.
+#[derive(Debug, Error)]
+pub enum RoadmapDocumentError {
+    /// TOML roadmap failed to parse.
+    #[error("failed to parse TOML roadmap: {0}")]
+    TomlParse(#[from] toml::de::Error),
+    /// TOML roadmap failed to render.
+    #[error("failed to render TOML roadmap: {0}")]
+    TomlSerialize(#[from] toml::ser::Error),
+    /// Markdown replacement patches are not supported without stable IDs.
+    #[error(
+        "markdown roadmap replacements require explicit stable IDs; apply this patch as a follow-up run instead"
+    )]
+    UnsupportedMarkdownReplacement,
+}
+
+#[derive(Debug, Clone)]
+struct MarkdownRoadmapDocument {
+    milestones_section_end: usize,
+    milestones: BTreeMap<String, MarkdownMilestoneLine>,
+}
+
+#[derive(Debug, Clone)]
+struct MarkdownMilestoneLine {
+    end_line_index: usize,
+}
+
+/// Parses a roadmap document from TOML or Markdown.
+pub fn parse_roadmap_document(
+    path: &Path,
+    content: &str,
+) -> Result<ParsedRoadmapDocument, RoadmapDocumentError> {
+    if is_toml_path(path) {
+        return Ok(ParsedRoadmapDocument {
+            roadmap: toml::from_str(content)?,
+            format: RoadmapDocumentFormat::Toml,
+            markdown: None,
+        });
+    }
+
+    Ok(parse_markdown_roadmap(content))
+}
+
+/// Renders an amended roadmap document in the same format as the original.
+pub fn render_amended_roadmap_document(
+    path: &Path,
+    original_content: &str,
+    parsed: &ParsedRoadmapDocument,
+    patch_result: &RoadmapPatchApplyResult,
+) -> Result<String, RoadmapDocumentError> {
+    match parsed.format {
+        RoadmapDocumentFormat::Toml => {
+            let _ = path;
+            toml::to_string_pretty(&patch_result.roadmap).map_err(RoadmapDocumentError::from)
+        },
+        RoadmapDocumentFormat::Markdown => {
+            render_markdown_amendment(original_content, parsed, patch_result)
+        },
+    }
+}
+
+/// Human-readable structured identifiers for feature-planner prompts.
+pub fn roadmap_identifiers_prompt(document: &ParsedRoadmapDocument) -> String {
+    let mut output = String::from("\n\n## Surge roadmap identifiers\n\n");
+    output.push_str("Use these stable IDs when creating roadmap patches:\n");
+
+    for milestone in &document.roadmap.milestones {
+        output.push_str(&format!(
+            "- `{}`: {} ({})\n",
+            milestone.id, milestone.title, milestone.status
+        ));
+        for task in &milestone.tasks {
+            output.push_str(&format!(
+                "  - `{}`: {} ({})\n",
+                task.id, task.title, task.status
+            ));
+        }
+    }
+
+    output
+}
+
+fn is_toml_path(path: &Path) -> bool {
+    path.extension()
+        .and_then(|extension| extension.to_str())
+        .is_some_and(|extension| extension.eq_ignore_ascii_case("toml"))
+}
+
+fn parse_markdown_roadmap(content: &str) -> ParsedRoadmapDocument {
+    let lines: Vec<&str> = content.lines().collect();
+    let (section_start, section_end) = find_milestones_section(&lines);
+    let mut used_ids = BTreeSet::new();
+    let mut roadmap = RoadmapArtifact::new(Vec::new());
+    let mut parsed_milestones = Vec::new();
+    let mut current_milestone: Option<usize> = None;
+
+    for (line_index, line) in lines
+        .iter()
+        .enumerate()
+        .take(section_end)
+        .skip(section_start)
+    {
+        let line = *line;
+        if let Some(parsed) = parse_markdown_item(line, MarkdownItemKind::Milestone) {
+            let id = unique_slug(&parsed.title, &mut used_ids);
+            let mut milestone = RoadmapMilestone::new(id.clone(), parsed.title);
+            milestone.status = parsed.status;
+            roadmap.milestones.push(milestone);
+            parsed_milestones.push((id, line_index));
+            current_milestone = Some(roadmap.milestones.len() - 1);
+            continue;
+        }
+
+        if let Some(milestone_index) = current_milestone
+            && let Some(parsed) = parse_markdown_item(line, MarkdownItemKind::Task)
+        {
+            let milestone_id = roadmap.milestones[milestone_index].id.clone();
+            let task_id = format!(
+                "{}-task-{}",
+                milestone_id,
+                roadmap.milestones[milestone_index].tasks.len() + 1
+            );
+            let mut task = RoadmapTask::new(task_id, parsed.title);
+            task.status = parsed.status;
+            task.description = (!parsed.description.is_empty()).then_some(parsed.description);
+            roadmap.milestones[milestone_index].tasks.push(task);
+        }
+    }
+
+    let mut milestones = BTreeMap::new();
+    for (index, (id, start_line_index)) in parsed_milestones.iter().enumerate() {
+        let end_line_index = parsed_milestones
+            .get(index + 1)
+            .map(|(_, next_line_index)| *next_line_index)
+            .unwrap_or(section_end);
+        milestones.insert(id.clone(), MarkdownMilestoneLine { end_line_index });
+        let _ = start_line_index;
+    }
+
+    ParsedRoadmapDocument {
+        roadmap,
+        format: RoadmapDocumentFormat::Markdown,
+        markdown: Some(MarkdownRoadmapDocument {
+            milestones_section_end: section_end,
+            milestones,
+        }),
+    }
+}
+
+fn find_milestones_section(lines: &[&str]) -> (usize, usize) {
+    let Some(heading_index) = lines
+        .iter()
+        .position(|line| line.trim().eq_ignore_ascii_case("## Milestones"))
+    else {
+        return (lines.len(), lines.len());
+    };
+
+    let section_start = heading_index + 1;
+    let section_end = lines
+        .iter()
+        .enumerate()
+        .skip(section_start)
+        .find_map(|(index, line)| line.trim_start().starts_with("## ").then_some(index))
+        .unwrap_or(lines.len());
+
+    (section_start, section_end)
+}
+
+#[derive(Debug, Clone, Copy)]
+enum MarkdownItemKind {
+    Milestone,
+    Task,
+}
+
+#[derive(Debug, Clone)]
+struct ParsedMarkdownItem {
+    title: String,
+    description: String,
+    status: RoadmapStatus,
+}
+
+fn parse_markdown_item(line: &str, kind: MarkdownItemKind) -> Option<ParsedMarkdownItem> {
+    match kind {
+        MarkdownItemKind::Milestone if !line.starts_with("- ") => return None,
+        MarkdownItemKind::Task if !line.starts_with("  - ") && !line.starts_with("\t- ") => {
+            return None;
+        },
+        _ => {},
+    }
+
+    let mut text = line.trim_start().strip_prefix("- ")?.trim_start();
+    let mut status = RoadmapStatus::Pending;
+
+    if let Some(rest) = text.strip_prefix('[') {
+        let marker = rest.chars().next()?;
+        let after_marker = rest.get(marker.len_utf8()..)?;
+        if let Some(after_checkbox) = after_marker.strip_prefix("] ") {
+            status = match marker {
+                'x' | 'X' => RoadmapStatus::Completed,
+                '~' => RoadmapStatus::Running,
+                _ => RoadmapStatus::Pending,
+            };
+            text = after_checkbox.trim_start();
+        }
+    }
+
+    let (title, description) = parse_title_and_description(text);
+    (!title.is_empty()).then_some(ParsedMarkdownItem {
+        title,
+        description,
+        status,
+    })
+}
+
+fn parse_title_and_description(text: &str) -> (String, String) {
+    let text = text.trim();
+    if let Some(rest) = text.strip_prefix("**")
+        && let Some(end_index) = rest.find("**")
+    {
+        let title = rest[..end_index].trim().to_string();
+        let description = rest[end_index + 2..]
+            .trim_start_matches(|ch: char| ch.is_whitespace() || ch == '-' || ch == '\u{2014}')
+            .trim()
+            .to_string();
+        return (title, description);
+    }
+
+    if let Some(separator) = find_title_separator(text) {
+        return (
+            text[..separator].trim().to_string(),
+            text[separator..]
+                .trim_start_matches(|ch: char| ch.is_whitespace() || ch == '-' || ch == '\u{2014}')
+                .trim()
+                .to_string(),
+        );
+    }
+
+    (text.to_string(), String::new())
+}
+
+fn find_title_separator(text: &str) -> Option<usize> {
+    [" - ", " -- "]
+        .iter()
+        .filter_map(|separator| text.find(separator))
+        .chain(text.find('\u{2014}'))
+        .min()
+}
+
+fn unique_slug(title: &str, used_ids: &mut BTreeSet<String>) -> String {
+    let base = slugify(title);
+    if used_ids.insert(base.clone()) {
+        return base;
+    }
+
+    for suffix in 2.. {
+        let candidate = format!("{base}-{suffix}");
+        if used_ids.insert(candidate.clone()) {
+            return candidate;
+        }
+    }
+
+    unreachable!("unbounded suffix search always returns");
+}
+
+fn slugify(title: &str) -> String {
+    let mut slug = String::new();
+    let mut pending_separator = false;
+
+    for ch in title.chars() {
+        if ch.is_ascii_alphanumeric() {
+            if pending_separator && !slug.is_empty() {
+                slug.push('-');
+            }
+            slug.push(ch.to_ascii_lowercase());
+            pending_separator = false;
+        } else {
+            pending_separator = true;
+        }
+    }
+
+    if slug.is_empty() {
+        "milestone".to_string()
+    } else {
+        slug
+    }
+}
+
+fn render_markdown_amendment(
+    original_content: &str,
+    parsed: &ParsedRoadmapDocument,
+    patch_result: &RoadmapPatchApplyResult,
+) -> Result<String, RoadmapDocumentError> {
+    if !patch_result.replaced_items.is_empty() {
+        return Err(RoadmapDocumentError::UnsupportedMarkdownReplacement);
+    }
+
+    let Some(markdown) = parsed.markdown.as_ref() else {
+        return Ok(patch_result.markdown.clone());
+    };
+
+    let mut lines: Vec<String> = original_content.lines().map(ToString::to_string).collect();
+    let mut insertions: BTreeMap<usize, Vec<String>> = BTreeMap::new();
+
+    if !patch_result.inserted_milestones.is_empty() {
+        let mut block = Vec::new();
+        for milestone_id in &patch_result.inserted_milestones {
+            let Some(milestone) = find_milestone(&patch_result.roadmap, milestone_id) else {
+                continue;
+            };
+            if !block.is_empty() {
+                block.push(String::new());
+            }
+            block.extend(render_milestone_block(milestone));
+        }
+        insertions
+            .entry(markdown.milestones_section_end)
+            .or_default()
+            .extend(block);
+    }
+
+    let inserted_milestone_ids: BTreeSet<&str> = patch_result
+        .inserted_milestones
+        .iter()
+        .map(String::as_str)
+        .collect();
+
+    for task_ref in &patch_result.inserted_tasks {
+        let RoadmapItemRef::Task {
+            milestone_id,
+            task_id,
+        } = task_ref
+        else {
+            continue;
+        };
+        if inserted_milestone_ids.contains(milestone_id.as_str()) {
+            continue;
+        }
+        let Some(location) = markdown.milestones.get(milestone_id.as_str()) else {
+            continue;
+        };
+        let Some(task) = find_task(
+            &patch_result.roadmap,
+            milestone_id.as_str(),
+            task_id.as_str(),
+        ) else {
+            continue;
+        };
+        insertions
+            .entry(location.end_line_index)
+            .or_default()
+            .push(render_task_line(task));
+    }
+
+    for (index, block) in insertions.into_iter().rev() {
+        let insertion_index = index.min(lines.len());
+        lines.splice(insertion_index..insertion_index, block);
+    }
+
+    let mut rendered = lines.join("\n");
+    if original_content.ends_with('\n') {
+        rendered.push('\n');
+    }
+    Ok(rendered)
+}
+
+fn render_milestone_block(milestone: &RoadmapMilestone) -> Vec<String> {
+    let mut block = vec![format!(
+        "- [{}] **{}**",
+        checkbox_marker(milestone.status),
+        milestone.title
+    )];
+    block.extend(milestone.tasks.iter().map(render_task_line));
+    block
+}
+
+fn find_milestone<'a>(
+    roadmap: &'a RoadmapArtifact,
+    milestone_id: &str,
+) -> Option<&'a RoadmapMilestone> {
+    roadmap
+        .milestones
+        .iter()
+        .find(|milestone| milestone.id == milestone_id)
+}
+
+fn find_task<'a>(
+    roadmap: &'a RoadmapArtifact,
+    milestone_id: &str,
+    task_id: &str,
+) -> Option<&'a RoadmapTask> {
+    find_milestone(roadmap, milestone_id)?
+        .tasks
+        .iter()
+        .find(|task| task.id == task_id)
+}
+
+fn render_task_line(task: &RoadmapTask) -> String {
+    format!(
+        "  - [{}] **{}**{}",
+        checkbox_marker(task.status),
+        task.title,
+        render_description_suffix(task.description.as_deref())
+    )
+}
+
+fn checkbox_marker(status: RoadmapStatus) -> &'static str {
+    match status {
+        RoadmapStatus::Completed => "x",
+        RoadmapStatus::Running => "~",
+        RoadmapStatus::Pending
+        | RoadmapStatus::Paused
+        | RoadmapStatus::Failed
+        | RoadmapStatus::Skipped => " ",
+    }
+}
+
+fn render_description_suffix(description: Option<&str>) -> String {
+    let Some(description) = description
+        .map(str::trim)
+        .filter(|description| !description.is_empty())
+    else {
+        return String::new();
+    };
+
+    format!(" - {description}")
+}
+
+#[cfg(test)]
+mod tests {
+    use surge_core::roadmap::RoadmapStatus;
+
+    use super::*;
+
+    #[test]
+    fn parses_markdown_project_roadmap_into_structured_ids() {
+        let markdown = r#"# Roadmap
+
+## Milestones
+
+- [x] **Core graph executor** - Existing implementation
+  - [x] **Validate graph**
+- [ ] **Telegram approvals**
+  - [ ] **Gate messages**
+
+## Completed
+
+- Legacy notes
+"#;
+
+        let parsed = parse_roadmap_document(Path::new(".ai-factory/ROADMAP.md"), markdown)
+            .expect("markdown roadmap should parse");
+
+        assert_eq!(parsed.format, RoadmapDocumentFormat::Markdown);
+        assert_eq!(parsed.roadmap.milestones.len(), 2);
+        assert_eq!(parsed.roadmap.milestones[0].id, "core-graph-executor");
+        assert_eq!(
+            parsed.roadmap.milestones[0].status,
+            RoadmapStatus::Completed
+        );
+        assert_eq!(
+            parsed.roadmap.milestones[1].tasks[0].id,
+            "telegram-approvals-task-1"
+        );
+    }
+
+    #[test]
+    fn renders_markdown_insertions_without_dropping_existing_sections() {
+        let markdown = r#"# Roadmap
+
+## Milestones
+
+- [ ] **Core graph executor**
+
+## Completed
+
+- Old milestone
+"#;
+        let parsed = parse_roadmap_document(Path::new(".ai-factory/ROADMAP.md"), markdown)
+            .expect("markdown roadmap should parse");
+        let mut roadmap = parsed.roadmap.clone();
+        let mut milestone = RoadmapMilestone::new("telegram-approvals", "Telegram approvals");
+        milestone.tasks.push(RoadmapTask::new(
+            "telegram-approvals-task-1",
+            "Send approval request",
+        ));
+        roadmap.milestones.push(milestone.clone());
+        let patch_result = RoadmapPatchApplyResult {
+            roadmap,
+            markdown: String::new(),
+            inserted_milestones: vec![milestone.id],
+            inserted_tasks: Vec::new(),
+            replaced_items: Vec::new(),
+            dependencies_added: Vec::new(),
+        };
+
+        let rendered = render_amended_roadmap_document(
+            Path::new(".ai-factory/ROADMAP.md"),
+            markdown,
+            &parsed,
+            &patch_result,
+        )
+        .expect("markdown amendment should render");
+
+        assert!(rendered.contains("- [ ] **Telegram approvals**"));
+        assert!(rendered.contains("  - [ ] **Send approval request**"));
+        assert!(rendered.contains("## Completed"));
+        assert!(rendered.find("Telegram approvals") < rendered.find("## Completed"));
+    }
+}

--- a/crates/surge-orchestrator/src/roadmap_document.rs
+++ b/crates/surge-orchestrator/src/roadmap_document.rs
@@ -45,6 +45,14 @@ pub enum RoadmapDocumentError {
         "markdown roadmap replacements require explicit stable IDs; apply this patch as a follow-up run instead"
     )]
     UnsupportedMarkdownReplacement,
+    /// Markdown insertion rendering cannot preserve a non-append placement.
+    #[error(
+        "markdown roadmap cannot preserve insertion order for {item}; apply this patch as a follow-up run instead"
+    )]
+    UnsupportedMarkdownInsertionOrder {
+        /// Item whose structured placement cannot be rendered safely.
+        item: String,
+    },
 }
 
 #[derive(Debug, Clone)]
@@ -326,6 +334,7 @@ fn render_markdown_amendment(
     if !patch_result.replaced_items.is_empty() {
         return Err(RoadmapDocumentError::UnsupportedMarkdownReplacement);
     }
+    validate_markdown_append_only_insertions(parsed, patch_result)?;
 
     let Some(markdown) = parsed.markdown.as_ref() else {
         return Ok(patch_result.markdown.clone());
@@ -394,6 +403,77 @@ fn render_markdown_amendment(
         rendered.push('\n');
     }
     Ok(rendered)
+}
+
+fn validate_markdown_append_only_insertions(
+    parsed: &ParsedRoadmapDocument,
+    patch_result: &RoadmapPatchApplyResult,
+) -> Result<(), RoadmapDocumentError> {
+    let inserted_milestones: BTreeSet<&str> = patch_result
+        .inserted_milestones
+        .iter()
+        .map(String::as_str)
+        .collect();
+    let inserted_tasks: BTreeSet<(&str, &str)> = patch_result
+        .inserted_tasks
+        .iter()
+        .filter_map(|item| match item {
+            RoadmapItemRef::Task {
+                milestone_id,
+                task_id,
+            } => Some((milestone_id.as_str(), task_id.as_str())),
+            RoadmapItemRef::Milestone { .. } => None,
+        })
+        .collect();
+
+    reject_non_append_milestones(&patch_result.roadmap, &inserted_milestones)?;
+    reject_non_append_tasks(&parsed.roadmap, &patch_result.roadmap, &inserted_tasks)
+}
+
+fn reject_non_append_milestones(
+    roadmap: &RoadmapArtifact,
+    inserted_milestones: &BTreeSet<&str>,
+) -> Result<(), RoadmapDocumentError> {
+    let mut saw_inserted = false;
+    for milestone in &roadmap.milestones {
+        if inserted_milestones.contains(milestone.id.as_str()) {
+            saw_inserted = true;
+            continue;
+        }
+        if saw_inserted {
+            return Err(RoadmapDocumentError::UnsupportedMarkdownInsertionOrder {
+                item: format!("milestone {}", milestone.id),
+            });
+        }
+    }
+    Ok(())
+}
+
+fn reject_non_append_tasks(
+    original: &RoadmapArtifact,
+    amended: &RoadmapArtifact,
+    inserted_tasks: &BTreeSet<(&str, &str)>,
+) -> Result<(), RoadmapDocumentError> {
+    for original_milestone in &original.milestones {
+        let Some(amended_milestone) = find_milestone(amended, &original_milestone.id) else {
+            continue;
+        };
+        let mut saw_inserted = false;
+        for task in &amended_milestone.tasks {
+            let is_inserted =
+                inserted_tasks.contains(&(original_milestone.id.as_str(), task.id.as_str()));
+            if is_inserted {
+                saw_inserted = true;
+                continue;
+            }
+            if saw_inserted {
+                return Err(RoadmapDocumentError::UnsupportedMarkdownInsertionOrder {
+                    item: format!("task {}/{}", original_milestone.id, task.id),
+                });
+            }
+        }
+    }
+    Ok(())
 }
 
 fn render_milestone_block(milestone: &RoadmapMilestone) -> Vec<String> {
@@ -538,5 +618,88 @@ mod tests {
         assert!(rendered.contains("  - [ ] **Send approval request**"));
         assert!(rendered.contains("## Completed"));
         assert!(rendered.find("Telegram approvals") < rendered.find("## Completed"));
+    }
+
+    #[test]
+    fn rejects_markdown_milestone_insertion_that_would_reorder_output() {
+        let markdown = r#"# Roadmap
+
+## Milestones
+
+- [ ] **Core graph executor**
+
+## Completed
+"#;
+        let parsed = parse_roadmap_document(Path::new(".ai-factory/ROADMAP.md"), markdown)
+            .expect("markdown roadmap should parse");
+        let mut roadmap = parsed.roadmap.clone();
+        roadmap
+            .milestones
+            .insert(0, RoadmapMilestone::new("telegram", "Telegram approvals"));
+        let patch_result = RoadmapPatchApplyResult {
+            roadmap,
+            markdown: String::new(),
+            inserted_milestones: vec!["telegram".into()],
+            inserted_tasks: Vec::new(),
+            replaced_items: Vec::new(),
+            dependencies_added: Vec::new(),
+        };
+
+        let err = render_amended_roadmap_document(
+            Path::new(".ai-factory/ROADMAP.md"),
+            markdown,
+            &parsed,
+            &patch_result,
+        )
+        .unwrap_err();
+
+        assert!(matches!(
+            err,
+            RoadmapDocumentError::UnsupportedMarkdownInsertionOrder { .. }
+        ));
+    }
+
+    #[test]
+    fn rejects_markdown_task_insertion_that_would_reorder_output() {
+        let markdown = r#"# Roadmap
+
+## Milestones
+
+- [ ] **Core graph executor**
+  - [ ] **Validate graph**
+
+## Completed
+"#;
+        let parsed = parse_roadmap_document(Path::new(".ai-factory/ROADMAP.md"), markdown)
+            .expect("markdown roadmap should parse");
+        let mut roadmap = parsed.roadmap.clone();
+        roadmap.milestones[0].tasks.insert(
+            0,
+            RoadmapTask::new("core-graph-executor-task-new", "New task"),
+        );
+        let patch_result = RoadmapPatchApplyResult {
+            roadmap,
+            markdown: String::new(),
+            inserted_milestones: Vec::new(),
+            inserted_tasks: vec![RoadmapItemRef::Task {
+                milestone_id: "core-graph-executor".into(),
+                task_id: "core-graph-executor-task-new".into(),
+            }],
+            replaced_items: Vec::new(),
+            dependencies_added: Vec::new(),
+        };
+
+        let err = render_amended_roadmap_document(
+            Path::new(".ai-factory/ROADMAP.md"),
+            markdown,
+            &parsed,
+            &patch_result,
+        )
+        .unwrap_err();
+
+        assert!(matches!(
+            err,
+            RoadmapDocumentError::UnsupportedMarkdownInsertionOrder { .. }
+        ));
     }
 }

--- a/crates/surge-orchestrator/src/roadmap_target.rs
+++ b/crates/surge-orchestrator/src/roadmap_target.rs
@@ -100,6 +100,14 @@ pub enum RoadmapTargetError {
     /// Requested run has no roadmap artifact in its materialized view.
     #[error("run {0} has no roadmap artifact")]
     RunRoadmapMissing(RunId),
+    /// Project roadmap path is absolute but not inside the project root.
+    #[error("project roadmap path {roadmap_path} is outside project root {project_path}")]
+    ProjectRoadmapOutsideProject {
+        /// Configured project root.
+        project_path: PathBuf,
+        /// Configured roadmap path.
+        roadmap_path: PathBuf,
+    },
     /// Auto-selection found no viable candidates.
     #[error("no roadmap amendment target found")]
     NoTarget,
@@ -234,7 +242,7 @@ impl RoadmapTargetResolver {
         Ok(Some(RoadmapTargetCandidate {
             selector: RoadmapTargetSelector::ProjectFile,
             target: RoadmapPatchTarget::ProjectRoadmap {
-                roadmap_path: self.project_roadmap_target_path(),
+                roadmap_path: self.project_roadmap_target_path()?,
             },
             project_path: self.project_path.clone(),
             roadmap_hash: Some(hash),
@@ -309,15 +317,18 @@ impl RoadmapTargetResolver {
         }
     }
 
-    fn project_roadmap_target_path(&self) -> String {
+    fn project_roadmap_target_path(&self) -> Result<String, RoadmapTargetError> {
         let path = if self.project_roadmap_path.is_absolute() {
             self.project_roadmap_path
                 .strip_prefix(&self.project_path)
-                .unwrap_or(&self.project_roadmap_path)
+                .map_err(|_| RoadmapTargetError::ProjectRoadmapOutsideProject {
+                    project_path: self.project_path.clone(),
+                    roadmap_path: self.project_roadmap_path.clone(),
+                })?
         } else {
             &self.project_roadmap_path
         };
-        path.to_string_lossy().replace('\\', "/")
+        Ok(path.to_string_lossy().replace('\\', "/"))
     }
 }
 

--- a/crates/surge-orchestrator/src/roadmap_target.rs
+++ b/crates/surge-orchestrator/src/roadmap_target.rs
@@ -1,0 +1,363 @@
+//! Roadmap amendment target discovery.
+//!
+//! This module normalizes "what roadmap should this patch amend?" before the
+//! CLI or notification layers get involved. It returns typed candidates with
+//! artifact hashes and pickup policy instead of asking callers to infer target
+//! semantics from paths and run status strings.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use surge_core::roadmap_patch::{ActivePickupPolicy, RoadmapPatchTarget};
+use surge_core::{ContentHash, RunId, RunStatus};
+use surge_persistence::runs::{
+    ArtifactRecord, OpenError, RunFilter, RunSummary, Storage, StorageError,
+};
+
+const ROADMAP_ARTIFACT_NAMES: &[&str] = &[
+    "roadmap",
+    "roadmap.md",
+    "roadmap.toml",
+    "roadmap-md",
+    "roadmap-toml",
+];
+const FLOW_ARTIFACT_NAMES: &[&str] = &["flow", "flow.toml", "flow-toml"];
+
+/// Selector supplied by CLI or higher-level orchestration.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RoadmapTargetSelector {
+    /// Pick automatically when there is exactly one viable candidate.
+    Auto,
+    /// Amend the project-level roadmap file.
+    ProjectFile,
+    /// Amend the roadmap artifact attached to a specific run.
+    Run {
+        /// Target run id.
+        run_id: RunId,
+    },
+}
+
+/// Where it is safe to apply the selected amendment.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RoadmapAmendmentPoint {
+    /// Direct project roadmap file amendment.
+    ProjectFile,
+    /// Active run can observe the update at a future safe loop boundary.
+    ActiveRunBoundary,
+    /// Terminal or non-pickup run requires a follow-up run.
+    FollowUpRun,
+    /// Target exists but active pickup is not currently safe.
+    Deferred,
+}
+
+/// Typed roadmap target candidate.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RoadmapTargetCandidate {
+    /// Selector that reproduces this candidate explicitly.
+    pub selector: RoadmapTargetSelector,
+    /// Patch target to embed in `roadmap-patch.toml`.
+    pub target: RoadmapPatchTarget,
+    /// Project path associated with this target.
+    pub project_path: PathBuf,
+    /// Current roadmap content hash.
+    pub roadmap_hash: Option<ContentHash>,
+    /// Current roadmap path.
+    pub roadmap_path: PathBuf,
+    /// Current flow content hash, when available.
+    pub flow_hash: Option<ContentHash>,
+    /// Current flow artifact path, when available.
+    pub flow_path: Option<PathBuf>,
+    /// Owning run id, when this candidate is run-backed.
+    pub run_id: Option<RunId>,
+    /// Owning run status, when this candidate is run-backed.
+    pub run_status: Option<RunStatus>,
+    /// Run worktree path, when this candidate is run-backed.
+    pub worktree_path: Option<PathBuf>,
+    /// Safe amendment point implied by run status and pickup policy.
+    pub amendment_point: RoadmapAmendmentPoint,
+    /// Whether an active runner may pick up the amendment.
+    pub active_pickup: ActivePickupPolicy,
+}
+
+/// Short candidate label used in ambiguity errors.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RoadmapTargetSummary {
+    /// Explicit selector for this candidate.
+    pub selector: RoadmapTargetSelector,
+    /// Human-readable label.
+    pub label: String,
+}
+
+/// Errors returned by [`RoadmapTargetResolver`].
+#[derive(Debug, thiserror::Error)]
+pub enum RoadmapTargetError {
+    /// Project roadmap path does not exist.
+    #[error("project roadmap not found: {0}")]
+    ProjectRoadmapMissing(PathBuf),
+    /// Requested run is absent from the registry.
+    #[error("run not found: {0}")]
+    RunNotFound(RunId),
+    /// Requested run has no roadmap artifact in its materialized view.
+    #[error("run {0} has no roadmap artifact")]
+    RunRoadmapMissing(RunId),
+    /// Auto-selection found no viable candidates.
+    #[error("no roadmap amendment target found")]
+    NoTarget,
+    /// Auto-selection found multiple viable candidates.
+    #[error("ambiguous roadmap amendment target ({count} candidates)")]
+    Ambiguous {
+        /// Number of candidates.
+        count: usize,
+        /// Candidate labels for UI/CLI prompts.
+        candidates: Vec<RoadmapTargetSummary>,
+    },
+    /// Opening a run reader failed.
+    #[error("open run reader failed: {0}")]
+    Open(#[from] OpenError),
+    /// Reading storage failed.
+    #[error("storage failed: {0}")]
+    Storage(#[from] StorageError),
+    /// Reading a project roadmap file failed.
+    #[error("I/O failed: {0}")]
+    Io(#[from] std::io::Error),
+}
+
+/// Discovers project-file and run-backed roadmap amendment targets.
+#[derive(Clone)]
+pub struct RoadmapTargetResolver {
+    storage: Arc<Storage>,
+    project_path: PathBuf,
+    project_roadmap_path: PathBuf,
+}
+
+impl RoadmapTargetResolver {
+    /// Create a resolver for one project.
+    #[must_use]
+    pub fn new(
+        storage: Arc<Storage>,
+        project_path: impl Into<PathBuf>,
+        project_roadmap_path: impl Into<PathBuf>,
+    ) -> Self {
+        Self {
+            storage,
+            project_path: project_path.into(),
+            project_roadmap_path: project_roadmap_path.into(),
+        }
+    }
+
+    /// Resolve one selector to a concrete candidate.
+    ///
+    /// # Errors
+    /// Returns [`RoadmapTargetError`] when the target is absent, ambiguous, or
+    /// cannot be read from storage.
+    pub async fn resolve(
+        &self,
+        selector: RoadmapTargetSelector,
+    ) -> Result<RoadmapTargetCandidate, RoadmapTargetError> {
+        tracing::debug!(
+            target: "roadmap_target",
+            selector = ?selector,
+            project_path = %self.project_path.display(),
+            "roadmap_target_resolve"
+        );
+        match selector {
+            RoadmapTargetSelector::ProjectFile => self.project_candidate_required().await,
+            RoadmapTargetSelector::Run { run_id } => self.run_candidate_required(run_id).await,
+            RoadmapTargetSelector::Auto => self.resolve_auto().await,
+        }
+    }
+
+    /// Discover every viable candidate for this project.
+    ///
+    /// # Errors
+    /// Returns [`RoadmapTargetError`] when run storage cannot be read.
+    pub async fn discover(&self) -> Result<Vec<RoadmapTargetCandidate>, RoadmapTargetError> {
+        let mut candidates = Vec::new();
+        if let Some(project) = self.project_candidate_optional().await? {
+            candidates.push(project);
+        }
+
+        let runs = self
+            .storage
+            .list_runs(RunFilter {
+                project_path: Some(self.project_path.clone()),
+                ..RunFilter::default()
+            })
+            .await?;
+        for run in runs {
+            if let Some(candidate) = self.run_candidate_from_summary(&run).await? {
+                candidates.push(candidate);
+            }
+        }
+        Ok(candidates)
+    }
+
+    async fn resolve_auto(&self) -> Result<RoadmapTargetCandidate, RoadmapTargetError> {
+        let candidates = self.discover().await?;
+        match candidates.len() {
+            0 => Err(RoadmapTargetError::NoTarget),
+            1 => {
+                let mut candidates = candidates.into_iter();
+                candidates.next().ok_or(RoadmapTargetError::NoTarget)
+            },
+            count => Err(RoadmapTargetError::Ambiguous {
+                count,
+                candidates: candidates.iter().map(candidate_summary).collect(),
+            }),
+        }
+    }
+
+    async fn project_candidate_required(
+        &self,
+    ) -> Result<RoadmapTargetCandidate, RoadmapTargetError> {
+        self.project_candidate_optional()
+            .await?
+            .ok_or_else(|| RoadmapTargetError::ProjectRoadmapMissing(self.project_roadmap_abs()))
+    }
+
+    async fn project_candidate_optional(
+        &self,
+    ) -> Result<Option<RoadmapTargetCandidate>, RoadmapTargetError> {
+        let path = self.project_roadmap_abs();
+        let bytes = match tokio::fs::read(&path).await {
+            Ok(bytes) => bytes,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(error) => return Err(error.into()),
+        };
+        let hash = ContentHash::compute(&bytes);
+        tracing::info!(
+            target: "roadmap_target",
+            roadmap_path = %path.display(),
+            roadmap_hash = %hash,
+            "project_roadmap_target_discovered"
+        );
+        Ok(Some(RoadmapTargetCandidate {
+            selector: RoadmapTargetSelector::ProjectFile,
+            target: RoadmapPatchTarget::ProjectRoadmap {
+                roadmap_path: self.project_roadmap_target_path(),
+            },
+            project_path: self.project_path.clone(),
+            roadmap_hash: Some(hash),
+            roadmap_path: path,
+            flow_hash: None,
+            flow_path: None,
+            run_id: None,
+            run_status: None,
+            worktree_path: None,
+            amendment_point: RoadmapAmendmentPoint::ProjectFile,
+            active_pickup: ActivePickupPolicy::FollowUpOnly,
+        }))
+    }
+
+    async fn run_candidate_required(
+        &self,
+        run_id: RunId,
+    ) -> Result<RoadmapTargetCandidate, RoadmapTargetError> {
+        let Some(summary) = self.storage.get_run(&run_id).await? else {
+            return Err(RoadmapTargetError::RunNotFound(run_id));
+        };
+        self.run_candidate_from_summary(&summary)
+            .await?
+            .ok_or(RoadmapTargetError::RunRoadmapMissing(run_id))
+    }
+
+    async fn run_candidate_from_summary(
+        &self,
+        summary: &RunSummary,
+    ) -> Result<Option<RoadmapTargetCandidate>, RoadmapTargetError> {
+        let reader = self.storage.open_run_reader(summary.id).await?;
+        let artifacts = reader.artifacts().await?;
+        let Some(roadmap) = latest_named_artifact(&artifacts, ROADMAP_ARTIFACT_NAMES) else {
+            return Ok(None);
+        };
+        let flow = latest_named_artifact(&artifacts, FLOW_ARTIFACT_NAMES);
+        let active_pickup = pickup_for_status(summary.status);
+        tracing::info!(
+            target: "roadmap_target",
+            run_id = %summary.id,
+            run_status = summary.status.as_str(),
+            roadmap_hash = %roadmap.content_hash,
+            active_pickup = ?active_pickup,
+            "run_roadmap_target_discovered"
+        );
+        Ok(Some(RoadmapTargetCandidate {
+            selector: RoadmapTargetSelector::Run { run_id: summary.id },
+            target: RoadmapPatchTarget::RunRoadmap {
+                run_id: summary.id,
+                roadmap_artifact: Some(roadmap.content_hash),
+                flow_artifact: flow.map(|artifact| artifact.content_hash),
+                active_pickup,
+            },
+            project_path: summary.project_path.clone(),
+            roadmap_hash: Some(roadmap.content_hash),
+            roadmap_path: roadmap.path.clone(),
+            flow_hash: flow.map(|artifact| artifact.content_hash),
+            flow_path: flow.map(|artifact| artifact.path.clone()),
+            run_id: Some(summary.id),
+            run_status: Some(summary.status),
+            worktree_path: Some(reader.worktree_path().to_path_buf()),
+            amendment_point: amendment_point_for_status(summary.status),
+            active_pickup,
+        }))
+    }
+
+    fn project_roadmap_abs(&self) -> PathBuf {
+        if self.project_roadmap_path.is_absolute() {
+            self.project_roadmap_path.clone()
+        } else {
+            self.project_path.join(&self.project_roadmap_path)
+        }
+    }
+
+    fn project_roadmap_target_path(&self) -> String {
+        let path = if self.project_roadmap_path.is_absolute() {
+            self.project_roadmap_path
+                .strip_prefix(&self.project_path)
+                .unwrap_or(&self.project_roadmap_path)
+        } else {
+            &self.project_roadmap_path
+        };
+        path.to_string_lossy().replace('\\', "/")
+    }
+}
+
+fn latest_named_artifact<'a>(
+    artifacts: &'a [ArtifactRecord],
+    names: &[&str],
+) -> Option<&'a ArtifactRecord> {
+    artifacts
+        .iter()
+        .filter(|artifact| names.contains(&artifact.name.as_str()))
+        .max_by_key(|artifact| artifact.produced_at_seq)
+}
+
+fn pickup_for_status(status: RunStatus) -> ActivePickupPolicy {
+    match status {
+        RunStatus::Running => ActivePickupPolicy::Allowed,
+        RunStatus::Bootstrapping => ActivePickupPolicy::Disabled,
+        RunStatus::Completed | RunStatus::Failed | RunStatus::Aborted | RunStatus::Crashed => {
+            ActivePickupPolicy::FollowUpOnly
+        },
+    }
+}
+
+fn amendment_point_for_status(status: RunStatus) -> RoadmapAmendmentPoint {
+    match status {
+        RunStatus::Running => RoadmapAmendmentPoint::ActiveRunBoundary,
+        RunStatus::Bootstrapping => RoadmapAmendmentPoint::Deferred,
+        RunStatus::Completed | RunStatus::Failed | RunStatus::Aborted | RunStatus::Crashed => {
+            RoadmapAmendmentPoint::FollowUpRun
+        },
+    }
+}
+
+fn candidate_summary(candidate: &RoadmapTargetCandidate) -> RoadmapTargetSummary {
+    let label = match (candidate.run_id, candidate.run_status) {
+        (Some(run_id), Some(status)) => format!("run {run_id} ({status})"),
+        _ => format!("project file {}", candidate.roadmap_path.display()),
+    };
+    RoadmapTargetSummary {
+        selector: candidate.selector.clone(),
+        label,
+    }
+}

--- a/crates/surge-orchestrator/tests/artifact_contract_golden_test.rs
+++ b/crates/surge-orchestrator/tests/artifact_contract_golden_test.rs
@@ -45,6 +45,7 @@ fn valid_fixtures_pass_all_artifact_contracts() {
         (ArtifactKind::Requirements, "valid/requirements.md"),
         (ArtifactKind::Roadmap, "valid/roadmap.toml"),
         (ArtifactKind::Roadmap, "valid/roadmap.md"),
+        (ArtifactKind::RoadmapPatch, "valid/roadmap-patch.toml"),
         (ArtifactKind::Spec, "valid/spec.toml"),
         (ArtifactKind::Spec, "valid/spec.md"),
         (
@@ -91,6 +92,11 @@ fn invalid_fixtures_emit_stable_diagnostic_codes() {
             ArtifactKind::Roadmap,
             "invalid/roadmap.toml",
             &[ArtifactDiagnosticCode::UnsupportedSchemaVersion],
+        ),
+        (
+            ArtifactKind::RoadmapPatch,
+            "invalid/roadmap-patch.toml",
+            &[ArtifactDiagnosticCode::MissingInsertionPoint],
         ),
         (
             ArtifactKind::Spec,

--- a/crates/surge-orchestrator/tests/engine_project_context_seed_test.rs
+++ b/crates/surge-orchestrator/tests/engine_project_context_seed_test.rs
@@ -11,7 +11,7 @@ use surge_core::node::{Node, NodeConfig, Position};
 use surge_core::run_event::{EventPayload, RunEvent};
 use surge_core::run_state::RunMemory;
 use surge_core::terminal_config::{TerminalConfig, TerminalKind};
-use surge_orchestrator::engine::config::ProjectContextSeed;
+use surge_orchestrator::engine::config::{ProjectContextSeed, RunSeedArtifact};
 use surge_orchestrator::engine::tools::ToolDispatcher;
 use surge_orchestrator::engine::tools::worktree::WorktreeToolDispatcher;
 use surge_orchestrator::engine::{Engine, EngineConfig, EngineRunConfig};
@@ -114,4 +114,79 @@ async fn start_run_seeds_project_context_artifact() {
     let artifact = memory.artifacts.get("project_context").unwrap();
     assert_eq!(artifact.hash, seed.hash);
     assert_eq!(artifact.produced_by.as_ref(), "project_context_seed");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn start_run_seeds_configured_run_artifacts() {
+    let storage_dir = tempfile::tempdir().unwrap();
+    let worktree = tempfile::tempdir().unwrap();
+    let storage = Storage::open(storage_dir.path()).await.unwrap();
+    let bridge = Arc::new(fixtures::mock_bridge::MockBridge::new()) as Arc<dyn BridgeFacade>;
+    let dispatcher = Arc::new(WorktreeToolDispatcher::new(worktree.path().to_path_buf()))
+        as Arc<dyn ToolDispatcher>;
+    let engine = Engine::new(bridge, storage.clone(), dispatcher, EngineConfig::default());
+    let seed = RunSeedArtifact::new(
+        "roadmap_amendment",
+        ".surge/roadmap_amendment.md",
+        "# Follow-up\n\n- m2/t1: Add runtime counters\n",
+        "roadmap_amendment_seed",
+    )
+    .unwrap();
+
+    let run_id = RunId::new();
+    let handle = engine
+        .start_run(
+            run_id,
+            terminal_graph(),
+            worktree.path().to_path_buf(),
+            EngineRunConfig {
+                seed_artifacts: vec![seed.clone()],
+                ..EngineRunConfig::default()
+            },
+        )
+        .await
+        .unwrap();
+    let _ = handle.await_completion().await.unwrap();
+
+    let reader = storage.open_run_reader(run_id).await.unwrap();
+    let events = reader.read_events(EventSeq(1)..EventSeq(64)).await.unwrap();
+    let mut memory = RunMemory::default();
+    let mut saw_seed = false;
+
+    for event in &events {
+        let payload = event.payload.payload.clone();
+        if let EventPayload::ArtifactProduced {
+            node,
+            artifact,
+            path,
+            name,
+        } = &payload
+        {
+            if name == "roadmap_amendment" {
+                assert_eq!(node.as_ref(), "roadmap_amendment_seed");
+                assert_eq!(*artifact, seed.hash);
+                assert_eq!(path, &seed.relative_path);
+                assert_eq!(
+                    std::fs::read(worktree.path().join(path)).unwrap(),
+                    seed.content.as_bytes()
+                );
+                saw_seed = true;
+            }
+        }
+        memory.apply_event(&RunEvent {
+            run_id,
+            seq: event.seq.as_u64(),
+            timestamp: chrono::Utc::now(),
+            payload,
+        });
+    }
+
+    assert!(
+        saw_seed,
+        "roadmap_amendment ArtifactProduced event is missing"
+    );
+    let artifact = memory.artifacts.get("roadmap_amendment").unwrap();
+    assert_eq!(artifact.hash, seed.hash);
+    assert_eq!(artifact.produced_by.as_ref(), "roadmap_amendment_seed");
+    assert_eq!(artifact.path, seed.relative_path);
 }

--- a/crates/surge-orchestrator/tests/feature_planner_driver_test.rs
+++ b/crates/surge-orchestrator/tests/feature_planner_driver_test.rs
@@ -1,0 +1,180 @@
+mod fixtures;
+
+use std::collections::HashMap;
+use std::str::FromStr;
+use std::sync::Arc;
+use std::time::Duration;
+
+use surge_acp::bridge::event::BridgeEvent;
+use surge_acp::bridge::facade::BridgeFacade;
+use surge_core::{OutcomeKey, RunId, SessionId};
+use surge_orchestrator::engine::hooks::HookExecutor;
+use surge_orchestrator::engine::tools::{
+    ToolCall, ToolDispatchContext, ToolDispatcher, ToolResultPayload,
+};
+use surge_orchestrator::feature_driver::{
+    FeaturePlannerParams, FeaturePlannerResult, run_feature_planner,
+};
+use surge_orchestrator::profile_loader::{DiskProfileSet, ProfileRegistry};
+use surge_persistence::artifacts::ArtifactStore;
+use surge_persistence::runs::Storage;
+use tokio::sync::Mutex;
+
+struct NoopDispatcher;
+
+#[async_trait::async_trait]
+impl ToolDispatcher for NoopDispatcher {
+    async fn dispatch(&self, _ctx: &ToolDispatchContext<'_>, call: &ToolCall) -> ToolResultPayload {
+        ToolResultPayload::Unsupported {
+            message: format!("unused: {}", call.tool),
+        }
+    }
+}
+
+const VALID_PATCH: &str = r#"schema_version = 1
+id = "rpatch-driver"
+rationale = "The requested follow-up belongs on the current roadmap."
+status = "drafted"
+
+[target]
+kind = "project_roadmap"
+roadmap_path = ".ai-factory/ROADMAP.md"
+
+[[operations]]
+op = "add_milestone"
+
+[operations.milestone]
+id = "m2"
+title = "Driver feature"
+
+[operations.insertion]
+kind = "append_to_roadmap"
+"#;
+
+const TEST_FEATURE_PLANNER_PROFILE: &str = r#"schema_version = 1
+
+[role]
+id = "feature-planner"
+version = "1.0.0"
+display_name = "Feature Planner Test"
+category = "agents"
+description = "Test profile without shell hooks."
+when_to_use = "Feature planner driver tests."
+
+[runtime]
+recommended_model = "test-model"
+agent_id = "mock"
+
+[sandbox]
+mode = "workspace-write"
+
+[[outcomes]]
+id = "patched"
+description = "Roadmap patch drafted."
+edge_kind_hint = "forward"
+required_artifacts = ["roadmap-patch.toml"]
+
+[[outcomes.produced_artifacts]]
+path = "roadmap-patch.toml"
+contract = { kind = "roadmap-patch", schema_version = 1 }
+
+[[outcomes]]
+id = "out_of_scope"
+description = "Out of scope."
+edge_kind_hint = "escalate"
+
+[prompt]
+system = "Request: {{request}}\nRoadmap: {{roadmap}}"
+"#;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn feature_planner_driver_reuses_agent_stage_artifact_validation() {
+    let storage_dir = tempfile::tempdir().unwrap();
+    let profiles_dir = storage_dir.path().join("profiles");
+    std::fs::create_dir_all(&profiles_dir).unwrap();
+    std::fs::write(
+        profiles_dir.join("feature-planner-1.0.toml"),
+        TEST_FEATURE_PLANNER_PROFILE,
+    )
+    .unwrap();
+    let storage = Storage::open(storage_dir.path()).await.unwrap();
+    let run_id = RunId::new();
+    let writer = storage
+        .create_run(run_id, storage_dir.path(), None)
+        .await
+        .unwrap();
+    let artifact_store = ArtifactStore::new(storage_dir.path().join("runs"));
+    std::fs::write(storage_dir.path().join("roadmap-patch.toml"), VALID_PATCH).unwrap();
+
+    let mock = Arc::new(fixtures::mock_bridge::MockBridge::new());
+    let bridge: Arc<dyn BridgeFacade> = mock.clone();
+    let session_id = SessionId::new();
+    mock.pin_next_session_id(session_id).await;
+    mock.enqueue_event(BridgeEvent::OutcomeReported {
+        session: session_id,
+        outcome: OutcomeKey::from_str("patched").unwrap(),
+        summary: "patch drafted".into(),
+        artifacts_produced: vec!["roadmap-patch.toml".into()],
+    })
+    .await;
+
+    let mock_for_pump = mock.clone();
+    let calls_for_pump = mock.recorded_calls.clone();
+    let pump = tokio::spawn(async move {
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+        loop {
+            let saw_send = calls_for_pump.lock().await.iter().any(|call| {
+                matches!(
+                    call,
+                    fixtures::mock_bridge::RecordedCall::SendMessage { .. }
+                )
+            });
+            if saw_send || tokio::time::Instant::now() >= deadline {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        mock_for_pump.pump_scripted_events().await;
+    });
+
+    let dispatcher: Arc<dyn ToolDispatcher> = Arc::new(NoopDispatcher);
+    let tool_resolutions = Arc::new(Mutex::new(HashMap::new()));
+    let profile_registry = Arc::new(ProfileRegistry::new(
+        DiskProfileSet::scan(&profiles_dir).unwrap(),
+    ));
+    let hook_executor = HookExecutor::new();
+
+    let result = tokio::time::timeout(
+        Duration::from_secs(10),
+        run_feature_planner(FeaturePlannerParams {
+            request: "Add driver test".into(),
+            roadmap: "## Milestones\n- m1".into(),
+            bridge: &bridge,
+            writer: &writer,
+            artifact_store: &artifact_store,
+            worktree_path: storage_dir.path(),
+            tool_dispatcher: &dispatcher,
+            run_memory: &surge_core::run_state::RunMemory::default(),
+            run_id,
+            tool_resolutions: &tool_resolutions,
+            human_input_timeout: Duration::from_secs(5),
+            mcp_registry: None,
+            mcp_servers: Vec::new(),
+            profile_registry,
+            hook_executor: &hook_executor,
+        }),
+    )
+    .await
+    .expect("driver should not hang")
+    .expect("driver succeeds");
+
+    pump.await.unwrap();
+
+    match result {
+        FeaturePlannerResult::Patched { patch, patch_path } => {
+            assert_eq!(patch.id.as_str(), "rpatch-driver");
+            assert!(patch_path.ends_with("roadmap-patch.toml"));
+        },
+        other => panic!("expected Patched, got {other:?}"),
+    }
+}

--- a/crates/surge-orchestrator/tests/fixtures/artifacts/invalid/roadmap-patch.toml
+++ b/crates/surge-orchestrator/tests/fixtures/artifacts/invalid/roadmap-patch.toml
@@ -1,0 +1,13 @@
+schema_version = 1
+id = "rpatch-invalid"
+
+[target]
+kind = "project_roadmap"
+roadmap_path = ".ai-factory/ROADMAP.md"
+
+[[operations]]
+op = "add_milestone"
+
+[operations.milestone]
+id = "m2"
+title = "Follow-up feature"

--- a/crates/surge-orchestrator/tests/fixtures/artifacts/valid/roadmap-patch.toml
+++ b/crates/surge-orchestrator/tests/fixtures/artifacts/valid/roadmap-patch.toml
@@ -1,0 +1,22 @@
+schema_version = 1
+id = "rpatch-valid"
+rationale = "Add follow-up work requested after the roadmap was approved."
+status = "drafted"
+
+[target]
+kind = "project_roadmap"
+roadmap_path = ".ai-factory/ROADMAP.md"
+
+[[operations]]
+op = "add_milestone"
+
+[operations.milestone]
+id = "m2"
+title = "Follow-up feature"
+
+[[operations.milestone.tasks]]
+id = "m2-t1"
+title = "Implement the follow-up feature"
+
+[operations.insertion]
+kind = "append_to_roadmap"

--- a/crates/surge-orchestrator/tests/flow_amendment_test.rs
+++ b/crates/surge-orchestrator/tests/flow_amendment_test.rs
@@ -1,0 +1,260 @@
+use std::collections::BTreeMap;
+
+use chrono::{TimeZone, Utc};
+use surge_core::agent_config::{AgentConfig, ArtifactSource, Binding, TemplateVar};
+use surge_core::content_hash::ContentHash;
+use surge_core::edge::{Edge, EdgeKind, EdgePolicy, PortRef};
+use surge_core::graph::{Graph, GraphMetadata, SCHEMA_VERSION};
+use surge_core::keys::{EdgeKey, NodeKey, OutcomeKey, ProfileKey};
+use surge_core::node::{Node, NodeConfig, OutcomeDecl, Position};
+use surge_core::roadmap::{RoadmapArtifact, RoadmapMilestone, RoadmapTask};
+use surge_core::roadmap_patch::{RoadmapItemRef, RoadmapPatchApplyResult};
+use surge_core::terminal_config::{TerminalConfig, TerminalKind};
+use surge_orchestrator::engine::validate::validate_for_m6;
+use surge_orchestrator::flow_amendment::{
+    FlowAmendmentError, amend_active_flow, create_follow_up_flow,
+};
+
+#[test]
+fn active_terminal_only_flow_inserts_amendment_chain_without_mutating_base() {
+    let base = terminal_only_graph();
+    let original = base.clone();
+    let patch_result = patch_result_with_milestone();
+
+    let amended = amend_active_flow(&base, &patch_result).expect("active flow amends");
+
+    assert_eq!(
+        base, original,
+        "base graph remains unchanged on clone-and-validate path"
+    );
+    assert_eq!(amended.graph.start, node_key("amend_001"));
+    assert_eq!(amended.inserted_nodes, vec![node_key("amend_001")]);
+    assert_agent_node_has_spec_binding(&amended.graph, "amend_001", "m2: Metrics");
+    assert_forward_edge(&amended.graph, "amend_001", "implemented", "end");
+    validate_for_m6(&amended.graph).expect("amended graph validates");
+    let parsed: Graph = toml::from_str(&amended.flow_toml).expect("flow TOML parses");
+    assert_eq!(parsed, amended.graph);
+}
+
+#[test]
+fn active_flow_rewires_existing_success_edge_to_inserted_stage() {
+    let base = existing_agent_to_success_graph();
+    let patch_result = patch_result_with_task();
+
+    let amended = amend_active_flow(&base, &patch_result).expect("active flow amends");
+
+    let old_edge = amended
+        .graph
+        .edges
+        .iter()
+        .find(|edge| edge.id == edge_key("e_existing"))
+        .expect("existing edge remains");
+    assert_eq!(old_edge.to, node_key("amend_001"));
+    assert_forward_edge(&amended.graph, "amend_001", "implemented", "end");
+    assert_eq!(amended.graph.start, node_key("existing"));
+    validate_for_m6(&amended.graph).expect("rewired graph validates");
+}
+
+#[test]
+fn follow_up_flow_is_valid_and_deterministic() {
+    let patch_result = patch_result_with_task();
+    let created_at = Utc
+        .with_ymd_and_hms(2026, 5, 11, 12, 0, 0)
+        .single()
+        .expect("fixed timestamp is valid");
+
+    let flow = create_follow_up_flow(&patch_result, created_at).expect("follow-up flow builds");
+
+    assert_eq!(flow.graph.metadata.created_at, created_at);
+    assert_eq!(flow.graph.start, node_key("amend_001"));
+    assert!(flow.graph.nodes.contains_key(&node_key("end")));
+    assert_eq!(
+        flow.graph_hash,
+        ContentHash::compute(flow.flow_toml.as_bytes())
+    );
+    let parsed: Graph = toml::from_str(&flow.flow_toml).expect("flow TOML parses");
+    validate_for_m6(&parsed).expect("follow-up graph validates");
+    assert_eq!(parsed, flow.graph);
+}
+
+#[test]
+fn no_amendment_items_returns_typed_error() {
+    let mut patch_result = patch_result_with_milestone();
+    patch_result.inserted_milestones.clear();
+    patch_result.inserted_tasks.clear();
+    patch_result.replaced_items.clear();
+
+    let error = amend_active_flow(&terminal_only_graph(), &patch_result)
+        .expect_err("empty amendment result is rejected");
+
+    assert!(matches!(error, FlowAmendmentError::NoAmendmentItems));
+}
+
+fn terminal_only_graph() -> Graph {
+    let end = node_key("end");
+    Graph {
+        schema_version: SCHEMA_VERSION,
+        metadata: GraphMetadata::new("terminal-only", Utc::now()),
+        start: end.clone(),
+        nodes: [(end.clone(), success_terminal_node("end"))].into(),
+        edges: Vec::new(),
+        subgraphs: BTreeMap::new(),
+    }
+}
+
+fn existing_agent_to_success_graph() -> Graph {
+    let existing = node_key("existing");
+    let end = node_key("end");
+    let mut nodes = BTreeMap::new();
+    nodes.insert(existing.clone(), agent_node("existing"));
+    nodes.insert(end, success_terminal_node("end"));
+    Graph {
+        schema_version: SCHEMA_VERSION,
+        metadata: GraphMetadata::new("existing-agent", Utc::now()),
+        start: existing,
+        nodes,
+        edges: vec![forward_edge("e_existing", "existing", "implemented", "end")],
+        subgraphs: BTreeMap::new(),
+    }
+}
+
+fn patch_result_with_milestone() -> RoadmapPatchApplyResult {
+    let roadmap = RoadmapArtifact::new(vec![RoadmapMilestone::new("m2", "Metrics")]);
+    RoadmapPatchApplyResult {
+        markdown: roadmap.to_markdown(),
+        roadmap,
+        inserted_milestones: vec!["m2".into()],
+        inserted_tasks: Vec::new(),
+        replaced_items: Vec::new(),
+        dependencies_added: Vec::new(),
+    }
+}
+
+fn patch_result_with_task() -> RoadmapPatchApplyResult {
+    let mut milestone = RoadmapMilestone::new("m2", "Metrics");
+    milestone
+        .tasks
+        .push(RoadmapTask::new("t1", "Add runtime counters"));
+    let roadmap = RoadmapArtifact::new(vec![milestone]);
+    RoadmapPatchApplyResult {
+        markdown: roadmap.to_markdown(),
+        roadmap,
+        inserted_milestones: Vec::new(),
+        inserted_tasks: vec![RoadmapItemRef::Task {
+            milestone_id: "m2".into(),
+            task_id: "t1".into(),
+        }],
+        replaced_items: Vec::new(),
+        dependencies_added: Vec::new(),
+    }
+}
+
+fn assert_agent_node_has_spec_binding(graph: &Graph, node: &str, expected: &str) {
+    let node = graph.nodes.get(&node_key(node)).expect("node exists");
+    assert_eq!(
+        node.declared_outcomes
+            .iter()
+            .map(|outcome| outcome.id.clone())
+            .collect::<Vec<_>>(),
+        vec![outcome_key("implemented")]
+    );
+    let NodeConfig::Agent(agent) = &node.config else {
+        panic!("expected agent node");
+    };
+    assert_eq!(agent.profile, profile_key("implementer@1.0"));
+    let binding = agent.bindings.first().expect("spec binding exists");
+    assert_eq!(binding.target, TemplateVar("spec".into()));
+    let ArtifactSource::Static { content } = &binding.source else {
+        panic!("expected static spec binding");
+    };
+    assert!(content.contains(expected), "spec contains label: {content}");
+    assert!(content.contains("## Amended roadmap"));
+}
+
+fn assert_forward_edge(graph: &Graph, from: &str, outcome: &str, to: &str) {
+    let exists = graph.edges.iter().any(|edge| {
+        edge.from.node == node_key(from)
+            && edge.from.outcome == outcome_key(outcome)
+            && edge.to == node_key(to)
+            && edge.kind == EdgeKind::Forward
+    });
+    assert!(
+        exists,
+        "expected forward edge {from}.{outcome} -> {to}, got {:?}",
+        graph.edges
+    );
+}
+
+fn agent_node(id: &str) -> Node {
+    let key = node_key(id);
+    Node {
+        id: key,
+        position: Position::default(),
+        declared_outcomes: vec![OutcomeDecl {
+            id: outcome_key("implemented"),
+            description: "implemented".into(),
+            edge_kind_hint: EdgeKind::Forward,
+            is_terminal: false,
+        }],
+        config: NodeConfig::Agent(AgentConfig {
+            profile: profile_key("implementer@1.0"),
+            prompt_overrides: None,
+            tool_overrides: None,
+            sandbox_override: None,
+            approvals_override: None,
+            bindings: vec![Binding {
+                source: ArtifactSource::Static {
+                    content: "# Spec".into(),
+                },
+                target: TemplateVar("spec".into()),
+                optional: false,
+            }],
+            rules_overrides: None,
+            limits: Default::default(),
+            hooks: Vec::new(),
+            custom_fields: Default::default(),
+        }),
+    }
+}
+
+fn success_terminal_node(id: &str) -> Node {
+    let key = node_key(id);
+    Node {
+        id: key,
+        position: Position::default(),
+        declared_outcomes: Vec::new(),
+        config: NodeConfig::Terminal(TerminalConfig {
+            kind: TerminalKind::Success,
+            message: None,
+        }),
+    }
+}
+
+fn forward_edge(id: &str, from: &str, outcome: &str, to: &str) -> Edge {
+    Edge {
+        id: edge_key(id),
+        from: PortRef {
+            node: node_key(from),
+            outcome: outcome_key(outcome),
+        },
+        to: node_key(to),
+        kind: EdgeKind::Forward,
+        policy: EdgePolicy::default(),
+    }
+}
+
+fn node_key(value: &str) -> NodeKey {
+    NodeKey::try_from(value).expect("valid node key")
+}
+
+fn edge_key(value: &str) -> EdgeKey {
+    EdgeKey::try_from(value).expect("valid edge key")
+}
+
+fn outcome_key(value: &str) -> OutcomeKey {
+    OutcomeKey::try_from(value).expect("valid outcome key")
+}
+
+fn profile_key(value: &str) -> ProfileKey {
+    ProfileKey::try_from(value).expect("valid profile key")
+}

--- a/crates/surge-orchestrator/tests/profile_registry_e2e.rs
+++ b/crates/surge-orchestrator/tests/profile_registry_e2e.rs
@@ -145,8 +145,8 @@ fn all_bundled_profiles_resolve_and_validator_hooks_are_portable() {
     }
 
     assert_eq!(
-        validator_hook_count, 5,
-        "description, roadmap, and spec profiles should register artifact validators"
+        validator_hook_count, 6,
+        "description, roadmap, feature-planner, and spec profiles should register artifact validators"
     );
 }
 

--- a/crates/surge-orchestrator/tests/roadmap_amendment_approval_test.rs
+++ b/crates/surge-orchestrator/tests/roadmap_amendment_approval_test.rs
@@ -1,0 +1,247 @@
+use surge_core::RunId;
+use surge_core::approvals::{ApprovalChannel, ApprovalDuration};
+use surge_core::roadmap::RoadmapMilestone;
+use surge_core::roadmap_patch::{
+    InsertionPoint, OperatorConflictChoice, RoadmapItemRef, RoadmapPatch,
+    RoadmapPatchApprovalDecision, RoadmapPatchConflict, RoadmapPatchConflictCode,
+    RoadmapPatchDependency, RoadmapPatchId, RoadmapPatchOperation, RoadmapPatchStatus,
+    RoadmapPatchTarget,
+};
+use surge_orchestrator::roadmap_amendment::{
+    RoadmapAmendmentError, RoadmapPatchApprovalAction, RoadmapPatchApprovalLoop,
+    RoadmapPatchApprovalResolution, patch_approval_requested_notification, store_patch_draft,
+};
+use surge_persistence::artifacts::ArtifactStore;
+use surge_persistence::runs::{EventSeq, Storage};
+
+fn approval_patch(id: &str) -> RoadmapPatch {
+    let mut patch = RoadmapPatch::new(
+        RoadmapPatchId::new(id).unwrap(),
+        RoadmapPatchTarget::ProjectRoadmap {
+            roadmap_path: ".ai-factory/ROADMAP.md".into(),
+        },
+        vec![RoadmapPatchOperation::AddMilestone {
+            milestone: RoadmapMilestone::new("m2", "Approval loop"),
+            insertion: Some(InsertionPoint::AppendToRoadmap),
+        }],
+    );
+    patch.rationale = "Let operators approve roadmap amendments before apply.".into();
+    patch.dependencies.push(RoadmapPatchDependency {
+        from: RoadmapItemRef::Milestone {
+            milestone_id: "m1".into(),
+        },
+        to: RoadmapItemRef::Milestone {
+            milestone_id: "m2".into(),
+        },
+        reason: "approval metadata depends on patch drafts".into(),
+    });
+    patch.conflicts.push(RoadmapPatchConflict {
+        code: RoadmapPatchConflictCode::RunningMilestone,
+        item: Some(RoadmapItemRef::Milestone {
+            milestone_id: "m1".into(),
+        }),
+        message: "m1 is currently running".into(),
+        choices: vec![
+            OperatorConflictChoice::CreateFollowUpRun,
+            OperatorConflictChoice::RejectPatch,
+        ],
+        selected_choice: None,
+    });
+    patch
+}
+
+async fn create_drafted_patch(
+    tmp: &tempfile::TempDir,
+    storage: &std::sync::Arc<Storage>,
+    run_id: RunId,
+    patch: &RoadmapPatch,
+) -> surge_persistence::runs::RunWriter {
+    let writer = storage.create_run(run_id, tmp.path(), None).await.unwrap();
+    let artifact_store = ArtifactStore::new(tmp.path().join("runs"));
+    store_patch_draft(
+        &artifact_store,
+        &writer,
+        run_id,
+        patch,
+        b"roadmap patch approval fixture",
+    )
+    .await
+    .unwrap();
+    writer
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn approval_loop_records_approve_decision_in_patch_view() {
+    let tmp = tempfile::tempdir().unwrap();
+    let storage = Storage::open(tmp.path()).await.unwrap();
+    let run_id = RunId::new();
+    let patch = approval_patch("rpatch-approve");
+    let writer = create_drafted_patch(&tmp, &storage, run_id, &patch).await;
+    let channel = ApprovalChannel::Desktop {
+        duration: ApprovalDuration::Transient,
+    };
+
+    let mut approval = RoadmapPatchApprovalLoop::new(2);
+    let prompt = approval
+        .request_approval(&writer, &patch, channel.clone())
+        .await
+        .unwrap();
+    assert!(prompt.summary.contains("Approval loop"));
+    assert!(prompt.summary.contains("append to roadmap"));
+    assert!(prompt.summary.contains("create_follow_up_run"));
+    assert_eq!(prompt.schema["required"][0], "decision");
+    let rendered_notification = patch_approval_requested_notification(&prompt).render();
+    assert!(rendered_notification.body.contains("rpatch-approve"));
+    assert!(rendered_notification.body.contains("Approval loop"));
+
+    let action = approval
+        .record_decision(
+            &writer,
+            &patch.id,
+            channel.kind(),
+            RoadmapPatchApprovalResolution {
+                decision: RoadmapPatchApprovalDecision::Approve,
+                comment: Some("ship it".into()),
+                conflict_choice: Some(OperatorConflictChoice::CreateFollowUpRun),
+            },
+        )
+        .await
+        .unwrap();
+    assert_eq!(action, RoadmapPatchApprovalAction::Apply);
+    writer.flush().await.unwrap();
+
+    let reader = storage.open_run_reader(run_id).await.unwrap();
+    let records = reader.roadmap_patches().await.unwrap();
+    assert_eq!(records.len(), 1);
+    assert_eq!(records[0].status, RoadmapPatchStatus::Approved);
+    assert_eq!(records[0].summary_hash, Some(prompt.summary_hash));
+    assert_eq!(
+        records[0].decision,
+        Some(RoadmapPatchApprovalDecision::Approve)
+    );
+    assert_eq!(records[0].decision_comment.as_deref(), Some("ship it"));
+    assert_eq!(
+        records[0].conflict_choice,
+        Some(OperatorConflictChoice::CreateFollowUpRun)
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn approval_loop_edit_returns_feedback_and_escalates_after_cap() {
+    let tmp = tempfile::tempdir().unwrap();
+    let storage = Storage::open(tmp.path()).await.unwrap();
+    let run_id = RunId::new();
+    let patch = approval_patch("rpatch-edit");
+    let writer = create_drafted_patch(&tmp, &storage, run_id, &patch).await;
+    let channel = ApprovalChannel::Desktop {
+        duration: ApprovalDuration::Transient,
+    };
+
+    let mut approval = RoadmapPatchApprovalLoop::new(1);
+    approval
+        .request_approval(&writer, &patch, channel.clone())
+        .await
+        .unwrap();
+    let action = approval
+        .record_decision(
+            &writer,
+            &patch.id,
+            channel.kind(),
+            RoadmapPatchApprovalResolution {
+                decision: RoadmapPatchApprovalDecision::Edit,
+                comment: Some("split the milestone into smaller work".into()),
+                conflict_choice: None,
+            },
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        action,
+        RoadmapPatchApprovalAction::Redraft {
+            feedback: "split the milestone into smaller work".into(),
+            attempt: 1,
+        }
+    );
+    assert_eq!(approval.edit_rounds(), 1);
+
+    approval
+        .request_approval(&writer, &patch, channel.clone())
+        .await
+        .unwrap();
+    let err = approval
+        .record_decision(
+            &writer,
+            &patch.id,
+            channel.kind(),
+            RoadmapPatchApprovalResolution {
+                decision: RoadmapPatchApprovalDecision::Edit,
+                comment: Some("still too broad".into()),
+                conflict_choice: None,
+            },
+        )
+        .await
+        .unwrap_err();
+    assert!(matches!(
+        err,
+        RoadmapAmendmentError::ApprovalLoopExceeded {
+            max_edit_rounds: 1,
+            ..
+        }
+    ));
+    assert_eq!(approval.edit_rounds(), 1);
+    writer.flush().await.unwrap();
+
+    let reader = storage.open_run_reader(run_id).await.unwrap();
+    let max_seq = reader.current_seq().await.unwrap();
+    let events = reader
+        .read_events(EventSeq(1)..EventSeq(max_seq.as_u64() + 1))
+        .await
+        .unwrap();
+    let kinds = events
+        .iter()
+        .map(|event| event.kind.as_str())
+        .collect::<Vec<_>>();
+    assert!(kinds.contains(&"EscalationRequested"));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn approval_loop_records_reject_as_terminal_patch_state() {
+    let tmp = tempfile::tempdir().unwrap();
+    let storage = Storage::open(tmp.path()).await.unwrap();
+    let run_id = RunId::new();
+    let patch = approval_patch("rpatch-reject");
+    let writer = create_drafted_patch(&tmp, &storage, run_id, &patch).await;
+    let channel = ApprovalChannel::Desktop {
+        duration: ApprovalDuration::Transient,
+    };
+
+    let mut approval = RoadmapPatchApprovalLoop::new(2);
+    approval
+        .request_approval(&writer, &patch, channel.clone())
+        .await
+        .unwrap();
+    let action = approval
+        .record_decision(
+            &writer,
+            &patch.id,
+            channel.kind(),
+            RoadmapPatchApprovalResolution {
+                decision: RoadmapPatchApprovalDecision::Reject,
+                comment: Some("not part of this roadmap".into()),
+                conflict_choice: Some(OperatorConflictChoice::RejectPatch),
+            },
+        )
+        .await
+        .unwrap();
+    assert_eq!(action, RoadmapPatchApprovalAction::Rejected);
+    writer.flush().await.unwrap();
+
+    let reader = storage.open_run_reader(run_id).await.unwrap();
+    let record = reader.roadmap_patch(&patch.id).await.unwrap().unwrap();
+    assert_eq!(record.status, RoadmapPatchStatus::Rejected);
+    assert_eq!(record.decision, Some(RoadmapPatchApprovalDecision::Reject));
+    assert_eq!(
+        record.conflict_choice,
+        Some(OperatorConflictChoice::RejectPatch)
+    );
+}

--- a/crates/surge-orchestrator/tests/roadmap_amendment_artifacts_test.rs
+++ b/crates/surge-orchestrator/tests/roadmap_amendment_artifacts_test.rs
@@ -1,0 +1,202 @@
+use std::collections::BTreeMap;
+
+use chrono::Utc;
+use surge_core::graph::{Graph, GraphMetadata, SCHEMA_VERSION};
+use surge_core::keys::NodeKey;
+use surge_core::node::{Node, NodeConfig, Position};
+use surge_core::roadmap::{RoadmapArtifact, RoadmapMilestone};
+use surge_core::roadmap_patch::{ActivePickupPolicy, RoadmapPatch, RoadmapPatchStatus};
+use surge_core::terminal_config::{TerminalConfig, TerminalKind};
+use surge_core::{
+    RoadmapPatchApplyResult, RoadmapPatchId, RoadmapPatchTarget, RunId, validate_artifact_text,
+};
+use surge_orchestrator::roadmap_amendment::{
+    apply_active_run_patch, record_roadmap_updated, store_applied_artifacts, store_patch_draft,
+};
+use surge_persistence::artifacts::ArtifactStore;
+use surge_persistence::runs::{EventSeq, Storage};
+
+const PATCH_TOML: &str = r#"schema_version = 1
+id = "rpatch-artifacts"
+rationale = "Store patch artifacts through the content-addressed store."
+status = "drafted"
+
+[target]
+kind = "project_roadmap"
+roadmap_path = ".ai-factory/ROADMAP.md"
+
+[[operations]]
+op = "add_milestone"
+
+[operations.milestone]
+id = "m2"
+title = "Artifact storage"
+
+[operations.insertion]
+kind = "append_to_roadmap"
+"#;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn stores_patch_and_amended_artifacts_with_lifecycle_events() {
+    let tmp = tempfile::tempdir().unwrap();
+    let storage = Storage::open(tmp.path()).await.unwrap();
+    let run_id = RunId::new();
+    let writer = storage.create_run(run_id, tmp.path(), None).await.unwrap();
+    let artifact_store = ArtifactStore::new(tmp.path().join("runs"));
+    let patch: RoadmapPatch = toml::from_str(PATCH_TOML).unwrap();
+
+    let patch_ref = store_patch_draft(
+        &artifact_store,
+        &writer,
+        run_id,
+        &patch,
+        PATCH_TOML.as_bytes(),
+    )
+    .await
+    .unwrap();
+    let artifacts = store_applied_artifacts(
+        &artifact_store,
+        &writer,
+        run_id,
+        &patch.id,
+        &patch.target,
+        b"schema_version = 1\nmilestones = []\n",
+        Some(b"schema_version = 1\nstart = \"end\"\n"),
+    )
+    .await
+    .unwrap();
+    record_roadmap_updated(
+        &writer,
+        &patch.id,
+        &patch.target,
+        &artifacts,
+        ActivePickupPolicy::Allowed,
+    )
+    .await
+    .unwrap();
+    writer.flush().await.unwrap();
+
+    let stored_patch = artifact_store.open(run_id, patch_ref.hash).await.unwrap();
+    assert_eq!(stored_patch, PATCH_TOML.as_bytes());
+    assert!(validate_artifact_text(surge_core::ArtifactKind::RoadmapPatch, PATCH_TOML).is_valid());
+
+    let reader = storage.open_run_reader(run_id).await.unwrap();
+    let max_seq = reader.current_seq().await.unwrap();
+    let events = reader
+        .read_events(EventSeq(1)..EventSeq(max_seq.as_u64() + 1))
+        .await
+        .unwrap();
+    let kinds = events
+        .iter()
+        .map(|event| event.kind.as_str())
+        .collect::<Vec<_>>();
+    assert!(kinds.contains(&"RoadmapPatchDrafted"));
+    assert!(kinds.contains(&"RoadmapPatchApplied"));
+    assert!(kinds.contains(&"RoadmapUpdated"));
+
+    let records = reader.roadmap_patches().await.unwrap();
+    assert_eq!(records.len(), 1);
+    assert_eq!(records[0].patch_id, patch.id);
+    assert_eq!(records[0].status, RoadmapPatchStatus::Applied);
+    assert_eq!(records[0].patch_artifact, Some(patch_ref.hash));
+    assert_eq!(records[0].roadmap_artifact, Some(artifacts.roadmap.hash));
+    assert_eq!(
+        records[0].flow_artifact,
+        artifacts.flow.as_ref().map(|artifact| artifact.hash)
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn active_run_patch_records_graph_revision_in_target_log() {
+    let tmp = tempfile::tempdir().unwrap();
+    let storage = Storage::open(tmp.path()).await.unwrap();
+    let run_id = RunId::new();
+    let writer = storage.create_run(run_id, tmp.path(), None).await.unwrap();
+    let artifact_store = ArtifactStore::new(tmp.path().join("runs"));
+    let patch_id = RoadmapPatchId::new("rpatch-active-log").unwrap();
+    let target = RoadmapPatchTarget::RunRoadmap {
+        run_id,
+        roadmap_artifact: None,
+        flow_artifact: None,
+        active_pickup: ActivePickupPolicy::Allowed,
+    };
+    let patch_result = patch_result_with_milestone();
+
+    let outcome = apply_active_run_patch(
+        &artifact_store,
+        &writer,
+        run_id,
+        &terminal_only_graph(),
+        &patch_id,
+        &target,
+        &patch_result,
+    )
+    .await
+    .unwrap();
+    writer.flush().await.unwrap();
+
+    assert_eq!(outcome.run_id, run_id);
+    assert_eq!(outcome.patch_id, patch_id);
+    assert_eq!(outcome.inserted_nodes, vec![node_key("amend_001")]);
+
+    let reader = storage.open_run_reader(run_id).await.unwrap();
+    let max_seq = reader.current_seq().await.unwrap();
+    let events = reader
+        .read_events(EventSeq(1)..EventSeq(max_seq.as_u64() + 1))
+        .await
+        .unwrap();
+    let kinds = events
+        .iter()
+        .map(|event| event.kind.as_str())
+        .collect::<Vec<_>>();
+    assert!(kinds.contains(&"RoadmapPatchApplied"));
+    assert!(kinds.contains(&"RoadmapUpdated"));
+    assert!(kinds.contains(&"GraphRevisionAccepted"));
+
+    let records = reader.roadmap_patches().await.unwrap();
+    assert_eq!(records.len(), 1);
+    assert_eq!(records[0].status, RoadmapPatchStatus::Applied);
+    assert_eq!(records[0].roadmap_artifact, Some(outcome.roadmap_artifact));
+    assert_eq!(records[0].flow_artifact, Some(outcome.flow_artifact));
+}
+
+fn patch_result_with_milestone() -> RoadmapPatchApplyResult {
+    let roadmap = RoadmapArtifact::new(vec![RoadmapMilestone::new("m2", "Metrics")]);
+    RoadmapPatchApplyResult {
+        markdown: roadmap.to_markdown(),
+        roadmap,
+        inserted_milestones: vec!["m2".into()],
+        inserted_tasks: Vec::new(),
+        replaced_items: Vec::new(),
+        dependencies_added: Vec::new(),
+    }
+}
+
+fn terminal_only_graph() -> Graph {
+    let end = node_key("end");
+    Graph {
+        schema_version: SCHEMA_VERSION,
+        metadata: GraphMetadata::new("terminal-only", Utc::now()),
+        start: end.clone(),
+        nodes: [(end.clone(), success_terminal_node("end"))].into(),
+        edges: Vec::new(),
+        subgraphs: BTreeMap::new(),
+    }
+}
+
+fn success_terminal_node(id: &str) -> Node {
+    let key = node_key(id);
+    Node {
+        id: key,
+        position: Position::default(),
+        declared_outcomes: Vec::new(),
+        config: NodeConfig::Terminal(TerminalConfig {
+            kind: TerminalKind::Success,
+            message: None,
+        }),
+    }
+}
+
+fn node_key(value: &str) -> NodeKey {
+    NodeKey::try_from(value).expect("valid node key")
+}

--- a/crates/surge-orchestrator/tests/roadmap_amendment_e2e.rs
+++ b/crates/surge-orchestrator/tests/roadmap_amendment_e2e.rs
@@ -1,0 +1,210 @@
+use surge_core::approvals::{ApprovalChannel, ApprovalDuration};
+use surge_core::roadmap::{RoadmapArtifact, RoadmapMilestone, RoadmapStatus, RoadmapTask};
+use surge_core::roadmap_patch::{
+    InsertionPoint, OperatorConflictChoice, RoadmapPatch, RoadmapPatchApplyError,
+    RoadmapPatchApprovalDecision, RoadmapPatchConflictCode, RoadmapPatchId, RoadmapPatchOperation,
+    RoadmapPatchStatus, RoadmapPatchTarget,
+};
+use surge_core::{
+    ArtifactDiagnosticCode, ArtifactKind, ContentHash, RunId, validate_artifact_text,
+};
+use surge_orchestrator::engine::validate::validate_for_m6;
+use surge_orchestrator::roadmap_amendment::{
+    RoadmapPatchApprovalLoop, RoadmapPatchApprovalResolution, apply_conflicts_as_patch_conflicts,
+    build_follow_up_run_request, follow_up_result_from_patch, store_patch_draft,
+};
+use surge_persistence::artifacts::ArtifactStore;
+use surge_persistence::roadmap_patches::RoadmapPatchIndexUpsert;
+use surge_persistence::runs::Storage;
+
+const INVALID_PATCH: &str = r#"schema_version = 1
+id = "rpatch-invalid"
+
+[target]
+kind = "project_roadmap"
+roadmap_path = ".ai-factory/ROADMAP.md"
+"#;
+
+#[test]
+fn malformed_patch_is_rejected_before_amendment_lifecycle() {
+    let report = validate_artifact_text(ArtifactKind::RoadmapPatch, INVALID_PATCH);
+
+    assert!(!report.is_valid());
+    assert!(
+        report
+            .diagnostics
+            .iter()
+            .any(|diagnostic| { diagnostic.code == ArtifactDiagnosticCode::MissingOperation })
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn duplicate_patch_content_keeps_original_registry_identity() {
+    let tmp = tempfile::tempdir().unwrap();
+    let storage = Storage::open(tmp.path()).await.unwrap();
+    let patch = add_task_patch("rpatch-duplicate-a");
+    let content_hash = patch.content_hash().unwrap();
+
+    let first = storage
+        .roadmap_patch_store()
+        .upsert(&index_upsert(
+            &patch,
+            content_hash,
+            RoadmapPatchStatus::Drafted,
+        ))
+        .unwrap();
+    let mut duplicate = add_task_patch("rpatch-duplicate-b");
+    duplicate.rationale = patch.rationale.clone();
+    let second = storage
+        .roadmap_patch_store()
+        .upsert(&index_upsert(
+            &duplicate,
+            content_hash,
+            RoadmapPatchStatus::PendingApproval,
+        ))
+        .unwrap();
+
+    assert_eq!(second.patch_id, first.patch_id);
+    assert_eq!(second.status, RoadmapPatchStatus::PendingApproval);
+    assert!(
+        storage
+            .roadmap_patch_store()
+            .get(&duplicate.id)
+            .unwrap()
+            .is_none()
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn running_milestone_conflict_records_choice_and_builds_follow_up() {
+    let tmp = tempfile::tempdir().unwrap();
+    let storage = Storage::open(tmp.path()).await.unwrap();
+    let run_id = RunId::new();
+    let writer = storage.create_run(run_id, tmp.path(), None).await.unwrap();
+    let artifact_store = ArtifactStore::new(tmp.path().join("runs"));
+    let roadmap = running_roadmap();
+    let patch = add_task_patch("rpatch-running-follow-up");
+    let RoadmapPatchApplyError::Conflicts { conflicts } =
+        patch.apply_to_roadmap(&roadmap).unwrap_err()
+    else {
+        panic!("expected running milestone conflict");
+    };
+    let patch_conflicts = apply_conflicts_as_patch_conflicts(&conflicts);
+
+    assert_eq!(
+        patch_conflicts[0].code,
+        RoadmapPatchConflictCode::RunningMilestone
+    );
+    assert!(
+        patch_conflicts[0]
+            .choices
+            .contains(&OperatorConflictChoice::CreateFollowUpRun)
+    );
+
+    let patch_toml = toml::to_string(&patch).unwrap();
+    store_patch_draft(
+        &artifact_store,
+        &writer,
+        run_id,
+        &patch,
+        patch_toml.as_bytes(),
+    )
+    .await
+    .unwrap();
+    let mut approval = RoadmapPatchApprovalLoop::new(0);
+    let channel = ApprovalChannel::Desktop {
+        duration: ApprovalDuration::Transient,
+    };
+    approval
+        .request_approval(&writer, &patch, channel.clone())
+        .await
+        .unwrap();
+    approval
+        .record_decision(
+            &writer,
+            &patch.id,
+            channel.kind(),
+            RoadmapPatchApprovalResolution {
+                decision: RoadmapPatchApprovalDecision::Approve,
+                comment: Some("run is already in the milestone".into()),
+                conflict_choice: Some(OperatorConflictChoice::CreateFollowUpRun),
+            },
+        )
+        .await
+        .unwrap();
+    writer.flush().await.unwrap();
+
+    let reader = storage.open_run_reader(run_id).await.unwrap();
+    let record = reader.roadmap_patch(&patch.id).await.unwrap().unwrap();
+    assert_eq!(record.status, RoadmapPatchStatus::Approved);
+    assert_eq!(
+        record.conflict_choice,
+        Some(OperatorConflictChoice::CreateFollowUpRun)
+    );
+
+    let follow_up = follow_up_result_from_patch(&patch);
+    let request = build_follow_up_run_request(
+        &patch.id,
+        &patch.target,
+        &follow_up,
+        tmp.path(),
+        None,
+        chrono::Utc::now(),
+    )
+    .unwrap();
+    validate_for_m6(&request.graph).unwrap();
+    assert!(
+        request.run_config.seed_artifacts[0]
+            .content
+            .contains("new-task")
+    );
+}
+
+fn running_roadmap() -> RoadmapArtifact {
+    let mut milestone = RoadmapMilestone::new("m1", "Running work");
+    milestone.status = RoadmapStatus::Running;
+    milestone
+        .tasks
+        .push(RoadmapTask::new("old-task", "Old task"));
+    RoadmapArtifact::new(vec![milestone])
+}
+
+fn add_task_patch(id: &str) -> RoadmapPatch {
+    let mut patch = RoadmapPatch::new(
+        RoadmapPatchId::new(id).unwrap(),
+        RoadmapPatchTarget::ProjectRoadmap {
+            roadmap_path: ".ai-factory/ROADMAP.md".into(),
+        },
+        vec![RoadmapPatchOperation::AddTask {
+            milestone_id: "m1".into(),
+            task: RoadmapTask::new("new-task", "New task"),
+            insertion: Some(InsertionPoint::AppendToMilestone {
+                milestone_id: "m1".into(),
+            }),
+        }],
+    );
+    patch.rationale = "Add task from feature request".into();
+    patch
+}
+
+fn index_upsert(
+    patch: &RoadmapPatch,
+    content_hash: ContentHash,
+    status: RoadmapPatchStatus,
+) -> RoadmapPatchIndexUpsert {
+    RoadmapPatchIndexUpsert {
+        patch_id: patch.id.clone(),
+        content_hash,
+        run_id: None,
+        project_path: std::path::PathBuf::from("/tmp/surge-project"),
+        target: patch.target.clone(),
+        status,
+        patch_artifact: None,
+        patch_path: None,
+        summary_hash: None,
+        decision: None,
+        decision_comment: None,
+        conflict_choice: None,
+        observed_at_ms: 1_700_000_000_000,
+    }
+}

--- a/crates/surge-orchestrator/tests/roadmap_amendment_follow_up_test.rs
+++ b/crates/surge-orchestrator/tests/roadmap_amendment_follow_up_test.rs
@@ -1,0 +1,241 @@
+use chrono::{TimeZone, Utc};
+use std::path::PathBuf;
+use std::sync::Mutex;
+use surge_core::keys::NodeKey;
+use surge_core::roadmap::{RoadmapArtifact, RoadmapMilestone, RoadmapTask};
+use surge_core::roadmap_patch::{
+    InsertionPoint, RoadmapItemRef, RoadmapPatch, RoadmapPatchApplyResult, RoadmapPatchId,
+    RoadmapPatchItem, RoadmapPatchOperation,
+};
+use surge_core::{Graph, RoadmapPatchTarget, RunId};
+use surge_orchestrator::engine::config::{EngineRunConfig, ProjectContextSeed};
+use surge_orchestrator::engine::error::EngineError;
+use surge_orchestrator::engine::facade::EngineFacade;
+use surge_orchestrator::engine::handle::{RunHandle, RunOutcome, RunSummary};
+use surge_orchestrator::engine::validate::validate_for_m6;
+use surge_orchestrator::roadmap_amendment::{
+    build_follow_up_run_request, follow_up_result_from_patch, start_follow_up_run,
+};
+
+#[test]
+fn follow_up_run_request_contains_valid_graph_and_seed_artifacts() {
+    let patch_id = RoadmapPatchId::new("rpatch-follow-up").unwrap();
+    let target = RoadmapPatchTarget::ProjectRoadmap {
+        roadmap_path: ".ai-factory/ROADMAP.md".into(),
+    };
+    let project_context = ProjectContextSeed::new(
+        "project.md".into(),
+        "# Project\n\nStable project context.".into(),
+    );
+    let created_at = Utc
+        .with_ymd_and_hms(2026, 5, 11, 13, 0, 0)
+        .single()
+        .unwrap();
+
+    let request = build_follow_up_run_request(
+        &patch_id,
+        &target,
+        &patch_result_with_task(),
+        ".worktrees/follow-up",
+        Some(project_context.clone()),
+        created_at,
+    )
+    .expect("follow-up request builds");
+
+    validate_for_m6(&request.graph).expect("follow-up graph validates");
+    assert_eq!(request.patch_id, patch_id);
+    assert_eq!(request.target, target);
+    assert_eq!(request.graph.metadata.created_at, created_at);
+    assert_eq!(
+        request.run_config.project_context.as_ref(),
+        Some(&project_context)
+    );
+    assert_eq!(request.run_config.seed_artifacts.len(), 1);
+    let seed = &request.run_config.seed_artifacts[0];
+    assert_eq!(seed.name, "roadmap_amendment");
+    assert_eq!(
+        seed.relative_path,
+        std::path::PathBuf::from(".surge/roadmap_amendment.md")
+    );
+    assert_eq!(seed.producer.as_ref(), "roadmap_amendment_seed");
+    assert!(seed.content.contains("m2/t1: Add runtime counters"));
+    assert!(seed.content.contains("## Amended roadmap"));
+}
+
+#[tokio::test]
+async fn start_follow_up_run_forwards_materialized_request_to_engine() {
+    let patch_id = RoadmapPatchId::new("rpatch-forward").unwrap();
+    let target = RoadmapPatchTarget::ProjectRoadmap {
+        roadmap_path: ".ai-factory/ROADMAP.md".into(),
+    };
+    let created_at = Utc
+        .with_ymd_and_hms(2026, 5, 11, 14, 0, 0)
+        .single()
+        .unwrap();
+    let request = build_follow_up_run_request(
+        &patch_id,
+        &target,
+        &patch_result_with_task(),
+        ".worktrees/follow-up-forward",
+        None,
+        created_at,
+    )
+    .expect("follow-up request builds");
+    let expected_run_id = request.run_id;
+    let engine = RecordingEngine::default();
+
+    let handle = start_follow_up_run(&engine, request)
+        .await
+        .expect("follow-up run starts");
+
+    assert_eq!(handle.run_id, expected_run_id);
+    let recorded = engine.take_recorded_start();
+    assert_eq!(recorded.run_id, expected_run_id);
+    assert_eq!(
+        recorded.worktree_path,
+        PathBuf::from(".worktrees/follow-up-forward")
+    );
+    assert_eq!(recorded.graph_name, "roadmap-amendment-follow-up");
+    assert_eq!(recorded.seed_names, vec!["roadmap_amendment"]);
+    assert!(recorded.initial_prompt.contains("rpatch-forward"));
+}
+
+#[test]
+fn follow_up_result_from_patch_preserves_conflicted_work_without_mutating_base() {
+    let target = RoadmapPatchTarget::ProjectRoadmap {
+        roadmap_path: ".ai-factory/ROADMAP.md".into(),
+    };
+    let patch = RoadmapPatch::new(
+        RoadmapPatchId::new("rpatch-conflicted-follow-up").unwrap(),
+        target,
+        vec![
+            RoadmapPatchOperation::AddTask {
+                milestone_id: "running".into(),
+                task: RoadmapTask::new("running-t2", "Deferred task"),
+                insertion: Some(InsertionPoint::AppendToMilestone {
+                    milestone_id: "running".into(),
+                }),
+            },
+            RoadmapPatchOperation::ReplaceDraftItem {
+                target: RoadmapItemRef::Task {
+                    milestone_id: "running".into(),
+                    task_id: "running-t1".into(),
+                },
+                replacement: RoadmapPatchItem::Task {
+                    task: RoadmapTask::new("running-t1b", "Reworked task"),
+                },
+                reason: "running milestone cannot be rewritten in place".into(),
+            },
+        ],
+    );
+
+    let result = follow_up_result_from_patch(&patch);
+
+    assert_eq!(result.roadmap.milestones.len(), 2);
+    assert!(result.markdown.contains("Deferred task"));
+    assert!(result.markdown.contains("Reworked task"));
+    assert_eq!(result.inserted_tasks.len(), 2);
+    assert_eq!(result.replaced_items.len(), 1);
+}
+
+fn patch_result_with_task() -> RoadmapPatchApplyResult {
+    let mut milestone = RoadmapMilestone::new("m2", "Metrics");
+    milestone
+        .tasks
+        .push(RoadmapTask::new("t1", "Add runtime counters"));
+    let roadmap = RoadmapArtifact::new(vec![milestone]);
+    RoadmapPatchApplyResult {
+        markdown: roadmap.to_markdown(),
+        roadmap,
+        inserted_milestones: Vec::new(),
+        inserted_tasks: vec![RoadmapItemRef::Task {
+            milestone_id: "m2".into(),
+            task_id: "t1".into(),
+        }],
+        replaced_items: Vec::new(),
+        dependencies_added: Vec::new(),
+    }
+}
+
+#[derive(Default)]
+struct RecordingEngine {
+    recorded_start: Mutex<Option<RecordedStart>>,
+}
+
+impl RecordingEngine {
+    fn take_recorded_start(&self) -> RecordedStart {
+        self.recorded_start
+            .lock()
+            .unwrap()
+            .take()
+            .expect("start_run should be called")
+    }
+}
+
+struct RecordedStart {
+    run_id: RunId,
+    worktree_path: PathBuf,
+    graph_name: String,
+    seed_names: Vec<String>,
+    initial_prompt: String,
+}
+
+#[async_trait::async_trait]
+impl EngineFacade for RecordingEngine {
+    async fn start_run(
+        &self,
+        run_id: RunId,
+        graph: Graph,
+        worktree_path: PathBuf,
+        run_config: EngineRunConfig,
+    ) -> Result<RunHandle, EngineError> {
+        *self.recorded_start.lock().unwrap() = Some(RecordedStart {
+            run_id,
+            worktree_path,
+            graph_name: graph.metadata.name,
+            seed_names: run_config
+                .seed_artifacts
+                .iter()
+                .map(|seed| seed.name.clone())
+                .collect(),
+            initial_prompt: run_config.initial_prompt,
+        });
+
+        let (_events_tx, events) = tokio::sync::broadcast::channel(8);
+        let completion = tokio::spawn(async {
+            RunOutcome::Completed {
+                terminal: NodeKey::try_from("success").unwrap(),
+            }
+        });
+        Ok(RunHandle {
+            run_id,
+            events,
+            completion,
+        })
+    }
+
+    async fn resume_run(
+        &self,
+        run_id: RunId,
+        _worktree_path: PathBuf,
+    ) -> Result<RunHandle, EngineError> {
+        Err(EngineError::RunNotFound(run_id))
+    }
+
+    async fn stop_run(&self, run_id: RunId, _reason: String) -> Result<(), EngineError> {
+        Err(EngineError::RunNotFound(run_id))
+    }
+
+    async fn resolve_human_input(
+        &self,
+        run_id: RunId,
+        _call_id: Option<String>,
+        _response: serde_json::Value,
+    ) -> Result<(), EngineError> {
+        Err(EngineError::RunNotFound(run_id))
+    }
+
+    async fn list_runs(&self) -> Result<Vec<RunSummary>, EngineError> {
+        Ok(Vec::new())
+    }
+}

--- a/crates/surge-orchestrator/tests/roadmap_target_resolver_test.rs
+++ b/crates/surge-orchestrator/tests/roadmap_target_resolver_test.rs
@@ -1,0 +1,183 @@
+use std::path::Path;
+
+use surge_core::keys::NodeKey;
+use surge_core::roadmap_patch::{ActivePickupPolicy, RoadmapPatchTarget};
+use surge_core::run_event::{EventPayload, VersionedEventPayload};
+use surge_core::{ContentHash, RunId, RunStatus};
+use surge_orchestrator::roadmap_target::{
+    RoadmapAmendmentPoint, RoadmapTargetError, RoadmapTargetResolver, RoadmapTargetSelector,
+};
+use surge_persistence::artifacts::ArtifactStore;
+use surge_persistence::runs::Storage;
+
+async fn create_run_with_artifacts(
+    storage: &std::sync::Arc<Storage>,
+    storage_home: &Path,
+    project_path: &Path,
+    status: RunStatus,
+) -> (RunId, ContentHash, ContentHash) {
+    let run_id = RunId::new();
+    let writer = storage
+        .create_run(run_id, project_path, None)
+        .await
+        .unwrap();
+    let artifact_store = ArtifactStore::new(storage_home.join("runs"));
+    let roadmap = artifact_store
+        .put(run_id, "roadmap", b"# Roadmap\n")
+        .await
+        .unwrap();
+    let flow = artifact_store
+        .put(run_id, "flow", b"schema_version = 1\n")
+        .await
+        .unwrap();
+    let node = NodeKey::try_from("roadmap_planner").unwrap();
+    writer
+        .append_event(VersionedEventPayload::new(EventPayload::ArtifactProduced {
+            node: node.clone(),
+            artifact: roadmap.hash,
+            path: roadmap.path,
+            name: "roadmap".into(),
+        }))
+        .await
+        .unwrap();
+    writer
+        .append_event(VersionedEventPayload::new(EventPayload::ArtifactProduced {
+            node,
+            artifact: flow.hash,
+            path: flow.path,
+            name: "flow".into(),
+        }))
+        .await
+        .unwrap();
+    writer.flush().await.unwrap();
+
+    let conn = storage.acquire_registry_conn().unwrap();
+    let status = status.as_str().to_owned();
+    let run_id_string = run_id.to_string();
+    conn.execute(
+        "UPDATE runs SET status = ? WHERE id = ?",
+        [status.as_str(), run_id_string.as_str()],
+    )
+    .unwrap();
+    (run_id, roadmap.hash, flow.hash)
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn explicit_project_target_reads_project_roadmap() {
+    let tmp = tempfile::tempdir().unwrap();
+    let project = tmp.path().join("project");
+    std::fs::create_dir_all(project.join(".ai-factory")).unwrap();
+    std::fs::write(
+        project.join(".ai-factory").join("ROADMAP.md"),
+        "# Roadmap\n",
+    )
+    .unwrap();
+    let storage = Storage::open(tmp.path().join("home")).await.unwrap();
+
+    let resolver =
+        RoadmapTargetResolver::new(storage, &project, Path::new(".ai-factory/ROADMAP.md"));
+    let candidate = resolver
+        .resolve(RoadmapTargetSelector::ProjectFile)
+        .await
+        .unwrap();
+
+    assert_eq!(candidate.run_id, None);
+    assert_eq!(
+        candidate.amendment_point,
+        RoadmapAmendmentPoint::ProjectFile
+    );
+    assert_eq!(candidate.active_pickup, ActivePickupPolicy::FollowUpOnly);
+    assert!(candidate.roadmap_hash.is_some());
+    assert!(matches!(
+        candidate.target,
+        RoadmapPatchTarget::ProjectRoadmap { .. }
+    ));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn explicit_run_target_returns_artifacts_and_active_pickup() {
+    let tmp = tempfile::tempdir().unwrap();
+    let project = tmp.path().join("project");
+    std::fs::create_dir_all(&project).unwrap();
+    let storage_home = tmp.path().join("home");
+    let storage = Storage::open(&storage_home).await.unwrap();
+    let (run_id, roadmap_hash, flow_hash) =
+        create_run_with_artifacts(&storage, &storage_home, &project, RunStatus::Running).await;
+
+    let resolver =
+        RoadmapTargetResolver::new(storage, &project, Path::new(".ai-factory/ROADMAP.md"));
+    let candidate = resolver
+        .resolve(RoadmapTargetSelector::Run { run_id })
+        .await
+        .unwrap();
+
+    assert_eq!(candidate.run_id, Some(run_id));
+    assert_eq!(candidate.run_status, Some(RunStatus::Running));
+    assert_eq!(candidate.roadmap_hash, Some(roadmap_hash));
+    assert_eq!(candidate.flow_hash, Some(flow_hash));
+    assert_eq!(candidate.active_pickup, ActivePickupPolicy::Allowed);
+    assert_eq!(
+        candidate.amendment_point,
+        RoadmapAmendmentPoint::ActiveRunBoundary
+    );
+    assert!(matches!(
+        candidate.target,
+        RoadmapPatchTarget::RunRoadmap {
+            active_pickup: ActivePickupPolicy::Allowed,
+            ..
+        }
+    ));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn completed_run_auto_target_uses_follow_up_policy() {
+    let tmp = tempfile::tempdir().unwrap();
+    let project = tmp.path().join("project");
+    std::fs::create_dir_all(&project).unwrap();
+    let storage_home = tmp.path().join("home");
+    let storage = Storage::open(&storage_home).await.unwrap();
+    let (run_id, _, _) =
+        create_run_with_artifacts(&storage, &storage_home, &project, RunStatus::Completed).await;
+
+    let resolver =
+        RoadmapTargetResolver::new(storage, &project, Path::new(".ai-factory/ROADMAP.md"));
+    let candidate = resolver.resolve(RoadmapTargetSelector::Auto).await.unwrap();
+
+    assert_eq!(candidate.run_id, Some(run_id));
+    assert_eq!(candidate.run_status, Some(RunStatus::Completed));
+    assert_eq!(candidate.active_pickup, ActivePickupPolicy::FollowUpOnly);
+    assert_eq!(
+        candidate.amendment_point,
+        RoadmapAmendmentPoint::FollowUpRun
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn auto_target_is_ambiguous_when_project_and_run_candidates_exist() {
+    let tmp = tempfile::tempdir().unwrap();
+    let project = tmp.path().join("project");
+    std::fs::create_dir_all(project.join(".ai-factory")).unwrap();
+    std::fs::write(
+        project.join(".ai-factory").join("ROADMAP.md"),
+        "# Roadmap\n",
+    )
+    .unwrap();
+    let storage_home = tmp.path().join("home");
+    let storage = Storage::open(&storage_home).await.unwrap();
+    create_run_with_artifacts(&storage, &storage_home, &project, RunStatus::Running).await;
+
+    let resolver =
+        RoadmapTargetResolver::new(storage, &project, Path::new(".ai-factory/ROADMAP.md"));
+    let err = resolver
+        .resolve(RoadmapTargetSelector::Auto)
+        .await
+        .unwrap_err();
+
+    match err {
+        RoadmapTargetError::Ambiguous { count, candidates } => {
+            assert_eq!(count, 2);
+            assert_eq!(candidates.len(), 2);
+        },
+        other => panic!("expected ambiguous target, got {other:?}"),
+    }
+}

--- a/crates/surge-orchestrator/tests/roadmap_target_resolver_test.rs
+++ b/crates/surge-orchestrator/tests/roadmap_target_resolver_test.rs
@@ -95,6 +95,34 @@ async fn explicit_project_target_reads_project_roadmap() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn absolute_project_roadmap_outside_project_root_is_rejected() {
+    let tmp = tempfile::tempdir().unwrap();
+    let project = tmp.path().join("project");
+    let outside = tmp.path().join("outside").join("ROADMAP.md");
+    std::fs::create_dir_all(&project).unwrap();
+    std::fs::create_dir_all(outside.parent().unwrap()).unwrap();
+    std::fs::write(&outside, "# Roadmap\n").unwrap();
+    let storage = Storage::open(tmp.path().join("home")).await.unwrap();
+
+    let resolver = RoadmapTargetResolver::new(storage, &project, &outside);
+    let err = resolver
+        .resolve(RoadmapTargetSelector::ProjectFile)
+        .await
+        .unwrap_err();
+
+    match err {
+        RoadmapTargetError::ProjectRoadmapOutsideProject {
+            project_path,
+            roadmap_path,
+        } => {
+            assert_eq!(project_path, project);
+            assert_eq!(roadmap_path, outside);
+        },
+        other => panic!("expected outside-project error, got {other:?}"),
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn explicit_run_target_returns_artifacts_and_active_pickup() {
     let tmp = tempfile::tempdir().unwrap();
     let project = tmp.path().join("project");

--- a/crates/surge-persistence/src/lib.rs
+++ b/crates/surge-persistence/src/lib.rs
@@ -65,6 +65,9 @@ pub mod memory;
 /// Pricing models for AI providers
 pub mod pricing;
 
+/// Registry-level roadmap patch lookup metadata.
+pub mod roadmap_patches;
+
 /// SQLite-based storage implementation
 pub mod store;
 

--- a/crates/surge-persistence/src/roadmap_patches.rs
+++ b/crates/surge-persistence/src/roadmap_patches.rs
@@ -1,0 +1,561 @@
+//! Registry-level roadmap patch index for CLI list/show/reject operations.
+//!
+//! Per-run event logs remain the source of truth for attached patch lifecycle
+//! events. This index is the cross-run lookup surface that avoids scanning
+//! every run database for common CLI operations.
+
+use std::path::PathBuf;
+use std::str::FromStr;
+
+use r2d2::Pool;
+use r2d2_sqlite::SqliteConnectionManager;
+use rusqlite::{OptionalExtension, Row, params};
+use serde::de::DeserializeOwned;
+use serde::{Deserialize, Serialize};
+use surge_core::{
+    ContentHash, OperatorConflictChoice, RoadmapPatchApprovalDecision, RoadmapPatchId,
+    RoadmapPatchStatus, RoadmapPatchTarget, RunId,
+};
+
+use crate::runs::error::StorageError;
+
+/// Filter for registry-level roadmap patch list queries.
+#[derive(Debug, Default, Clone)]
+pub struct RoadmapPatchIndexFilter {
+    /// Only return patches with this lifecycle status.
+    pub status: Option<RoadmapPatchStatus>,
+    /// Only return patches associated with this project path.
+    pub project_path: Option<PathBuf>,
+    /// Only return patches attached to this run id.
+    pub run_id: Option<RunId>,
+    /// Limit returned rows.
+    pub limit: Option<usize>,
+}
+
+/// Input used to upsert one registry-level roadmap patch index row.
+#[derive(Debug, Clone)]
+pub struct RoadmapPatchIndexUpsert {
+    /// Proposed patch id. Existing rows with the same content hash keep their original id.
+    pub patch_id: RoadmapPatchId,
+    /// Stable hash of the semantic patch contents.
+    pub content_hash: ContentHash,
+    /// Run that owns this patch, when already attached to a run.
+    pub run_id: Option<RunId>,
+    /// Project path this patch belongs to.
+    pub project_path: PathBuf,
+    /// Target roadmap/run being amended.
+    pub target: RoadmapPatchTarget,
+    /// Latest lifecycle status.
+    pub status: RoadmapPatchStatus,
+    /// Stored patch artifact hash, when known.
+    pub patch_artifact: Option<ContentHash>,
+    /// Stored patch path, when known.
+    pub patch_path: Option<PathBuf>,
+    /// Approval summary hash, when approval has been requested.
+    pub summary_hash: Option<ContentHash>,
+    /// Operator decision, when known.
+    pub decision: Option<RoadmapPatchApprovalDecision>,
+    /// Operator comment, when present.
+    pub decision_comment: Option<String>,
+    /// Conflict choice selected by the operator, when present.
+    pub conflict_choice: Option<OperatorConflictChoice>,
+    /// Timestamp for this observation in unix epoch milliseconds.
+    pub observed_at_ms: i64,
+}
+
+/// One row from the registry-level roadmap patch index.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RoadmapPatchIndexRecord {
+    /// Stable patch identifier.
+    pub patch_id: RoadmapPatchId,
+    /// Stable hash of the semantic patch contents.
+    pub content_hash: ContentHash,
+    /// Run that owns this patch, when already attached to a run.
+    pub run_id: Option<RunId>,
+    /// Project path this patch belongs to.
+    pub project_path: PathBuf,
+    /// Target roadmap/run being amended.
+    pub target: RoadmapPatchTarget,
+    /// Latest lifecycle status.
+    pub status: RoadmapPatchStatus,
+    /// Stored patch artifact hash, when known.
+    pub patch_artifact: Option<ContentHash>,
+    /// Stored patch path, when known.
+    pub patch_path: Option<PathBuf>,
+    /// Approval summary hash, when approval has been requested.
+    pub summary_hash: Option<ContentHash>,
+    /// Operator decision, when known.
+    pub decision: Option<RoadmapPatchApprovalDecision>,
+    /// Operator comment, when present.
+    pub decision_comment: Option<String>,
+    /// Conflict choice selected by the operator, when present.
+    pub conflict_choice: Option<OperatorConflictChoice>,
+    /// First time this row was created in unix epoch milliseconds.
+    pub created_at_ms: i64,
+    /// Last time this row was updated in unix epoch milliseconds.
+    pub updated_at_ms: i64,
+}
+
+/// Registry-backed store for roadmap patch lookup metadata.
+#[derive(Clone)]
+pub struct RoadmapPatchStore {
+    pool: Pool<SqliteConnectionManager>,
+}
+
+impl RoadmapPatchStore {
+    /// Create a store over the registry DB connection pool.
+    #[must_use]
+    pub fn new(pool: Pool<SqliteConnectionManager>) -> Self {
+        Self { pool }
+    }
+
+    /// Insert or update patch metadata, using `content_hash` for idempotency.
+    ///
+    /// # Errors
+    /// Returns [`StorageError`] when the registry DB cannot be read or written.
+    pub fn upsert(
+        &self,
+        input: &RoadmapPatchIndexUpsert,
+    ) -> Result<RoadmapPatchIndexRecord, StorageError> {
+        tracing::debug!(
+            target: "roadmap_patch_index",
+            patch_id = %input.patch_id,
+            content_hash = %input.content_hash,
+            status = status_label(input.status),
+            "roadmap_patch_index_upsert"
+        );
+        let mut conn = self
+            .pool
+            .get()
+            .map_err(|e| StorageError::Pool(e.to_string()))?;
+        let tx = conn.transaction()?;
+        let patch_id = existing_patch_id_for_hash(&tx, input.content_hash)?
+            .unwrap_or_else(|| input.patch_id.clone());
+
+        tx.execute(
+            "INSERT INTO roadmap_patch_index
+                (patch_id, content_hash, run_id, project_path, target_json, status,
+                 patch_artifact, patch_path, summary_hash, decision, decision_comment,
+                 conflict_choice, created_at, updated_at)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+             ON CONFLICT(patch_id) DO UPDATE SET
+                content_hash = excluded.content_hash,
+                run_id = excluded.run_id,
+                project_path = excluded.project_path,
+                target_json = excluded.target_json,
+                status = excluded.status,
+                patch_artifact = excluded.patch_artifact,
+                patch_path = excluded.patch_path,
+                summary_hash = excluded.summary_hash,
+                decision = excluded.decision,
+                decision_comment = excluded.decision_comment,
+                conflict_choice = excluded.conflict_choice,
+                updated_at = excluded.updated_at",
+            params![
+                patch_id.as_str(),
+                input.content_hash.to_string(),
+                input.run_id.map(|run_id| run_id.to_string()),
+                input.project_path.to_string_lossy().to_string(),
+                serde_json::to_string(&input.target)?,
+                status_label(input.status),
+                input.patch_artifact.map(|hash| hash.to_string()),
+                input
+                    .patch_path
+                    .as_ref()
+                    .map(|path| path.to_string_lossy().to_string()),
+                input.summary_hash.map(|hash| hash.to_string()),
+                input.decision.map(decision_label),
+                input.decision_comment.as_deref(),
+                input.conflict_choice.map(conflict_choice_label),
+                input.observed_at_ms,
+                input.observed_at_ms,
+            ],
+        )?;
+        let record = get_by_patch_id(&tx, &patch_id)?;
+        tx.commit()?;
+        record.ok_or_else(|| StorageError::MigrationFailed("roadmap patch upsert vanished".into()))
+    }
+
+    /// List patch metadata rows matching `filter`.
+    ///
+    /// # Errors
+    /// Returns [`StorageError`] when the registry DB cannot be read.
+    pub fn list(
+        &self,
+        filter: &RoadmapPatchIndexFilter,
+    ) -> Result<Vec<RoadmapPatchIndexRecord>, StorageError> {
+        tracing::debug!(
+            target: "roadmap_patch_index",
+            status = filter.status.map(status_label),
+            project_path = filter.project_path.as_ref().map(|path| path.display().to_string()),
+            run_id = filter.run_id.map(|run_id| run_id.to_string()),
+            "roadmap_patch_index_list"
+        );
+        let conn = self
+            .pool
+            .get()
+            .map_err(|e| StorageError::Pool(e.to_string()))?;
+        let mut sql = String::from(
+            "SELECT patch_id, content_hash, run_id, project_path, target_json, status,
+                    patch_artifact, patch_path, summary_hash, decision, decision_comment,
+                    conflict_choice, created_at, updated_at
+             FROM roadmap_patch_index WHERE 1=1",
+        );
+        let mut binds: Vec<Box<dyn rusqlite::ToSql>> = Vec::new();
+        if let Some(status) = filter.status {
+            sql.push_str(" AND status = ?");
+            binds.push(Box::new(status_label(status).to_owned()));
+        }
+        if let Some(project_path) = &filter.project_path {
+            sql.push_str(" AND project_path = ?");
+            binds.push(Box::new(project_path.to_string_lossy().to_string()));
+        }
+        if let Some(run_id) = filter.run_id {
+            sql.push_str(" AND run_id = ?");
+            binds.push(Box::new(run_id.to_string()));
+        }
+        sql.push_str(" ORDER BY updated_at DESC, patch_id");
+        if let Some(limit) = filter.limit {
+            sql.push_str(" LIMIT ?");
+            binds.push(Box::new(limit as i64));
+        }
+
+        let bind_refs: Vec<&dyn rusqlite::ToSql> =
+            binds.iter().map(std::convert::AsRef::as_ref).collect();
+        let mut stmt = conn.prepare(&sql)?;
+        let rows = stmt.query_map(rusqlite::params_from_iter(bind_refs), row_to_record)?;
+        rows.collect::<rusqlite::Result<_>>().map_err(Into::into)
+    }
+
+    /// Read one patch metadata row by id.
+    ///
+    /// # Errors
+    /// Returns [`StorageError`] when the registry DB cannot be read.
+    pub fn get(
+        &self,
+        patch_id: &RoadmapPatchId,
+    ) -> Result<Option<RoadmapPatchIndexRecord>, StorageError> {
+        let conn = self
+            .pool
+            .get()
+            .map_err(|e| StorageError::Pool(e.to_string()))?;
+        get_by_patch_id(&conn, patch_id)
+    }
+
+    /// Read one patch metadata row by content hash.
+    ///
+    /// # Errors
+    /// Returns [`StorageError`] when the registry DB cannot be read.
+    pub fn get_by_content_hash(
+        &self,
+        content_hash: ContentHash,
+    ) -> Result<Option<RoadmapPatchIndexRecord>, StorageError> {
+        let conn = self
+            .pool
+            .get()
+            .map_err(|e| StorageError::Pool(e.to_string()))?;
+        conn.query_row(
+            "SELECT patch_id, content_hash, run_id, project_path, target_json, status,
+                    patch_artifact, patch_path, summary_hash, decision, decision_comment,
+                    conflict_choice, created_at, updated_at
+             FROM roadmap_patch_index WHERE content_hash = ?",
+            params![content_hash.to_string()],
+            row_to_record,
+        )
+        .optional()
+        .map_err(Into::into)
+    }
+
+    /// Mark a patch rejected without scanning run event logs.
+    ///
+    /// Applied patches are left unchanged and returned as-is.
+    ///
+    /// # Errors
+    /// Returns [`StorageError`] when the registry DB cannot be read or written.
+    pub fn reject(
+        &self,
+        patch_id: &RoadmapPatchId,
+        comment: Option<&str>,
+        conflict_choice: Option<OperatorConflictChoice>,
+        observed_at_ms: i64,
+    ) -> Result<Option<RoadmapPatchIndexRecord>, StorageError> {
+        tracing::info!(
+            target: "roadmap_patch_index",
+            patch_id = %patch_id,
+            "roadmap_patch_index_reject"
+        );
+        let conn = self
+            .pool
+            .get()
+            .map_err(|e| StorageError::Pool(e.to_string()))?;
+        conn.execute(
+            "UPDATE roadmap_patch_index
+             SET status = ?,
+                 decision = ?,
+                 decision_comment = COALESCE(?, decision_comment),
+                 conflict_choice = COALESCE(?, conflict_choice),
+                 updated_at = ?
+             WHERE patch_id = ? AND status != ?",
+            params![
+                status_label(RoadmapPatchStatus::Rejected),
+                decision_label(RoadmapPatchApprovalDecision::Reject),
+                comment,
+                conflict_choice.map(conflict_choice_label),
+                observed_at_ms,
+                patch_id.as_str(),
+                status_label(RoadmapPatchStatus::Applied),
+            ],
+        )?;
+        self.get(patch_id)
+    }
+}
+
+fn existing_patch_id_for_hash(
+    conn: &rusqlite::Connection,
+    content_hash: ContentHash,
+) -> rusqlite::Result<Option<RoadmapPatchId>> {
+    conn.query_row(
+        "SELECT patch_id FROM roadmap_patch_index WHERE content_hash = ?",
+        params![content_hash.to_string()],
+        |row| parse_patch_id(row.get(0)?, 0),
+    )
+    .optional()
+}
+
+fn get_by_patch_id(
+    conn: &rusqlite::Connection,
+    patch_id: &RoadmapPatchId,
+) -> Result<Option<RoadmapPatchIndexRecord>, StorageError> {
+    conn.query_row(
+        "SELECT patch_id, content_hash, run_id, project_path, target_json, status,
+                patch_artifact, patch_path, summary_hash, decision, decision_comment,
+                conflict_choice, created_at, updated_at
+         FROM roadmap_patch_index WHERE patch_id = ?",
+        params![patch_id.as_str()],
+        row_to_record,
+    )
+    .optional()
+    .map_err(Into::into)
+}
+
+fn row_to_record(row: &Row<'_>) -> rusqlite::Result<RoadmapPatchIndexRecord> {
+    Ok(RoadmapPatchIndexRecord {
+        patch_id: parse_patch_id(row.get(0)?, 0)?,
+        content_hash: parse_hash(row.get(1)?, 1)?,
+        run_id: parse_optional_run_id(row.get(2)?, 2)?,
+        project_path: PathBuf::from(row.get::<_, String>(3)?),
+        target: parse_json(row.get(4)?, 4)?,
+        status: parse_json_string(row.get(5)?, 5)?,
+        patch_artifact: parse_optional_hash(row.get(6)?, 6)?,
+        patch_path: optional_path(row.get(7)?),
+        summary_hash: parse_optional_hash(row.get(8)?, 8)?,
+        decision: parse_optional_json_string(row.get(9)?, 9)?,
+        decision_comment: row.get(10)?,
+        conflict_choice: parse_optional_json_string(row.get(11)?, 11)?,
+        created_at_ms: row.get(12)?,
+        updated_at_ms: row.get(13)?,
+    })
+}
+
+fn parse_patch_id(value: String, column: usize) -> rusqlite::Result<RoadmapPatchId> {
+    RoadmapPatchId::from_str(&value).map_err(|error| conversion_error(column, error))
+}
+
+fn parse_hash(value: String, column: usize) -> rusqlite::Result<ContentHash> {
+    ContentHash::from_str(&value).map_err(|error| conversion_error(column, error))
+}
+
+fn parse_optional_hash(
+    value: Option<String>,
+    column: usize,
+) -> rusqlite::Result<Option<ContentHash>> {
+    value.map(|inner| parse_hash(inner, column)).transpose()
+}
+
+fn parse_optional_run_id(value: Option<String>, column: usize) -> rusqlite::Result<Option<RunId>> {
+    value
+        .map(|inner| RunId::from_str(&inner).map_err(|error| conversion_error(column, error)))
+        .transpose()
+}
+
+fn parse_json<T: DeserializeOwned>(value: String, column: usize) -> rusqlite::Result<T> {
+    serde_json::from_str(&value).map_err(|error| conversion_error(column, error))
+}
+
+fn parse_json_string<T: DeserializeOwned>(value: String, column: usize) -> rusqlite::Result<T> {
+    serde_json::from_value(serde_json::Value::String(value))
+        .map_err(|error| conversion_error(column, error))
+}
+
+fn parse_optional_json_string<T: DeserializeOwned>(
+    value: Option<String>,
+    column: usize,
+) -> rusqlite::Result<Option<T>> {
+    value
+        .map(|inner| parse_json_string(inner, column))
+        .transpose()
+}
+
+fn optional_path(value: Option<String>) -> Option<PathBuf> {
+    value.map(PathBuf::from)
+}
+
+fn conversion_error<E>(column: usize, error: E) -> rusqlite::Error
+where
+    E: std::error::Error + Send + Sync + 'static,
+{
+    rusqlite::Error::FromSqlConversionFailure(column, rusqlite::types::Type::Text, Box::new(error))
+}
+
+const fn status_label(status: RoadmapPatchStatus) -> &'static str {
+    match status {
+        RoadmapPatchStatus::Drafted => "drafted",
+        RoadmapPatchStatus::PendingApproval => "pending_approval",
+        RoadmapPatchStatus::Approved => "approved",
+        RoadmapPatchStatus::Applied => "applied",
+        RoadmapPatchStatus::Rejected => "rejected",
+        RoadmapPatchStatus::Superseded => "superseded",
+    }
+}
+
+const fn decision_label(decision: RoadmapPatchApprovalDecision) -> &'static str {
+    match decision {
+        RoadmapPatchApprovalDecision::Approve => "approve",
+        RoadmapPatchApprovalDecision::Edit => "edit",
+        RoadmapPatchApprovalDecision::Reject => "reject",
+    }
+}
+
+const fn conflict_choice_label(choice: OperatorConflictChoice) -> &'static str {
+    match choice {
+        OperatorConflictChoice::DeferToNextMilestone => "defer_to_next_milestone",
+        OperatorConflictChoice::AbortCurrentRun => "abort_current_run",
+        OperatorConflictChoice::CreateFollowUpRun => "create_follow_up_run",
+        OperatorConflictChoice::RejectPatch => "reject_patch",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runs::clock::MockClock;
+    use crate::runs::registry::open_registry_pool;
+
+    fn store() -> RoadmapPatchStore {
+        let tmp = tempfile::tempdir().unwrap();
+        let clock = MockClock::new(1_700_000_000_000);
+        let pool = open_registry_pool(tmp.path(), &clock).unwrap();
+        RoadmapPatchStore::new(pool)
+    }
+
+    fn upsert(id: &str, content: &[u8], status: RoadmapPatchStatus) -> RoadmapPatchIndexUpsert {
+        RoadmapPatchIndexUpsert {
+            patch_id: RoadmapPatchId::new(id).unwrap(),
+            content_hash: ContentHash::compute(content),
+            run_id: None,
+            project_path: PathBuf::from("/tmp/project"),
+            target: RoadmapPatchTarget::ProjectRoadmap {
+                roadmap_path: ".ai-factory/ROADMAP.md".into(),
+            },
+            status,
+            patch_artifact: None,
+            patch_path: None,
+            summary_hash: None,
+            decision: None,
+            decision_comment: None,
+            conflict_choice: None,
+            observed_at_ms: 1_700_000_000_001,
+        }
+    }
+
+    #[test]
+    fn duplicate_content_hash_keeps_existing_patch_id() {
+        let store = store();
+        let first = store
+            .upsert(&upsert(
+                "rpatch-one",
+                b"same patch",
+                RoadmapPatchStatus::Drafted,
+            ))
+            .unwrap();
+        let second = store
+            .upsert(&upsert(
+                "rpatch-two",
+                b"same patch",
+                RoadmapPatchStatus::PendingApproval,
+            ))
+            .unwrap();
+
+        assert_eq!(second.patch_id, first.patch_id);
+        assert_eq!(second.status, RoadmapPatchStatus::PendingApproval);
+        assert!(
+            store
+                .get(&RoadmapPatchId::new("rpatch-two").unwrap())
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn list_filters_by_status_and_reject_is_idempotent() {
+        let store = store();
+        let pending = store
+            .upsert(&upsert(
+                "rpatch-pending",
+                b"pending patch",
+                RoadmapPatchStatus::PendingApproval,
+            ))
+            .unwrap();
+        let applied = store
+            .upsert(&upsert(
+                "rpatch-applied",
+                b"applied patch",
+                RoadmapPatchStatus::Applied,
+            ))
+            .unwrap();
+
+        let listed = store
+            .list(&RoadmapPatchIndexFilter {
+                status: Some(RoadmapPatchStatus::PendingApproval),
+                ..Default::default()
+            })
+            .unwrap();
+        assert_eq!(listed.len(), 1);
+        assert_eq!(listed[0].patch_id, pending.patch_id);
+
+        let rejected = store
+            .reject(
+                &pending.patch_id,
+                Some("no longer needed"),
+                Some(OperatorConflictChoice::RejectPatch),
+                1_700_000_000_500,
+            )
+            .unwrap()
+            .unwrap();
+        assert_eq!(rejected.status, RoadmapPatchStatus::Rejected);
+        assert_eq!(
+            rejected.decision,
+            Some(RoadmapPatchApprovalDecision::Reject)
+        );
+        assert_eq!(
+            rejected.decision_comment.as_deref(),
+            Some("no longer needed")
+        );
+        assert_eq!(
+            rejected.conflict_choice,
+            Some(OperatorConflictChoice::RejectPatch)
+        );
+
+        let still_applied = store
+            .reject(
+                &applied.patch_id,
+                Some("too late"),
+                Some(OperatorConflictChoice::RejectPatch),
+                1_700_000_000_600,
+            )
+            .unwrap()
+            .unwrap();
+        assert_eq!(still_applied.status, RoadmapPatchStatus::Applied);
+        assert_eq!(still_applied.decision_comment, None);
+    }
+}

--- a/crates/surge-persistence/src/runs/migrations.rs
+++ b/crates/surge-persistence/src/runs/migrations.rs
@@ -37,13 +37,23 @@ pub const REGISTRY_MIGRATIONS: MigrationSet = &[
         "registry-0005-inbox-queues",
         include_str!("migrations/registry/0005_inbox_queues.sql"),
     ),
+    (
+        "registry-0006-roadmap-patch-index",
+        include_str!("migrations/registry/0006_roadmap_patch_index.sql"),
+    ),
 ];
 
 /// Migrations applied to each per-run DB.
-pub const PER_RUN_MIGRATIONS: MigrationSet = &[(
-    "per-run-0001-initial",
-    include_str!("migrations/per_run/0001_initial.sql"),
-)];
+pub const PER_RUN_MIGRATIONS: MigrationSet = &[
+    (
+        "per-run-0001-initial",
+        include_str!("migrations/per_run/0001_initial.sql"),
+    ),
+    (
+        "per-run-0002-roadmap-patches",
+        include_str!("migrations/per_run/0002_roadmap_patches.sql"),
+    ),
+];
 
 /// Errors from the migration runner.
 #[derive(Debug, thiserror::Error)]
@@ -154,6 +164,16 @@ mod tests {
             .unwrap();
         assert_eq!(count, 1);
 
+        let count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM sqlite_master
+                 WHERE type='table' AND name='roadmap_patch_index'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(count, 1);
+
         let applied: i64 = conn
             .query_row("SELECT COUNT(*) FROM _migrations", [], |r| r.get(0))
             .unwrap();
@@ -174,6 +194,7 @@ mod tests {
             "pending_approvals",
             "cost_summary",
             "graph_snapshots",
+            "roadmap_patches",
         ] {
             let n: i64 = conn
                 .query_row(

--- a/crates/surge-persistence/src/runs/migrations/per_run/0002_roadmap_patches.sql
+++ b/crates/surge-persistence/src/runs/migrations/per_run/0002_roadmap_patches.sql
@@ -1,0 +1,27 @@
+CREATE TABLE roadmap_patches (
+    patch_id                  TEXT    PRIMARY KEY,
+    target_json               TEXT    NOT NULL,
+    status                    TEXT    NOT NULL,
+    patch_artifact            TEXT,
+    patch_path                TEXT,
+    summary_hash              TEXT,
+    decision                  TEXT,
+    decision_comment          TEXT,
+    conflict_choice           TEXT,
+    amended_roadmap_artifact  TEXT,
+    amended_roadmap_path      TEXT,
+    amended_flow_artifact     TEXT,
+    amended_flow_path         TEXT,
+    roadmap_artifact          TEXT,
+    roadmap_path              TEXT,
+    flow_artifact             TEXT,
+    flow_path                 TEXT,
+    active_pickup             TEXT,
+    created_seq               INTEGER NOT NULL,
+    updated_seq               INTEGER NOT NULL,
+    created_at                INTEGER NOT NULL,
+    updated_at                INTEGER NOT NULL
+);
+
+CREATE INDEX idx_roadmap_patches_status ON roadmap_patches(status);
+CREATE INDEX idx_roadmap_patches_updated ON roadmap_patches(updated_seq);

--- a/crates/surge-persistence/src/runs/migrations/registry/0006_roadmap_patch_index.sql
+++ b/crates/surge-persistence/src/runs/migrations/registry/0006_roadmap_patch_index.sql
@@ -1,0 +1,28 @@
+CREATE TABLE roadmap_patch_index (
+    patch_id          TEXT    PRIMARY KEY,
+    content_hash      TEXT    NOT NULL UNIQUE,
+    run_id            TEXT,
+    project_path      TEXT    NOT NULL,
+    target_json       TEXT    NOT NULL,
+    status            TEXT    NOT NULL,
+    patch_artifact    TEXT,
+    patch_path        TEXT,
+    summary_hash      TEXT,
+    decision          TEXT,
+    decision_comment  TEXT,
+    conflict_choice   TEXT,
+    created_at        INTEGER NOT NULL,
+    updated_at        INTEGER NOT NULL
+);
+
+CREATE INDEX idx_roadmap_patch_index_status
+    ON roadmap_patch_index(status);
+
+CREATE INDEX idx_roadmap_patch_index_project_status
+    ON roadmap_patch_index(project_path, status);
+
+CREATE INDEX idx_roadmap_patch_index_run
+    ON roadmap_patch_index(run_id);
+
+CREATE INDEX idx_roadmap_patch_index_updated
+    ON roadmap_patch_index(updated_at);

--- a/crates/surge-persistence/src/runs/mod.rs
+++ b/crates/surge-persistence/src/runs/mod.rs
@@ -72,5 +72,5 @@ pub use run_writer::RunWriter;
 pub use seq::EventSeq;
 pub use storage::{ActiveRunRow, Storage};
 pub use subscribe::SUBSCRIBE_BATCH_MAX;
-pub use types::{ArtifactRecord, CostSummary, PendingApproval, StageExecution};
+pub use types::{ArtifactRecord, CostSummary, PendingApproval, RoadmapPatchRecord, StageExecution};
 pub use writer::{DEFAULT_CHANNEL_CAPACITY, WriterCommand, WriterConfig};

--- a/crates/surge-persistence/src/runs/reader.rs
+++ b/crates/surge-persistence/src/runs/reader.rs
@@ -7,12 +7,14 @@ use std::sync::Arc;
 use r2d2::Pool;
 use r2d2_sqlite::SqliteConnectionManager;
 use rusqlite::params;
-use surge_core::{ContentHash, RunId, VersionedEventPayload, migrate_payload};
+use surge_core::{ContentHash, RoadmapPatchId, RunId, VersionedEventPayload, migrate_payload};
 
 use crate::runs::error::StorageError;
 use crate::runs::reader_views as views;
 use crate::runs::seq::EventSeq;
-use crate::runs::types::{ArtifactRecord, CostSummary, PendingApproval, StageExecution};
+use crate::runs::types::{
+    ArtifactRecord, CostSummary, PendingApproval, RoadmapPatchRecord, StageExecution,
+};
 
 /// Read-only handle on a per-run database.
 ///
@@ -193,6 +195,32 @@ impl RunReader {
         tokio::task::spawn_blocking(move || {
             let conn = pool.get().map_err(|e| StorageError::Pool(e.to_string()))?;
             views::cost_summary(&conn)
+        })
+        .await
+        .map_err(|e| StorageError::Pool(e.to_string()))?
+    }
+
+    /// Read all roadmap patch lifecycle records.
+    pub async fn roadmap_patches(&self) -> Result<Vec<RoadmapPatchRecord>, StorageError> {
+        let pool = self.pool.clone();
+        tokio::task::spawn_blocking(move || {
+            let conn = pool.get().map_err(|e| StorageError::Pool(e.to_string()))?;
+            views::roadmap_patches(&conn)
+        })
+        .await
+        .map_err(|e| StorageError::Pool(e.to_string()))?
+    }
+
+    /// Read one roadmap patch lifecycle record by ID.
+    pub async fn roadmap_patch(
+        &self,
+        patch_id: &RoadmapPatchId,
+    ) -> Result<Option<RoadmapPatchRecord>, StorageError> {
+        let pool = self.pool.clone();
+        let patch_id = patch_id.clone();
+        tokio::task::spawn_blocking(move || {
+            let conn = pool.get().map_err(|e| StorageError::Pool(e.to_string()))?;
+            views::roadmap_patch(&conn, &patch_id)
         })
         .await
         .map_err(|e| StorageError::Pool(e.to_string()))?

--- a/crates/surge-persistence/src/runs/reader_views.rs
+++ b/crates/surge-persistence/src/runs/reader_views.rs
@@ -146,7 +146,7 @@ pub fn roadmap_patches(
                 amended_flow_artifact, amended_flow_path,
                 roadmap_artifact, roadmap_path, flow_artifact, flow_path,
                 active_pickup, created_seq, updated_seq, created_at, updated_at
-         FROM roadmap_patches ORDER BY updated_seq, patch_id",
+         FROM roadmap_patches ORDER BY updated_seq DESC, patch_id",
     )?;
     let iter = stmt.query_map([], row_to_roadmap_patch)?;
     iter.collect::<rusqlite::Result<_>>().map_err(Into::into)

--- a/crates/surge-persistence/src/runs/reader_views.rs
+++ b/crates/surge-persistence/src/runs/reader_views.rs
@@ -7,12 +7,15 @@ use std::str::FromStr;
 
 use r2d2::PooledConnection;
 use r2d2_sqlite::SqliteConnectionManager;
-use rusqlite::params;
-use surge_core::{ContentHash, NodeKey};
+use rusqlite::{Row, params};
+use serde::de::DeserializeOwned;
+use surge_core::{ContentHash, NodeKey, RoadmapPatchId};
 
 use crate::runs::error::StorageError;
 use crate::runs::seq::EventSeq;
-use crate::runs::types::{ArtifactRecord, CostSummary, PendingApproval, StageExecution};
+use crate::runs::types::{
+    ArtifactRecord, CostSummary, PendingApproval, RoadmapPatchRecord, StageExecution,
+};
 
 /// Read all rows of the `stage_executions` view ordered by `started_seq`.
 pub fn stage_executions(
@@ -132,6 +135,45 @@ pub fn cost_summary(
     Ok(summary)
 }
 
+/// Read all roadmap patch lifecycle rows ordered by latest update.
+pub fn roadmap_patches(
+    conn: &PooledConnection<SqliteConnectionManager>,
+) -> Result<Vec<RoadmapPatchRecord>, StorageError> {
+    let mut stmt = conn.prepare(
+        "SELECT patch_id, target_json, status, patch_artifact, patch_path,
+                summary_hash, decision, decision_comment, conflict_choice,
+                amended_roadmap_artifact, amended_roadmap_path,
+                amended_flow_artifact, amended_flow_path,
+                roadmap_artifact, roadmap_path, flow_artifact, flow_path,
+                active_pickup, created_seq, updated_seq, created_at, updated_at
+         FROM roadmap_patches ORDER BY updated_seq, patch_id",
+    )?;
+    let iter = stmt.query_map([], row_to_roadmap_patch)?;
+    iter.collect::<rusqlite::Result<_>>().map_err(Into::into)
+}
+
+/// Read one roadmap patch lifecycle row by ID.
+pub fn roadmap_patch(
+    conn: &PooledConnection<SqliteConnectionManager>,
+    patch_id: &RoadmapPatchId,
+) -> Result<Option<RoadmapPatchRecord>, StorageError> {
+    match conn.query_row(
+        "SELECT patch_id, target_json, status, patch_artifact, patch_path,
+                summary_hash, decision, decision_comment, conflict_choice,
+                amended_roadmap_artifact, amended_roadmap_path,
+                amended_flow_artifact, amended_flow_path,
+                roadmap_artifact, roadmap_path, flow_artifact, flow_path,
+                active_pickup, created_seq, updated_seq, created_at, updated_at
+         FROM roadmap_patches WHERE patch_id = ?",
+        params![patch_id.as_str()],
+        row_to_roadmap_patch,
+    ) {
+        Ok(record) => Ok(Some(record)),
+        Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+        Err(error) => Err(error.into()),
+    }
+}
+
 /// List the seqs of all written graph snapshots.
 pub fn list_snapshots(
     conn: &PooledConnection<SqliteConnectionManager>,
@@ -139,6 +181,97 @@ pub fn list_snapshots(
     let mut stmt = conn.prepare("SELECT at_seq FROM graph_snapshots ORDER BY at_seq")?;
     let iter = stmt.query_map([], |row| Ok(EventSeq(row.get::<_, i64>(0)? as u64)))?;
     iter.collect::<rusqlite::Result<_>>().map_err(Into::into)
+}
+
+fn row_to_roadmap_patch(row: &Row<'_>) -> rusqlite::Result<RoadmapPatchRecord> {
+    let patch_id = parse_patch_id(row.get(0)?, 0)?;
+    let target = parse_json(row.get(1)?, 1)?;
+    let status = parse_json_string(row.get(2)?, 2)?;
+
+    Ok(RoadmapPatchRecord {
+        patch_id,
+        target,
+        status,
+        patch_artifact: parse_optional_hash(row.get(3)?, 3)?,
+        patch_path: optional_path(row.get(4)?),
+        summary_hash: parse_optional_hash(row.get(5)?, 5)?,
+        decision: parse_optional_json_string(row.get(6)?, 6)?,
+        decision_comment: row.get(7)?,
+        conflict_choice: parse_optional_json_string(row.get(8)?, 8)?,
+        amended_roadmap_artifact: parse_optional_hash(row.get(9)?, 9)?,
+        amended_roadmap_path: optional_path(row.get(10)?),
+        amended_flow_artifact: parse_optional_hash(row.get(11)?, 11)?,
+        amended_flow_path: optional_path(row.get(12)?),
+        roadmap_artifact: parse_optional_hash(row.get(13)?, 13)?,
+        roadmap_path: optional_path(row.get(14)?),
+        flow_artifact: parse_optional_hash(row.get(15)?, 15)?,
+        flow_path: optional_path(row.get(16)?),
+        active_pickup: parse_optional_json_string(row.get(17)?, 17)?,
+        created_seq: EventSeq(row.get::<_, i64>(18)? as u64),
+        updated_seq: EventSeq(row.get::<_, i64>(19)? as u64),
+        created_at_ms: row.get(20)?,
+        updated_at_ms: row.get(21)?,
+    })
+}
+
+fn parse_patch_id(value: String, column: usize) -> rusqlite::Result<RoadmapPatchId> {
+    RoadmapPatchId::from_str(&value).map_err(|error| {
+        rusqlite::Error::FromSqlConversionFailure(
+            column,
+            rusqlite::types::Type::Text,
+            Box::new(error),
+        )
+    })
+}
+
+fn parse_json<T: DeserializeOwned>(value: String, column: usize) -> rusqlite::Result<T> {
+    serde_json::from_str(&value).map_err(|error| {
+        rusqlite::Error::FromSqlConversionFailure(
+            column,
+            rusqlite::types::Type::Text,
+            Box::new(error),
+        )
+    })
+}
+
+fn parse_json_string<T: DeserializeOwned>(value: String, column: usize) -> rusqlite::Result<T> {
+    serde_json::from_value(serde_json::Value::String(value)).map_err(|error| {
+        rusqlite::Error::FromSqlConversionFailure(
+            column,
+            rusqlite::types::Type::Text,
+            Box::new(error),
+        )
+    })
+}
+
+fn parse_optional_json_string<T: DeserializeOwned>(
+    value: Option<String>,
+    column: usize,
+) -> rusqlite::Result<Option<T>> {
+    value
+        .map(|inner| parse_json_string(inner, column))
+        .transpose()
+}
+
+fn parse_optional_hash(
+    value: Option<String>,
+    column: usize,
+) -> rusqlite::Result<Option<ContentHash>> {
+    value
+        .map(|inner| {
+            ContentHash::from_str(&inner).map_err(|error| {
+                rusqlite::Error::FromSqlConversionFailure(
+                    column,
+                    rusqlite::types::Type::Text,
+                    Box::new(error),
+                )
+            })
+        })
+        .transpose()
+}
+
+fn optional_path(value: Option<String>) -> Option<PathBuf> {
+    value.map(PathBuf::from)
 }
 
 /// Find the most recent snapshot at or before `seq`, returning the seq and raw blob.

--- a/crates/surge-persistence/src/runs/storage.rs
+++ b/crates/surge-persistence/src/runs/storage.rs
@@ -11,6 +11,7 @@ use r2d2_sqlite::SqliteConnectionManager;
 use surge_core::RunId;
 use tokio::runtime::{Handle, RuntimeFlavor};
 
+use crate::roadmap_patches::RoadmapPatchStore;
 use crate::runs::clock::{Clock, SystemClock};
 use crate::runs::config::{StorageConfig, load_or_default};
 use crate::runs::error::OpenError;
@@ -80,6 +81,11 @@ impl Storage {
     /// Registry database path.
     pub fn registry_db_path(&self) -> PathBuf {
         self.home.join("db").join("registry.sqlite")
+    }
+
+    /// Registry-level roadmap patch metadata store.
+    pub fn roadmap_patch_store(&self) -> RoadmapPatchStore {
+        RoadmapPatchStore::new(self.registry_pool.clone())
     }
 
     /// Acquire a registry-pool connection. Used by inbox subsystems that

--- a/crates/surge-persistence/src/runs/types.rs
+++ b/crates/surge-persistence/src/runs/types.rs
@@ -3,7 +3,10 @@
 use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
-use surge_core::{ContentHash, NodeKey};
+use surge_core::{
+    ActivePickupPolicy, ContentHash, NodeKey, OperatorConflictChoice, RoadmapPatchApprovalDecision,
+    RoadmapPatchId, RoadmapPatchStatus, RoadmapPatchTarget,
+};
 
 use crate::runs::seq::EventSeq;
 
@@ -68,6 +71,55 @@ pub struct PendingApproval {
     pub delivered: bool,
     /// External message id assigned by the channel after delivery, NULL otherwise.
     pub message_id: Option<i64>,
+}
+
+/// One row of the `roadmap_patches` materialized view.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RoadmapPatchRecord {
+    /// Stable patch identifier.
+    pub patch_id: RoadmapPatchId,
+    /// Target roadmap or run.
+    pub target: RoadmapPatchTarget,
+    /// Latest lifecycle status derived from events.
+    pub status: RoadmapPatchStatus,
+    /// Stored patch artifact hash.
+    pub patch_artifact: Option<ContentHash>,
+    /// Stored patch path.
+    pub patch_path: Option<PathBuf>,
+    /// Approval summary hash, when approval was requested.
+    pub summary_hash: Option<ContentHash>,
+    /// Operator approval decision, when known.
+    pub decision: Option<RoadmapPatchApprovalDecision>,
+    /// Operator comment, when present.
+    pub decision_comment: Option<String>,
+    /// Conflict choice selected by the operator, when present.
+    pub conflict_choice: Option<OperatorConflictChoice>,
+    /// Amended roadmap artifact from the apply step.
+    pub amended_roadmap_artifact: Option<ContentHash>,
+    /// Amended roadmap path from the apply step.
+    pub amended_roadmap_path: Option<PathBuf>,
+    /// Amended flow artifact from the apply step.
+    pub amended_flow_artifact: Option<ContentHash>,
+    /// Amended flow path from the apply step.
+    pub amended_flow_path: Option<PathBuf>,
+    /// Latest roadmap artifact accepted by the runner/read model.
+    pub roadmap_artifact: Option<ContentHash>,
+    /// Latest roadmap path accepted by the runner/read model.
+    pub roadmap_path: Option<PathBuf>,
+    /// Latest flow artifact accepted by the runner/read model.
+    pub flow_artifact: Option<ContentHash>,
+    /// Latest flow path accepted by the runner/read model.
+    pub flow_path: Option<PathBuf>,
+    /// Active pickup policy captured with `RoadmapUpdated`.
+    pub active_pickup: Option<ActivePickupPolicy>,
+    /// Event seq that first created the record.
+    pub created_seq: EventSeq,
+    /// Event seq that last updated the record.
+    pub updated_seq: EventSeq,
+    /// Unix epoch ms when record was created.
+    pub created_at_ms: i64,
+    /// Unix epoch ms when record was updated.
+    pub updated_at_ms: i64,
 }
 
 /// Summary of cost-related metrics from the `cost_summary` view.

--- a/crates/surge-persistence/src/runs/views.rs
+++ b/crates/surge-persistence/src/runs/views.rs
@@ -13,6 +13,10 @@
 //! All other event variants currently produce no view changes.
 
 use rusqlite::Transaction;
+use surge_core::roadmap_patch::{
+    ActivePickupPolicy, OperatorConflictChoice, RoadmapPatchApprovalDecision, RoadmapPatchStatus,
+    RoadmapPatchTarget,
+};
 use surge_core::run_event::EventPayload;
 
 use crate::runs::error::WriterError;
@@ -30,12 +34,13 @@ pub fn maintain(
     use EventPayload::{
         ApprovalDecided, ApprovalRequested, ArtifactProduced, BootstrapApprovalDecided,
         BootstrapApprovalRequested, BootstrapArtifactProduced, BootstrapEditRequested,
-        BootstrapStageStarted, EdgeTraversed, ForkCreated, HookExecuted, LoopCompleted,
-        LoopIterationCompleted, LoopIterationStarted, OutcomeRejectedByHook, OutcomeReported,
-        PipelineMaterialized, RunAborted, RunCompleted, RunFailed, RunStarted,
-        SandboxElevationDecided, SandboxElevationRequested, SessionClosed, SessionOpened,
-        StageCompleted, StageEntered, StageFailed, StageInputsResolved, TokensConsumed, ToolCalled,
-        ToolResultReceived,
+        BootstrapStageStarted, EdgeTraversed, ForkCreated, GraphRevisionAccepted, HookExecuted,
+        LoopCompleted, LoopIterationCompleted, LoopIterationStarted, OutcomeRejectedByHook,
+        OutcomeReported, PipelineMaterialized, RoadmapPatchApplied, RoadmapPatchApprovalDecided,
+        RoadmapPatchApprovalRequested, RoadmapPatchDrafted, RoadmapUpdated, RunAborted,
+        RunCompleted, RunFailed, RunStarted, SandboxElevationDecided, SandboxElevationRequested,
+        SessionClosed, SessionOpened, StageCompleted, StageEntered, StageFailed,
+        StageInputsResolved, TokensConsumed, ToolCalled, ToolResultReceived,
     };
     match payload {
         StageEntered { node, attempt } => {
@@ -141,6 +146,176 @@ pub fn maintain(
                 rusqlite::params![gate.as_str()],
             )?;
         },
+        RoadmapPatchDrafted {
+            patch_id,
+            target,
+            patch_artifact,
+            patch_path,
+        } => {
+            let target_json = target_json(target)?;
+            tx.execute(
+                "INSERT INTO roadmap_patches
+                    (patch_id, target_json, status, patch_artifact, patch_path,
+                     created_seq, updated_seq, created_at, updated_at)
+                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                 ON CONFLICT(patch_id) DO UPDATE SET
+                    target_json = excluded.target_json,
+                    status = excluded.status,
+                    patch_artifact = excluded.patch_artifact,
+                    patch_path = excluded.patch_path,
+                    updated_seq = excluded.updated_seq,
+                    updated_at = excluded.updated_at",
+                rusqlite::params![
+                    patch_id.as_str(),
+                    target_json,
+                    status_label(RoadmapPatchStatus::Drafted),
+                    patch_artifact.to_string(),
+                    patch_path.to_string_lossy(),
+                    seq.0 as i64,
+                    seq.0 as i64,
+                    timestamp_ms,
+                    timestamp_ms,
+                ],
+            )?;
+        },
+        RoadmapPatchApprovalRequested {
+            patch_id,
+            target,
+            summary_hash,
+            ..
+        } => {
+            let target_json = target_json(target)?;
+            tx.execute(
+                "UPDATE roadmap_patches
+                 SET target_json = ?,
+                     status = ?,
+                     summary_hash = ?,
+                     updated_seq = ?,
+                     updated_at = ?
+                 WHERE patch_id = ?",
+                rusqlite::params![
+                    target_json,
+                    status_label(RoadmapPatchStatus::PendingApproval),
+                    summary_hash.to_string(),
+                    seq.0 as i64,
+                    timestamp_ms,
+                    patch_id.as_str(),
+                ],
+            )?;
+        },
+        RoadmapPatchApprovalDecided {
+            patch_id,
+            decision,
+            comment,
+            conflict_choice,
+            ..
+        } => {
+            tx.execute(
+                "UPDATE roadmap_patches
+                 SET status = ?,
+                     decision = ?,
+                     decision_comment = ?,
+                     conflict_choice = ?,
+                     updated_seq = ?,
+                     updated_at = ?
+                 WHERE patch_id = ?",
+                rusqlite::params![
+                    status_label(status_for_decision(*decision)),
+                    decision_label(*decision),
+                    comment,
+                    conflict_choice.map(choice_label),
+                    seq.0 as i64,
+                    timestamp_ms,
+                    patch_id.as_str(),
+                ],
+            )?;
+        },
+        RoadmapPatchApplied {
+            patch_id,
+            target,
+            amended_roadmap_artifact,
+            amended_roadmap_path,
+            amended_flow_artifact,
+            amended_flow_path,
+        } => {
+            let target_json = target_json(target)?;
+            tx.execute(
+                "INSERT INTO roadmap_patches
+                    (patch_id, target_json, status,
+                     amended_roadmap_artifact, amended_roadmap_path,
+                     amended_flow_artifact, amended_flow_path,
+                     created_seq, updated_seq, created_at, updated_at)
+                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                 ON CONFLICT(patch_id) DO UPDATE SET
+                    target_json = excluded.target_json,
+                    status = excluded.status,
+                    amended_roadmap_artifact = excluded.amended_roadmap_artifact,
+                    amended_roadmap_path = excluded.amended_roadmap_path,
+                    amended_flow_artifact = excluded.amended_flow_artifact,
+                    amended_flow_path = excluded.amended_flow_path,
+                    updated_seq = excluded.updated_seq,
+                    updated_at = excluded.updated_at",
+                rusqlite::params![
+                    patch_id.as_str(),
+                    target_json,
+                    status_label(RoadmapPatchStatus::Applied),
+                    amended_roadmap_artifact.to_string(),
+                    amended_roadmap_path.to_string_lossy(),
+                    amended_flow_artifact.map(|hash| hash.to_string()),
+                    amended_flow_path
+                        .as_ref()
+                        .map(|path| path.to_string_lossy().to_string()),
+                    seq.0 as i64,
+                    seq.0 as i64,
+                    timestamp_ms,
+                    timestamp_ms,
+                ],
+            )?;
+        },
+        RoadmapUpdated {
+            patch_id,
+            target,
+            roadmap_artifact,
+            roadmap_path,
+            flow_artifact,
+            flow_path,
+            active_pickup,
+        } => {
+            let target_json = target_json(target)?;
+            tx.execute(
+                "INSERT INTO roadmap_patches
+                    (patch_id, target_json, status,
+                     roadmap_artifact, roadmap_path, flow_artifact, flow_path,
+                     active_pickup, created_seq, updated_seq, created_at, updated_at)
+                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                 ON CONFLICT(patch_id) DO UPDATE SET
+                    target_json = excluded.target_json,
+                    status = excluded.status,
+                    roadmap_artifact = excluded.roadmap_artifact,
+                    roadmap_path = excluded.roadmap_path,
+                    flow_artifact = excluded.flow_artifact,
+                    flow_path = excluded.flow_path,
+                    active_pickup = excluded.active_pickup,
+                    updated_seq = excluded.updated_seq,
+                    updated_at = excluded.updated_at",
+                rusqlite::params![
+                    patch_id.as_str(),
+                    target_json,
+                    status_label(RoadmapPatchStatus::Applied),
+                    roadmap_artifact.to_string(),
+                    roadmap_path.to_string_lossy(),
+                    flow_artifact.map(|hash| hash.to_string()),
+                    flow_path
+                        .as_ref()
+                        .map(|path| path.to_string_lossy().to_string()),
+                    pickup_label(*active_pickup),
+                    seq.0 as i64,
+                    seq.0 as i64,
+                    timestamp_ms,
+                    timestamp_ms,
+                ],
+            )?;
+        },
         // All other variants currently produce no view changes.
         // Listed explicitly here so a future variant addition forces a
         // conscious decision rather than silently falling through.
@@ -154,6 +329,7 @@ pub fn maintain(
         | BootstrapApprovalDecided { .. }
         | BootstrapEditRequested { .. }
         | PipelineMaterialized { .. }
+        | GraphRevisionAccepted { .. }
         | StageInputsResolved { .. }
         | SessionOpened { .. }
         | ToolCalled { .. }
@@ -188,6 +364,54 @@ fn upsert_metric(tx: &Transaction<'_>, metric: &str, delta: f64, ts: i64) -> rus
     Ok(())
 }
 
+fn target_json(target: &RoadmapPatchTarget) -> Result<String, WriterError> {
+    serde_json::to_string(target).map_err(Into::into)
+}
+
+const fn status_for_decision(decision: RoadmapPatchApprovalDecision) -> RoadmapPatchStatus {
+    match decision {
+        RoadmapPatchApprovalDecision::Approve => RoadmapPatchStatus::Approved,
+        RoadmapPatchApprovalDecision::Edit => RoadmapPatchStatus::Drafted,
+        RoadmapPatchApprovalDecision::Reject => RoadmapPatchStatus::Rejected,
+    }
+}
+
+const fn status_label(status: RoadmapPatchStatus) -> &'static str {
+    match status {
+        RoadmapPatchStatus::Drafted => "drafted",
+        RoadmapPatchStatus::PendingApproval => "pending_approval",
+        RoadmapPatchStatus::Approved => "approved",
+        RoadmapPatchStatus::Applied => "applied",
+        RoadmapPatchStatus::Rejected => "rejected",
+        RoadmapPatchStatus::Superseded => "superseded",
+    }
+}
+
+const fn decision_label(decision: RoadmapPatchApprovalDecision) -> &'static str {
+    match decision {
+        RoadmapPatchApprovalDecision::Approve => "approve",
+        RoadmapPatchApprovalDecision::Edit => "edit",
+        RoadmapPatchApprovalDecision::Reject => "reject",
+    }
+}
+
+const fn choice_label(choice: OperatorConflictChoice) -> &'static str {
+    match choice {
+        OperatorConflictChoice::DeferToNextMilestone => "defer_to_next_milestone",
+        OperatorConflictChoice::AbortCurrentRun => "abort_current_run",
+        OperatorConflictChoice::CreateFollowUpRun => "create_follow_up_run",
+        OperatorConflictChoice::RejectPatch => "reject_patch",
+    }
+}
+
+const fn pickup_label(policy: ActivePickupPolicy) -> &'static str {
+    match policy {
+        ActivePickupPolicy::Allowed => "allowed",
+        ActivePickupPolicy::FollowUpOnly => "follow_up_only",
+        ActivePickupPolicy::Disabled => "disabled",
+    }
+}
+
 /// Truncate all materialized view tables. Called at the start of `RebuildViews`.
 pub fn rebuild(tx: &Transaction<'_>) -> Result<(), WriterError> {
     tx.execute_batch(
@@ -195,7 +419,8 @@ pub fn rebuild(tx: &Transaction<'_>) -> Result<(), WriterError> {
          DELETE FROM artifacts;
          DELETE FROM pending_approvals;
          DELETE FROM cost_summary;
-         DELETE FROM graph_snapshots;",
+         DELETE FROM graph_snapshots;
+         DELETE FROM roadmap_patches;",
     )?;
     Ok(())
 }
@@ -208,7 +433,10 @@ mod tests {
     use rusqlite::Connection;
     use std::path::PathBuf;
     use std::str::FromStr;
-    use surge_core::approvals::ApprovalChannel;
+    use surge_core::approvals::{ApprovalChannel, ApprovalChannelKind, ApprovalDuration};
+    use surge_core::roadmap_patch::{
+        ActivePickupPolicy, RoadmapPatchApprovalDecision, RoadmapPatchId, RoadmapPatchTarget,
+    };
     use surge_core::run_event::EventPayload;
     use surge_core::{ContentHash, NodeKey, OutcomeKey, SessionId};
 
@@ -652,8 +880,6 @@ mod tests {
 
     #[test]
     fn approval_requested_then_decided_clears_row() {
-        use surge_core::approvals::ApprovalChannelKind;
-
         let mut conn = fresh_db();
         let tx = conn.transaction().unwrap();
         maintain(
@@ -694,6 +920,104 @@ mod tests {
     }
 
     #[test]
+    fn roadmap_patch_lifecycle_updates_view() {
+        let mut conn = fresh_db();
+        let tx = conn.transaction().unwrap();
+        let patch_id = RoadmapPatchId::new("rpatch-view").unwrap();
+        let target = RoadmapPatchTarget::ProjectRoadmap {
+            roadmap_path: ".ai-factory/ROADMAP.md".into(),
+        };
+        let patch_hash = ContentHash::compute(b"patch");
+        let roadmap_hash = ContentHash::compute(b"roadmap");
+        let flow_hash = ContentHash::compute(b"flow");
+
+        maintain(
+            &tx,
+            EventSeq(1),
+            1_700_000_000_001,
+            &EventPayload::RoadmapPatchDrafted {
+                patch_id: patch_id.clone(),
+                target: target.clone(),
+                patch_artifact: patch_hash,
+                patch_path: PathBuf::from("roadmap-patch.toml"),
+            },
+        )
+        .unwrap();
+        maintain(
+            &tx,
+            EventSeq(2),
+            1_700_000_000_002,
+            &EventPayload::RoadmapPatchApprovalRequested {
+                patch_id: patch_id.clone(),
+                target: target.clone(),
+                channel: ApprovalChannel::Desktop {
+                    duration: ApprovalDuration::Transient,
+                },
+                summary_hash: ContentHash::compute(b"summary"),
+            },
+        )
+        .unwrap();
+        maintain(
+            &tx,
+            EventSeq(3),
+            1_700_000_000_003,
+            &EventPayload::RoadmapPatchApprovalDecided {
+                patch_id: patch_id.clone(),
+                decision: RoadmapPatchApprovalDecision::Approve,
+                channel_used: ApprovalChannelKind::Desktop,
+                comment: Some("ok".into()),
+                conflict_choice: None,
+            },
+        )
+        .unwrap();
+        maintain(
+            &tx,
+            EventSeq(4),
+            1_700_000_000_004,
+            &EventPayload::RoadmapUpdated {
+                patch_id: patch_id.clone(),
+                target,
+                roadmap_artifact: roadmap_hash,
+                roadmap_path: PathBuf::from("roadmap.toml"),
+                flow_artifact: Some(flow_hash),
+                flow_path: Some(PathBuf::from("flow.toml")),
+                active_pickup: ActivePickupPolicy::Allowed,
+            },
+        )
+        .unwrap();
+        tx.commit().unwrap();
+
+        let (status, patch_artifact, roadmap_artifact, flow_artifact, updated_seq): (
+            String,
+            String,
+            String,
+            String,
+            i64,
+        ) = conn
+            .query_row(
+                "SELECT status, patch_artifact, roadmap_artifact, flow_artifact, updated_seq
+                 FROM roadmap_patches WHERE patch_id = ?",
+                rusqlite::params![patch_id.as_str()],
+                |row| {
+                    Ok((
+                        row.get(0)?,
+                        row.get(1)?,
+                        row.get(2)?,
+                        row.get(3)?,
+                        row.get(4)?,
+                    ))
+                },
+            )
+            .unwrap();
+
+        assert_eq!(status, "applied");
+        assert_eq!(patch_artifact, patch_hash.to_string());
+        assert_eq!(roadmap_artifact, roadmap_hash.to_string());
+        assert_eq!(flow_artifact, flow_hash.to_string());
+        assert_eq!(updated_seq, 4);
+    }
+
+    #[test]
     fn no_op_variant_does_not_touch_views() {
         let mut conn = fresh_db();
         let tx = conn.transaction().unwrap();
@@ -714,6 +1038,7 @@ mod tests {
             "artifacts",
             "pending_approvals",
             "cost_summary",
+            "roadmap_patches",
         ] {
             let n: i64 = conn
                 .query_row(&format!("SELECT COUNT(*) FROM {table}"), [], |r| r.get(0))

--- a/crates/surge-persistence/src/runs/views.rs
+++ b/crates/surge-persistence/src/runs/views.rs
@@ -163,6 +163,19 @@ pub fn maintain(
                     status = excluded.status,
                     patch_artifact = excluded.patch_artifact,
                     patch_path = excluded.patch_path,
+                    summary_hash = NULL,
+                    decision = NULL,
+                    decision_comment = NULL,
+                    conflict_choice = NULL,
+                    amended_roadmap_artifact = NULL,
+                    amended_roadmap_path = NULL,
+                    amended_flow_artifact = NULL,
+                    amended_flow_path = NULL,
+                    roadmap_artifact = NULL,
+                    roadmap_path = NULL,
+                    flow_artifact = NULL,
+                    flow_path = NULL,
+                    active_pickup = NULL,
                     updated_seq = excluded.updated_seq,
                     updated_at = excluded.updated_at",
                 rusqlite::params![
@@ -190,6 +203,18 @@ pub fn maintain(
                  SET target_json = ?,
                      status = ?,
                      summary_hash = ?,
+                     decision = NULL,
+                     decision_comment = NULL,
+                     conflict_choice = NULL,
+                     amended_roadmap_artifact = NULL,
+                     amended_roadmap_path = NULL,
+                     amended_flow_artifact = NULL,
+                     amended_flow_path = NULL,
+                     roadmap_artifact = NULL,
+                     roadmap_path = NULL,
+                     flow_artifact = NULL,
+                     flow_path = NULL,
+                     active_pickup = NULL,
                      updated_seq = ?,
                      updated_at = ?
                  WHERE patch_id = ?",
@@ -1015,6 +1040,129 @@ mod tests {
         assert_eq!(roadmap_artifact, roadmap_hash.to_string());
         assert_eq!(flow_artifact, flow_hash.to_string());
         assert_eq!(updated_seq, 4);
+    }
+
+    #[test]
+    fn roadmap_patch_draft_and_pending_clear_stale_lifecycle_fields() {
+        let mut conn = fresh_db();
+        let tx = conn.transaction().unwrap();
+        let patch_id = RoadmapPatchId::new("rpatch-clear").unwrap();
+        let target = RoadmapPatchTarget::ProjectRoadmap {
+            roadmap_path: ".ai-factory/ROADMAP.md".into(),
+        };
+        let patch_hash = ContentHash::compute(b"patch");
+        let next_patch_hash = ContentHash::compute(b"patch-next");
+
+        maintain(
+            &tx,
+            EventSeq(1),
+            1_700_000_000_001,
+            &EventPayload::RoadmapPatchDrafted {
+                patch_id: patch_id.clone(),
+                target: target.clone(),
+                patch_artifact: patch_hash,
+                patch_path: PathBuf::from("roadmap-patch.toml"),
+            },
+        )
+        .unwrap();
+        maintain(
+            &tx,
+            EventSeq(2),
+            1_700_000_000_002,
+            &EventPayload::RoadmapPatchApprovalRequested {
+                patch_id: patch_id.clone(),
+                target: target.clone(),
+                channel: ApprovalChannel::Desktop {
+                    duration: ApprovalDuration::Transient,
+                },
+                summary_hash: ContentHash::compute(b"summary"),
+            },
+        )
+        .unwrap();
+        maintain(
+            &tx,
+            EventSeq(3),
+            1_700_000_000_003,
+            &EventPayload::RoadmapPatchApprovalDecided {
+                patch_id: patch_id.clone(),
+                decision: RoadmapPatchApprovalDecision::Approve,
+                channel_used: ApprovalChannelKind::Desktop,
+                comment: Some("ok".into()),
+                conflict_choice: Some(OperatorConflictChoice::CreateFollowUpRun),
+            },
+        )
+        .unwrap();
+        maintain(
+            &tx,
+            EventSeq(4),
+            1_700_000_000_004,
+            &EventPayload::RoadmapUpdated {
+                patch_id: patch_id.clone(),
+                target: target.clone(),
+                roadmap_artifact: ContentHash::compute(b"roadmap"),
+                roadmap_path: PathBuf::from("roadmap.toml"),
+                flow_artifact: Some(ContentHash::compute(b"flow")),
+                flow_path: Some(PathBuf::from("flow.toml")),
+                active_pickup: ActivePickupPolicy::Allowed,
+            },
+        )
+        .unwrap();
+        maintain(
+            &tx,
+            EventSeq(5),
+            1_700_000_000_005,
+            &EventPayload::RoadmapPatchDrafted {
+                patch_id: patch_id.clone(),
+                target: target.clone(),
+                patch_artifact: next_patch_hash,
+                patch_path: PathBuf::from("roadmap-patch-next.toml"),
+            },
+        )
+        .unwrap();
+        maintain(
+            &tx,
+            EventSeq(6),
+            1_700_000_000_006,
+            &EventPayload::RoadmapPatchApprovalRequested {
+                patch_id: patch_id.clone(),
+                target,
+                channel: ApprovalChannel::Desktop {
+                    duration: ApprovalDuration::Transient,
+                },
+                summary_hash: ContentHash::compute(b"summary-next"),
+            },
+        )
+        .unwrap();
+        tx.commit().unwrap();
+
+        let (status, decision, conflict_choice, roadmap_artifact, flow_artifact): (
+            String,
+            Option<String>,
+            Option<String>,
+            Option<String>,
+            Option<String>,
+        ) = conn
+            .query_row(
+                "SELECT status, decision, conflict_choice, roadmap_artifact, flow_artifact
+                 FROM roadmap_patches WHERE patch_id = ?",
+                rusqlite::params![patch_id.as_str()],
+                |row| {
+                    Ok((
+                        row.get(0)?,
+                        row.get(1)?,
+                        row.get(2)?,
+                        row.get(3)?,
+                        row.get(4)?,
+                    ))
+                },
+            )
+            .unwrap();
+
+        assert_eq!(status, "pending_approval");
+        assert_eq!(decision, None);
+        assert_eq!(conflict_choice, None);
+        assert_eq!(roadmap_artifact, None);
+        assert_eq!(flow_artifact, None);
     }
 
     #[test]

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,9 +7,9 @@ Detailed docs for the Surge workspace. The project landing page is [`README.md`]
 | Page | Description |
 |---|---|
 | [Getting Started](getting-started.md) | Requirements, build, project initialization, run examples, agent configuration, smoke tests |
-| [CLI](cli.md) | Command surface, project context commands, execution paths, current → target mapping |
+| [CLI](cli.md) | Command surface, project context commands, execution paths, roadmap amendment commands |
 | [Bootstrap](bootstrap.md) | Adaptive prompt → description → roadmap → flow generation |
-| [Workflow](workflow.md) | AFK workflow, flow model, intake sources, run lifecycle |
+| [Workflow](workflow.md) | AFK workflow, flow model, intake sources, roadmap amendments, run lifecycle |
 | [Architecture](ARCHITECTURE.md) | Canonical architecture: positioning, principles, engine, ACP bridge, storage |
 | [Hooks](hooks.md) | `pre_tool_use` / `post_tool_use` / `on_outcome` / `on_error` lifecycle, matcher, failure modes |
 | [Artifact Conventions](conventions/README.md) | Canonical generated artifact names, schemas, validators, and examples |

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -17,6 +17,7 @@ surge spec ...          manage legacy specs
 surge run ...           execute the legacy spec pipeline
 surge bootstrap ...     generate an adaptive flow from a free-form prompt
 surge engine ...        execute flow.toml graphs
+surge feature ...       draft, approve, list, show, or reject roadmap amendments
 surge artifact ...      validate generated artifacts against Surge contracts
 surge daemon ...        manage the long-running local engine host
 surge clean             clean up orphaned worktrees and merged branches
@@ -50,7 +51,7 @@ The product model in [`docs/ARCHITECTURE.md`](ARCHITECTURE.md) describes a riche
 | Describe or refresh project context | `surge project describe`, optionally with `--dry-run`, `--refresh`, `--output <path>`, or `--author-mode <auto\|agent\|deterministic>` | `auto` uses Project Context Author through ACP when its runtime is installed, otherwise falls back to deterministic local context. |
 | Create a focused feature/task run | `surge bootstrap "..."` or `surge engine run --template single-task --watch` | Bootstrap is now available; richer daemon/Telegram approval UX is still target behavior. |
 | Run a full roadmap/flow | `surge bootstrap "..."` or manually create `flow.toml`, then `surge engine run <flow.toml> --watch` | Bootstrap generates roadmap and flow; tracker intake and richer approval channels are still target UX. |
-| Amend an existing roadmap with a new feature | Create another spec with `surge spec create ...` or edit roadmap/flow files manually | No `surge feature` command yet that inserts work into a roadmap and wakes the runner. |
+| Amend an existing roadmap with a new feature | `surge feature describe "..." --project` or `surge feature describe "..." --run <run_id>` | Active-run pickup is stored through amendment events; Telegram rich cards are still target UX. |
 | Run AFK through a daemon | `surge daemon start` and `surge engine run <flow.toml> --daemon --watch` | Daemon exists; the full Telegram approval bot and tracker intake loop are still target UX. |
 | Start from GitHub Issues or Linear | No direct CLI equivalent | GitHub / Linear issue intake should normalize tracker payloads into the same bootstrap path; not a user-facing command yet. |
 
@@ -80,6 +81,23 @@ used by bundled profile `on_outcome` hooks for description, roadmap, and spec
 artifacts. See [Artifact Conventions](conventions/README.md) for every
 canonical path and minimal example.
 
+## Roadmap Amendments
+
+`surge feature` is the current roadmap-amendment surface. It asks the bundled Feature Planner profile for a `roadmap-patch.toml`, stores the draft in the run artifact store, records lifecycle events, and mirrors patch metadata into the registry index for quick lookup.
+
+```text
+surge feature describe "add CSV export" --project
+surge feature describe "add CSV export" --run <run_id> --approval prompt
+surge feature describe "add CSV export" --run <run_id> --approval approve --conflict-choice create-follow-up-run
+surge feature list --status pending-approval
+surge feature show rpatch-...
+surge feature reject rpatch-... --reason "out of scope"
+```
+
+Approval modes are `prompt`, `approve`, `reject`, and `store`. When a patch conflicts with already-running or terminal roadmap history, choose one conflict resolution: `defer-to-next-milestone`, `abort-current-run`, `create-follow-up-run`, or `reject-patch`. The selected choice is persisted in `RoadmapPatchApprovalDecided` and in the registry row so `feature show` can report it later.
+
+For debugging, set `RUST_LOG=feature_cli=debug,roadmap_amendment=debug,roadmap_patch_index=debug`. Conflict detection logs stable conflict codes at WARN level; approval, apply, follow-up, and registry transitions log at INFO.
+
 ## Project Initialization And Context
 
 `surge init --default` is the non-interactive setup path. It writes a complete validated `surge.toml`, chooses the best detected ACP registry agent when possible, and keeps an existing config unchanged. `surge init` without flags enters the wizard and can update onboarding sections in an existing config while preserving unrelated TOML content.
@@ -104,7 +122,6 @@ From the product model in [`docs/ARCHITECTURE.md`](ARCHITECTURE.md), command nam
 
 ```text
 surge task ...          create a focused task run
-surge feature ...       amend roadmap with a new feature
 ```
 
 ## See Also

--- a/docs/conventions/roadmap.md
+++ b/docs/conventions/roadmap.md
@@ -55,6 +55,65 @@ mitigation = "Keep profile prompts linked to this convention."
 - Tasks include clear titles and testable acceptance criteria when known.
 - Markdown compatibility view has `## Milestones`, `## Dependencies`, and `## Risks`.
 
+## Roadmap Patch Artifacts
+
+`surge feature describe` produces `roadmap-patch.toml` through the Feature
+Planner profile. A patch is an amendment proposal, not an immediate mutation.
+It includes a target, rationale, ordered operations, optional dependencies,
+optional conflicts, and a lifecycle status.
+
+Minimal append example:
+
+```toml
+schema_version = 1
+id = "rpatch-csv-export"
+rationale = "User asked for CSV export after the roadmap was approved."
+status = "drafted"
+
+[target]
+kind = "project_roadmap"
+roadmap_path = ".ai-factory/ROADMAP.md"
+
+[[operations]]
+op = "add_task"
+milestone_id = "m2"
+
+[operations.task]
+id = "m2-csv-export"
+title = "Add CSV export"
+acceptance_criteria = ["Exports current table filters", "Handles empty result sets"]
+
+[operations.insertion]
+kind = "append_to_milestone"
+milestone_id = "m2"
+```
+
+Conflicts use stable codes such as `running_milestone`,
+`completed_history`, `missing_target`, `duplicate_item`,
+`dependency_cycle`, and `unsupported_operation`. Running milestone conflicts
+must expose clear operator choices:
+
+```toml
+[[conflicts]]
+code = "running_milestone"
+message = "m2 is already running; choose where the new work should go."
+choices = [
+  "defer_to_next_milestone",
+  "abort_current_run",
+  "create_follow_up_run",
+  "reject_patch",
+]
+
+[conflicts.item]
+kind = "milestone"
+milestone_id = "m2"
+```
+
+When an operator chooses a resolution, Surge records it in
+`RoadmapPatchApprovalDecided.conflict_choice` and in the registry patch index.
+The patch artifact remains the proposal; events and views carry lifecycle
+state so replay stays deterministic.
+
 ## Profile Guidance
 
 Roadmap Planner should report both `roadmap.toml` and `roadmap.md`. The bundled

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -263,37 +263,55 @@ future runs, not replay or resume of the current run.
 
 ## Roadmap Amendments
 
-Roadmaps are not frozen documents. After roadmap approval, the user can add a feature through a target `surge feature` flow. The feature planner proposes a patch: where to insert the feature and how to expand it into milestone / tasks.
+Roadmaps are not frozen documents. After roadmap approval, the user can add a feature through `surge feature describe`. The Feature Planner proposes a typed `roadmap-patch.toml`: target, rationale, operations, dependencies, detected conflicts, and lifecycle status. Surge stores the patch as a run artifact, appends amendment lifecycle events, and mirrors patch metadata into the registry so `surge feature list/show/reject` does not have to scan every run log.
 
 ```mermaid
 flowchart TD
     User[surge feature<br/>describe new feature]
-    Chat[Interactive chat<br/>clarify scope]
     FeatureAgent[Feature planner agent]
     Patch[Roadmap patch<br/>placement + task breakdown]
+    Conflict{Conflict?}
+    Choice{Operator choice}
     Decision{Approve patch?}
     RoadmapUpdate[roadmap.md vNext]
-    FlowUpdate[Update flow<br/>new milestone/task nodes]
-    RunnerState{Roadmap runner active?}
-    ActiveRunner[Runner picks up<br/>new pending work]
-    FollowUp[Create follow-up run]
+    Events[RoadmapUpdated<br/>GraphRevisionAccepted]
+    ActiveRunner[Runner picks up<br/>safe boundary]
+    FollowUp[Create follow-up run<br/>seed amendment artifact]
+    Registry[Patch index<br/>list/show/reject]
     Daemon[surge-daemon queues or starts run]
 
-    User --> Chat
-    Chat --> FeatureAgent
+    User --> FeatureAgent
     FeatureAgent --> Patch
-    Patch --> Decision
-    Decision -->|edit| Chat
-    Decision -->|reject| User
+    Patch --> Registry
+    Patch --> Conflict
+    Conflict -->|no| Decision
+    Conflict -->|yes| Choice
+    Choice -->|defer to next milestone| Decision
+    Choice -->|abort current run| Registry
+    Choice -->|create follow-up run| FollowUp
+    Choice -->|reject patch| Registry
     Decision -->|approve| RoadmapUpdate
-    RoadmapUpdate --> FlowUpdate
-    FlowUpdate --> RunnerState
-    RunnerState -->|yes| ActiveRunner
-    RunnerState -->|no| FollowUp
+    Decision -->|reject/store| Registry
+    RoadmapUpdate --> Events
+    Events --> ActiveRunner
     FollowUp --> Daemon
 ```
 
-If a roadmap runner is active, the daemon can emit a roadmap-updated event and the runner sees the new pending milestone / tasks. If the roadmap is already terminal, or roadmap-flow execution is disabled, Surge appends the feature and creates a follow-up run instead of mutating completed execution history.
+Amendments are replay-safe. The event log records `RoadmapPatchDrafted`, `RoadmapPatchApprovalRequested`, `RoadmapPatchApprovalDecided`, `RoadmapPatchApplied`, `RoadmapUpdated`, and `GraphRevisionAccepted`. `GraphRevisionAccepted` embeds the full revised graph so replay does not depend on mutable files. `RoadmapUpdated` records the amended roadmap/flow artifact hashes and the active-pickup policy used by the runner.
+
+Conflict handling is explicit. A patch that touches an already-running or paused milestone surfaces stable conflict code `running_milestone` and the operator choices `defer-to-next-milestone`, `abort-current-run`, `create-follow-up-run`, and `reject-patch`. Terminal history uses `completed_history` and can be resolved through a follow-up run or rejection. The selected choice is persisted and reflected in the apply path: defer recalculates the target to pending work, follow-up creates a new run seed, reject marks the patch terminal, and abort records that current execution must stop before a later apply.
+
+Current CLI examples:
+
+```text
+surge feature describe "add CSV export" --project --approval prompt
+surge feature describe "add CSV export" --run <run_id> --approval approve --conflict-choice create-follow-up-run
+surge feature list --status pending-approval
+surge feature show rpatch-...
+surge feature reject rpatch-... --reason "superseded"
+```
+
+For lifecycle debugging, use `RUST_LOG=feature_cli=debug,roadmap_amendment=debug,roadmap_patch_index=debug`. Conflict detection logs WARN entries with stable conflict codes; approval, artifact storage, apply, and follow-up creation log INFO entries.
 
 ## Runtime Architecture
 


### PR DESCRIPTION
## Summary

Adds the roadmap amendment workflow end to end: a `surge feature` CLI surface, roadmap patch artifact schema/validation, patch persistence, approval-aware run events, daemon IPC wiring, active-run graph amendment handling, notifications, docs, and regression coverage.

Also adds a tracked `.env.example` and ignores local `.env` files so real ACP, Telegram, GitHub, Linear, and provider credentials can live outside git.

## Why

The feature planner needed a durable path from roadmap intent to approved changes without replacing roadmap content blindly. Review feedback also exposed that active-run amendments needed to be applied through the engine boundary, persisted to the target run log, and reflected in materialized views instead of relying on ad hoc local mutation.

## Impact

Users can request roadmap-driven changes, inspect/apply structured patches, start follow-up work, and safely configure local integration credentials through `.env`. Existing daemon subscribers and run readers now see roadmap patch lifecycle events consistently.

## Validation

- `git diff --cached --check`
- `cargo fmt --check`
- `cargo check --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p surge-daemon`
- `cargo test -p surge-orchestrator roadmap_document`
- `cargo test -p surge-orchestrator --test roadmap_amendment_artifacts_test`
- `cargo test -p surge-orchestrator --test flow_amendment_test`
- `cargo test -p surge-persistence roadmap_patch_lifecycle_updates_view`
- `cargo test -p surge-orchestrator --test roadmap_amendment_follow_up_test`
- `CARGO_INCREMENTAL=0 cargo test --workspace`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `surge feature` CLI commands for roadmap amendments: `describe` (draft & approve patches), `list` (view pending patches), `show` (inspect patch details), and `reject` (decline patches).
  * Implemented conflict resolution for amendments affecting active runs (defer work, abort/create follow-up runs).

* **Documentation**
  * Updated CLI, workflow, and roadmap convention guides with amendment examples and conflict-handling semantics.

* **Chores**
  * Added environment configuration example file for local development setup.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vanyastaff/surge/pull/54)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->