### PR TITLE
feat(artifact-contract): reject placeholder acceptance criteria

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed — Artifact contract acceptance-criteria validation
+
+- **Stricter acceptance-criteria checks** — Spec (Markdown and TOML) and Story
+  artifacts now reject placeholder, empty-checkbox, or too-short acceptance
+  criteria (e.g. `TBD`, `- [ ]`, `?`). The new
+  `empty_acceptance_criteria` diagnostic code points to the offending criterion
+  by index (`Acceptance Criteria[N]` for Markdown,
+  `spec.subtasks[i].acceptance_criteria[j]` for TOML). Each criterion must be a
+  non-placeholder string of at least 8 characters after trimming.
+
 ### Added — Bootstrap & adaptive flow generation
 
 - **`surge bootstrap` CLI** — runs the bundled Description Author →

--- a/crates/surge-core/src/artifact_contract.rs
+++ b/crates/surge-core/src/artifact_contract.rs
@@ -930,7 +930,7 @@ fn validate_spec_toml_acceptance(report: &mut ArtifactValidationReport, value: &
                     report.kind,
                     ArtifactDiagnosticCode::EmptyAcceptanceCriteria,
                     Some(location),
-                    "acceptance criterion is empty or placeholder",
+                    "acceptance criterion must be a string or a table with a `description` field",
                 ));
                 continue;
             };
@@ -2001,6 +2001,37 @@ subtasks = [
         );
 
         assert!(report.is_valid(), "{report:#?}");
+    }
+
+    #[test]
+    fn rejects_spec_toml_criterion_of_wrong_shape_with_shape_message() {
+        let report = validate_artifact(
+            ArtifactKind::Spec,
+            Some(Path::new("spec.toml")),
+            r#"schema_version = 1
+
+[spec]
+subtasks = [
+  { id = "one", acceptance_criteria = [42] },
+]
+"#,
+        );
+
+        assert!(!report.is_valid());
+        let shape_diag = report
+            .diagnostics
+            .iter()
+            .find(|diagnostic| {
+                diagnostic.code == ArtifactDiagnosticCode::EmptyAcceptanceCriteria
+                    && diagnostic.location.as_deref()
+                        == Some("spec.subtasks[0].acceptance_criteria[0]")
+            })
+            .expect("expected a shape diagnostic for the integer criterion");
+        assert!(
+            shape_diag.message.contains("string") && shape_diag.message.contains("description"),
+            "diagnostic message should explain the expected criterion shape, got: {:?}",
+            shape_diag.message,
+        );
     }
 
     #[test]

--- a/crates/surge-core/src/artifact_contract.rs
+++ b/crates/surge-core/src/artifact_contract.rs
@@ -19,6 +19,23 @@ use crate::roadmap_patch::{
 /// Current schema version used by Surge-owned artifact contracts.
 pub const ARTIFACT_SCHEMA_VERSION: u32 = 1;
 
+/// Minimum length (in characters) for an acceptance criterion body.
+const ACCEPTANCE_CRITERION_MIN_LENGTH: usize = 8;
+
+/// Lower-cased tokens treated as placeholder acceptance criteria.
+const ACCEPTANCE_CRITERION_PLACEHOLDERS: &[&str] = &[
+    "tbd",
+    "todo",
+    "?",
+    "??",
+    "???",
+    "n/a",
+    "-",
+    "tba",
+    "пока нет",
+    "wip",
+];
+
 /// Role artifact families that Surge validates.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
@@ -175,6 +192,8 @@ pub enum ArtifactDiagnosticCode {
     InvalidFrontmatter,
     /// Acceptance criteria are missing.
     MissingAcceptanceCriteria,
+    /// An acceptance criterion is empty, a placeholder, or too short to be testable.
+    EmptyAcceptanceCriteria,
     /// Artifact kind is not supported by this validator.
     UnsupportedArtifactKind,
     /// Flow graph parsed as TOML but failed engine-level graph validation.
@@ -202,6 +221,7 @@ impl ArtifactDiagnosticCode {
             Self::InvalidToml => "invalid_toml",
             Self::InvalidFrontmatter => "invalid_frontmatter",
             Self::MissingAcceptanceCriteria => "missing_acceptance_criteria",
+            Self::EmptyAcceptanceCriteria => "empty_acceptance_criteria",
             Self::UnsupportedArtifactKind => "unsupported_artifact_kind",
             Self::GraphValidationFailed => "graph_validation_failed",
             Self::GraphParseFailed => "graph_parse_failed",
@@ -853,15 +873,78 @@ fn roadmap_contains_ref(roadmap: &RoadmapArtifact, reference: &RoadmapItemRef) -
 }
 
 fn validate_spec_toml_acceptance(report: &mut ArtifactValidationReport, value: &toml::Value) {
-    if spec_toml_has_acceptance_criteria(value) {
+    let spec = value.get("spec").unwrap_or(value);
+    let Some(subtasks) = spec.get("subtasks").and_then(toml::Value::as_array) else {
+        report.push(ArtifactValidationDiagnostic::error(
+            report.kind,
+            ArtifactDiagnosticCode::MissingAcceptanceCriteria,
+            Some("spec.subtasks.acceptance_criteria".to_string()),
+            "every spec subtask must include machine-readable acceptance criteria",
+        ));
+        return;
+    };
+
+    if subtasks.is_empty() {
+        report.push(ArtifactValidationDiagnostic::error(
+            report.kind,
+            ArtifactDiagnosticCode::MissingAcceptanceCriteria,
+            Some("spec.subtasks.acceptance_criteria".to_string()),
+            "every spec subtask must include machine-readable acceptance criteria",
+        ));
         return;
     }
-    report.push(ArtifactValidationDiagnostic::error(
-        report.kind,
-        ArtifactDiagnosticCode::MissingAcceptanceCriteria,
-        Some("spec.subtasks.acceptance_criteria".to_string()),
-        "every spec subtask must include machine-readable acceptance criteria",
-    ));
+
+    for (subtask_index, subtask) in subtasks.iter().enumerate() {
+        let criteria = subtask
+            .get("acceptance_criteria")
+            .and_then(toml::Value::as_array);
+        let Some(criteria) = criteria else {
+            report.push(ArtifactValidationDiagnostic::error(
+                report.kind,
+                ArtifactDiagnosticCode::MissingAcceptanceCriteria,
+                Some(format!(
+                    "spec.subtasks[{subtask_index}].acceptance_criteria"
+                )),
+                "every spec subtask must include machine-readable acceptance criteria",
+            ));
+            continue;
+        };
+
+        if criteria.is_empty() {
+            report.push(ArtifactValidationDiagnostic::error(
+                report.kind,
+                ArtifactDiagnosticCode::MissingAcceptanceCriteria,
+                Some(format!(
+                    "spec.subtasks[{subtask_index}].acceptance_criteria"
+                )),
+                "every spec subtask must include machine-readable acceptance criteria",
+            ));
+            continue;
+        }
+
+        for (criterion_index, criterion) in criteria.iter().enumerate() {
+            let location =
+                format!("spec.subtasks[{subtask_index}].acceptance_criteria[{criterion_index}]");
+            let Some(text) = extract_toml_criterion_text(criterion) else {
+                report.push(ArtifactValidationDiagnostic::error(
+                    report.kind,
+                    ArtifactDiagnosticCode::EmptyAcceptanceCriteria,
+                    Some(location),
+                    "acceptance criterion is empty or placeholder",
+                ));
+                continue;
+            };
+            validate_acceptance_criterion_text(report, location, text);
+        }
+    }
+}
+
+fn extract_toml_criterion_text(value: &toml::Value) -> Option<&str> {
+    match value {
+        toml::Value::String(text) => Some(text.as_str()),
+        toml::Value::Table(table) => table.get("description").and_then(toml::Value::as_str),
+        _ => None,
+    }
 }
 
 fn parse_toml_value(report: &mut ArtifactValidationReport, content: &str) -> Option<toml::Value> {
@@ -929,25 +1012,6 @@ fn toml_field<'a>(value: &'a toml::Value, path: &str) -> Option<&'a toml::Value>
         .try_fold(value, |current, segment| current.get(segment))
 }
 
-fn spec_toml_has_acceptance_criteria(value: &toml::Value) -> bool {
-    let spec = value.get("spec").unwrap_or(value);
-    let Some(subtasks) = spec.get("subtasks").and_then(toml::Value::as_array) else {
-        return false;
-    };
-
-    !subtasks.is_empty()
-        && subtasks
-            .iter()
-            .all(|subtask| toml_array_is_non_empty(subtask, "acceptance_criteria"))
-}
-
-fn toml_array_is_non_empty(value: &toml::Value, field: &str) -> bool {
-    value
-        .get(field)
-        .and_then(toml::Value::as_array)
-        .is_some_and(|items| !items.is_empty())
-}
-
 fn validate_adr_frontmatter(report: &mut ArtifactValidationReport, content: &str) {
     let Some(frontmatter) = parse_toml_frontmatter(report, content) else {
         return;
@@ -1006,17 +1070,128 @@ fn require_markdown_sections(
 }
 
 fn require_acceptance_criteria(report: &mut ArtifactValidationReport, content: &str) {
-    if has_markdown_heading(content, "Acceptance Criteria")
-        || content.to_ascii_lowercase().contains("acceptance criteria")
-    {
+    let bullets = extract_acceptance_criteria_bullets(content);
+    let Some(bullets) = bullets else {
+        report.push(ArtifactValidationDiagnostic::error(
+            report.kind,
+            ArtifactDiagnosticCode::MissingAcceptanceCriteria,
+            Some("Acceptance Criteria".to_string()),
+            "artifact must include acceptance criteria",
+        ));
+        return;
+    };
+
+    if bullets.is_empty() {
+        report.push(ArtifactValidationDiagnostic::error(
+            report.kind,
+            ArtifactDiagnosticCode::MissingAcceptanceCriteria,
+            Some("Acceptance Criteria".to_string()),
+            "acceptance criteria section has no bullets",
+        ));
         return;
     }
-    report.push(ArtifactValidationDiagnostic::error(
-        report.kind,
-        ArtifactDiagnosticCode::MissingAcceptanceCriteria,
-        Some("Acceptance Criteria".to_string()),
-        "artifact must include acceptance criteria",
-    ));
+
+    for (index, bullet) in bullets.iter().enumerate() {
+        validate_acceptance_criterion_text(
+            report,
+            format!("Acceptance Criteria[{index}]"),
+            bullet,
+        );
+    }
+}
+
+fn extract_acceptance_criteria_bullets(content: &str) -> Option<Vec<&str>> {
+    let mut in_section = false;
+    let mut bullets = Vec::new();
+    for line in content.lines() {
+        let trimmed_start = line.trim_start();
+        if trimmed_start.starts_with('#') {
+            if in_section {
+                return Some(bullets);
+            }
+            let heading = trimmed_start.trim_start_matches('#').trim();
+            if strip_trailing_heading_marker(heading).eq_ignore_ascii_case("acceptance criteria") {
+                in_section = true;
+            }
+            continue;
+        }
+        if !in_section {
+            continue;
+        }
+        if let Some(bullet) = strip_bullet_marker(trimmed_start) {
+            bullets.push(bullet);
+        }
+    }
+    if in_section { Some(bullets) } else { None }
+}
+
+fn strip_bullet_marker(line: &str) -> Option<&str> {
+    for marker in ["- ", "* ", "+ "] {
+        if let Some(rest) = line.strip_prefix(marker) {
+            return Some(rest);
+        }
+    }
+    if matches!(line, "-" | "*" | "+") {
+        return Some("");
+    }
+    let digit_end = line
+        .char_indices()
+        .find(|(_, ch)| !ch.is_ascii_digit())
+        .map_or(line.len(), |(index, _)| index);
+    if digit_end > 0 {
+        let tail = &line[digit_end..];
+        if let Some(rest) = tail.strip_prefix(". ") {
+            return Some(rest);
+        }
+        if tail == "." {
+            return Some("");
+        }
+    }
+    None
+}
+
+fn validate_acceptance_criterion_text(
+    report: &mut ArtifactValidationReport,
+    location: String,
+    raw: &str,
+) {
+    let trimmed = raw.trim();
+    let body = strip_optional_checkbox(trimmed).trim();
+
+    if body.is_empty() || is_placeholder_criterion(body) {
+        report.push(ArtifactValidationDiagnostic::error(
+            report.kind,
+            ArtifactDiagnosticCode::EmptyAcceptanceCriteria,
+            Some(location),
+            "acceptance criterion is empty or placeholder",
+        ));
+        return;
+    }
+
+    if body.chars().count() < ACCEPTANCE_CRITERION_MIN_LENGTH {
+        report.push(ArtifactValidationDiagnostic::error(
+            report.kind,
+            ArtifactDiagnosticCode::EmptyAcceptanceCriteria,
+            Some(location),
+            "acceptance criterion is too short to be testable",
+        ));
+    }
+}
+
+fn strip_optional_checkbox(text: &str) -> &str {
+    let trimmed = text.trim_start();
+    for marker in ["[ ]", "[x]", "[X]"] {
+        if let Some(rest) = trimmed.strip_prefix(marker) {
+            return rest;
+        }
+    }
+    trimmed
+}
+
+fn is_placeholder_criterion(text: &str) -> bool {
+    ACCEPTANCE_CRITERION_PLACEHOLDERS
+        .iter()
+        .any(|placeholder| text.eq_ignore_ascii_case(placeholder))
 }
 
 fn has_markdown_heading(content: &str, expected: &str) -> bool {
@@ -1603,8 +1778,262 @@ subtasks = [
         assert!(!report.is_valid());
         assert!(report.diagnostics.iter().any(|diagnostic| {
             diagnostic.code == ArtifactDiagnosticCode::MissingAcceptanceCriteria
-                && diagnostic.location.as_deref() == Some("spec.subtasks.acceptance_criteria")
+                && diagnostic.location.as_deref() == Some("spec.subtasks[1].acceptance_criteria")
         }));
+    }
+
+    #[test]
+    fn rejects_spec_markdown_placeholder_criterion() {
+        let report = validate_artifact(
+            ArtifactKind::Spec,
+            Some(Path::new("spec.md")),
+            r#"# Spec
+
+## Goal
+Build a validator.
+
+## Subtasks
+- Add the pure core module.
+
+## Acceptance Criteria
+- TBD
+"#,
+        );
+
+        assert!(!report.is_valid(), "{report:#?}");
+        assert!(report.diagnostics.iter().any(|diagnostic| {
+            diagnostic.code == ArtifactDiagnosticCode::EmptyAcceptanceCriteria
+                && diagnostic.location.as_deref() == Some("Acceptance Criteria[0]")
+        }));
+    }
+
+    #[test]
+    fn rejects_spec_markdown_empty_checkbox_criterion() {
+        let report = validate_artifact(
+            ArtifactKind::Spec,
+            Some(Path::new("spec.md")),
+            r#"# Spec
+
+## Goal
+Build a validator.
+
+## Subtasks
+- Add the pure core module.
+
+## Acceptance Criteria
+- [ ]
+"#,
+        );
+
+        assert!(!report.is_valid());
+        assert!(
+            report
+                .diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.code
+                    == ArtifactDiagnosticCode::EmptyAcceptanceCriteria)
+        );
+    }
+
+    #[test]
+    fn rejects_spec_markdown_single_question_mark_criterion() {
+        let report = validate_artifact(
+            ArtifactKind::Spec,
+            Some(Path::new("spec.md")),
+            r#"# Spec
+
+## Goal
+Build a validator.
+
+## Subtasks
+- Add the pure core module.
+
+## Acceptance Criteria
+- ?
+"#,
+        );
+
+        assert!(!report.is_valid());
+        assert!(
+            report
+                .diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.code
+                    == ArtifactDiagnosticCode::EmptyAcceptanceCriteria)
+        );
+    }
+
+    #[test]
+    fn rejects_spec_markdown_too_short_criterion() {
+        let report = validate_artifact(
+            ArtifactKind::Spec,
+            Some(Path::new("spec.md")),
+            r#"# Spec
+
+## Goal
+Build a validator.
+
+## Subtasks
+- Add the pure core module.
+
+## Acceptance Criteria
+- works
+"#,
+        );
+
+        assert!(!report.is_valid());
+        assert_eq!(
+            report
+                .diagnostics
+                .iter()
+                .filter(|diagnostic| diagnostic.code
+                    == ArtifactDiagnosticCode::EmptyAcceptanceCriteria)
+                .count(),
+            1,
+        );
+    }
+
+    #[test]
+    fn rejects_spec_markdown_when_acceptance_section_is_empty() {
+        let report = validate_artifact(
+            ArtifactKind::Spec,
+            Some(Path::new("spec.md")),
+            r#"# Spec
+
+## Goal
+Build a validator.
+
+## Subtasks
+- Add the pure core module.
+
+## Acceptance Criteria
+
+## Constraints
+- Stay pure.
+"#,
+        );
+
+        assert!(!report.is_valid());
+        assert!(report.diagnostics.iter().any(|diagnostic| {
+            diagnostic.code == ArtifactDiagnosticCode::MissingAcceptanceCriteria
+        }));
+    }
+
+    #[test]
+    fn rejects_story_markdown_placeholder_criterion() {
+        let report = validate_artifact(
+            ArtifactKind::Story,
+            Some(Path::new("stories/story-002.md")),
+            r#"# Story 002
+
+## Context
+Demonstrate story-level placeholder rejection.
+
+## What needs to be done
+Add validation.
+
+## Architecture decisions
+None.
+
+## Files to modify
+- crates/surge-core/src/artifact_contract.rs
+
+## Acceptance criteria
+- N/A
+
+## Out of scope
+- Other artifacts.
+"#,
+        );
+
+        assert!(!report.is_valid());
+        assert!(report.diagnostics.iter().any(|diagnostic| {
+            diagnostic.code == ArtifactDiagnosticCode::EmptyAcceptanceCriteria
+        }));
+    }
+
+    #[test]
+    fn rejects_spec_toml_when_criterion_is_placeholder_string() {
+        let report = validate_artifact(
+            ArtifactKind::Spec,
+            Some(Path::new("spec.toml")),
+            r#"schema_version = 1
+
+[spec]
+subtasks = [
+  { id = "one", acceptance_criteria = ["TBD"] },
+]
+"#,
+        );
+
+        assert!(!report.is_valid());
+        assert!(report.diagnostics.iter().any(|diagnostic| {
+            diagnostic.code == ArtifactDiagnosticCode::EmptyAcceptanceCriteria
+                && diagnostic.location.as_deref()
+                    == Some("spec.subtasks[0].acceptance_criteria[0]")
+        }));
+    }
+
+    #[test]
+    fn rejects_spec_toml_when_criterion_table_description_is_too_short() {
+        let report = validate_artifact(
+            ArtifactKind::Spec,
+            Some(Path::new("spec.toml")),
+            r#"schema_version = 1
+
+[spec]
+subtasks = [
+  { id = "one", acceptance_criteria = [{ description = "ok" }] },
+]
+"#,
+        );
+
+        assert!(!report.is_valid());
+        assert!(report.diagnostics.iter().any(|diagnostic| {
+            diagnostic.code == ArtifactDiagnosticCode::EmptyAcceptanceCriteria
+        }));
+    }
+
+    #[test]
+    fn accepts_spec_toml_with_table_form_criterion() {
+        let report = validate_artifact(
+            ArtifactKind::Spec,
+            Some(Path::new("spec.toml")),
+            r#"schema_version = 1
+
+[spec]
+subtasks = [
+  { id = "one", acceptance_criteria = [{ description = "valid fixtures pass validation" }] },
+]
+"#,
+        );
+
+        assert!(report.is_valid(), "{report:#?}");
+    }
+
+    #[test]
+    fn placeholder_match_is_case_insensitive_for_ascii() {
+        let report = validate_artifact(
+            ArtifactKind::Spec,
+            Some(Path::new("spec.toml")),
+            r#"schema_version = 1
+
+[spec]
+subtasks = [
+  { id = "one", acceptance_criteria = ["Tbd", "ToDo"] },
+]
+"#,
+        );
+
+        assert!(!report.is_valid());
+        let empty_count = report
+            .diagnostics
+            .iter()
+            .filter(|diagnostic| {
+                diagnostic.code == ArtifactDiagnosticCode::EmptyAcceptanceCriteria
+            })
+            .count();
+        assert_eq!(empty_count, 2);
     }
 
     #[test]

--- a/crates/surge-core/src/artifact_contract.rs
+++ b/crates/surge-core/src/artifact_contract.rs
@@ -1092,11 +1092,7 @@ fn require_acceptance_criteria(report: &mut ArtifactValidationReport, content: &
     }
 
     for (index, bullet) in bullets.iter().enumerate() {
-        validate_acceptance_criterion_text(
-            report,
-            format!("Acceptance Criteria[{index}]"),
-            bullet,
-        );
+        validate_acceptance_criterion_text(report, format!("Acceptance Criteria[{index}]"), bullet);
     }
 }
 
@@ -1827,11 +1823,9 @@ Build a validator.
 
         assert!(!report.is_valid());
         assert!(
-            report
-                .diagnostics
-                .iter()
-                .any(|diagnostic| diagnostic.code
-                    == ArtifactDiagnosticCode::EmptyAcceptanceCriteria)
+            report.diagnostics.iter().any(
+                |diagnostic| diagnostic.code == ArtifactDiagnosticCode::EmptyAcceptanceCriteria
+            )
         );
     }
 
@@ -1855,11 +1849,9 @@ Build a validator.
 
         assert!(!report.is_valid());
         assert!(
-            report
-                .diagnostics
-                .iter()
-                .any(|diagnostic| diagnostic.code
-                    == ArtifactDiagnosticCode::EmptyAcceptanceCriteria)
+            report.diagnostics.iter().any(
+                |diagnostic| diagnostic.code == ArtifactDiagnosticCode::EmptyAcceptanceCriteria
+            )
         );
     }
 
@@ -1886,8 +1878,9 @@ Build a validator.
             report
                 .diagnostics
                 .iter()
-                .filter(|diagnostic| diagnostic.code
-                    == ArtifactDiagnosticCode::EmptyAcceptanceCriteria)
+                .filter(
+                    |diagnostic| diagnostic.code == ArtifactDiagnosticCode::EmptyAcceptanceCriteria
+                )
                 .count(),
             1,
         );
@@ -1969,8 +1962,7 @@ subtasks = [
         assert!(!report.is_valid());
         assert!(report.diagnostics.iter().any(|diagnostic| {
             diagnostic.code == ArtifactDiagnosticCode::EmptyAcceptanceCriteria
-                && diagnostic.location.as_deref()
-                    == Some("spec.subtasks[0].acceptance_criteria[0]")
+                && diagnostic.location.as_deref() == Some("spec.subtasks[0].acceptance_criteria[0]")
         }));
     }
 
@@ -2029,9 +2021,7 @@ subtasks = [
         let empty_count = report
             .diagnostics
             .iter()
-            .filter(|diagnostic| {
-                diagnostic.code == ArtifactDiagnosticCode::EmptyAcceptanceCriteria
-            })
+            .filter(|diagnostic| diagnostic.code == ArtifactDiagnosticCode::EmptyAcceptanceCriteria)
             .count();
         assert_eq!(empty_count, 2);
     }

--- a/crates/surge-orchestrator/tests/artifact_contract_golden_test.rs
+++ b/crates/surge-orchestrator/tests/artifact_contract_golden_test.rs
@@ -30,6 +30,15 @@ fn validate_fixture(kind: ArtifactKind, relative: &str) -> ArtifactValidationRep
     validate_artifact(kind, Some(artifact_path), &content)
 }
 
+fn validate_fixture_as(
+    kind: ArtifactKind,
+    relative: &str,
+    virtual_path: &str,
+) -> ArtifactValidationReport {
+    let (_, content) = load_fixture(relative);
+    validate_artifact(kind, Some(std::path::Path::new(virtual_path)), &content)
+}
+
 fn diagnostic_codes(report: &ArtifactValidationReport) -> Vec<ArtifactDiagnosticCode> {
     report
         .diagnostics
@@ -131,6 +140,25 @@ fn invalid_fixtures_emit_stable_diagnostic_codes() {
         assert_eq!(
             diagnostic_codes(&report),
             *expected_codes,
+            "{relative} diagnostic codes drifted"
+        );
+    }
+}
+
+#[test]
+fn invalid_spec_markdown_fixtures_emit_empty_acceptance_criteria() {
+    let cases = [
+        "invalid/spec-placeholder.md",
+        "invalid/spec-empty-checkbox.md",
+        "invalid/spec-question-mark.md",
+    ];
+
+    for relative in cases {
+        let report = validate_fixture_as(ArtifactKind::Spec, relative, "spec.md");
+        assert!(!report.is_valid(), "{relative} should be invalid");
+        assert_eq!(
+            diagnostic_codes(&report),
+            vec![ArtifactDiagnosticCode::EmptyAcceptanceCriteria],
             "{relative} diagnostic codes drifted"
         );
     }

--- a/crates/surge-orchestrator/tests/fixtures/artifacts/invalid/spec-empty-checkbox.md
+++ b/crates/surge-orchestrator/tests/fixtures/artifacts/invalid/spec-empty-checkbox.md
@@ -1,0 +1,10 @@
+# Spec
+
+## Goal
+Demonstrate empty-checkbox rejection.
+
+## Subtasks
+- Add some validation.
+
+## Acceptance Criteria
+- [ ]

--- a/crates/surge-orchestrator/tests/fixtures/artifacts/invalid/spec-placeholder.md
+++ b/crates/surge-orchestrator/tests/fixtures/artifacts/invalid/spec-placeholder.md
@@ -1,0 +1,10 @@
+# Spec
+
+## Goal
+Demonstrate placeholder rejection.
+
+## Subtasks
+- Add some validation.
+
+## Acceptance Criteria
+- TBD

--- a/crates/surge-orchestrator/tests/fixtures/artifacts/invalid/spec-question-mark.md
+++ b/crates/surge-orchestrator/tests/fixtures/artifacts/invalid/spec-question-mark.md
@@ -1,0 +1,10 @@
+# Spec
+
+## Goal
+Demonstrate single-question-mark rejection.
+
+## Subtasks
+- Add some validation.
+
+## Acceptance Criteria
+- ?


### PR DESCRIPTION
## Summary

- Adds semantic validation for acceptance criteria in Spec (Markdown + TOML) and Story (Markdown) artifacts. Previously, bullets like `- TBD`, `- [ ]`, or `- ?` passed validation because checks were purely structural.
- Introduces new diagnostic code `empty_acceptance_criteria` with precise, indexed locations (`Acceptance Criteria[N]` for Markdown, `spec.subtasks[i].acceptance_criteria[j]` for TOML).
- Each criterion must, after trimming and stripping an optional checkbox marker (`[ ]` / `[x]`):
  - Be non-empty.
  - Not match a placeholder token: `TBD`, `TODO`, `?`, `??`, `???`, `N/A`, `-`, `TBA`, `WIP`, `пока нет` (ASCII-case-insensitive).
  - Be at least 8 characters long.
- The placeholder list is a `const &[&str]` at the top of `artifact_contract.rs` so reviewers can edit it without digging into the parsing logic.

## Why

`artifact_contract.rs` only checked for required Markdown headings and TOML fields. An agent could emit `## Acceptance Criteria\n- TBD` and still pass — the biggest semantic hole in the contract. This change closes it without adding NLP-style heuristics: only formal rules (empty / placeholder / minimum length).

## What changed

- `crates/surge-core/src/artifact_contract.rs`
  - New variant `ArtifactDiagnosticCode::EmptyAcceptanceCriteria` (`empty_acceptance_criteria`).
  - New constants `ACCEPTANCE_CRITERION_MIN_LENGTH` and `ACCEPTANCE_CRITERION_PLACEHOLDERS`.
  - `require_acceptance_criteria` now parses the `## Acceptance Criteria` / `## Acceptance criteria` section, extracts bullets via `strip_bullet_marker` (`-` / `*` / `+` / `N.`), strips an optional checkbox, and validates each one.
  - `validate_spec_toml_acceptance` walks `spec.subtasks[i].acceptance_criteria[j]`, supporting both string and `{ description = "..." }` table forms, and applies the same rules.
  - Old helpers `spec_toml_has_acceptance_criteria` / `toml_array_is_non_empty` removed (no other callers).
  - 9 new unit tests covering each rule and edge case (Spec md, Story md, Spec TOML string + table forms, case-insensitivity, empty section).
- `crates/surge-orchestrator/tests/fixtures/artifacts/invalid/{spec-placeholder.md,spec-empty-checkbox.md,spec-question-mark.md}` — new invalid fixtures.
- `crates/surge-orchestrator/tests/artifact_contract_golden_test.rs` — new `invalid_spec_markdown_fixtures_emit_empty_acceptance_criteria` golden test using a `validate_fixture_as` helper to override the artifact path.
- `CHANGELOG.md` — `[Unreleased]` entry under `### Changed`.

## Reviewer notes

- **Public API unchanged.** `validate_artifact*` signatures, the diagnostic struct, and report shape are stable. Only a new enum variant and additional diagnostics are emitted.
- **`ArtifactDiagnosticCode` is not `#[non_exhaustive]`** — adding a variant is technically a breaking change for downstream exhaustive matches, but the enum is internal-facing today, so this is acceptable.
- The Spec Markdown loose match (`content.to_ascii_lowercase().contains(\"acceptance criteria\")`) is gone. The section now must be a proper heading, which `require_markdown_sections` already enforces, so behavior is consistent.
- Existing valid fixtures already had meaningful (>=18 char) criteria, so they did not need to be strengthened.

## Test plan

- [x] `cargo test -p surge-core` — 398 + sibling test groups all green.
- [x] `cargo test -p surge-orchestrator --test artifact_contract_golden_test` — 4/4 green.
- [x] `cargo test -p surge-orchestrator --test roadmap_amendment_artifacts_test --test roadmap_amendment_e2e` — 5/5 green (smoke-check that other consumers of `validate_artifact` still work).
- [x] `cargo test -p surge-cli` — all green.
- [x] `cargo clippy --workspace -- -D warnings` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Stricter validation of acceptance criteria in artifact specifications
  * Specifications are now rejected if they contain placeholder text, empty checklist items, or acceptance criteria that are too short (fewer than 8 characters)
  * Improved error messages pinpoint the exact location of each validation failure to aid debugging

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vanyastaff/surge/pull/56)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->