### PR TITLE
feat(core,cli): export artifact contracts as JSON Schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — Self-describing artifact contracts
+
+- **`surge artifact schema <kind>` CLI** — exports the JSON Schema (draft
+  2020-12) describing on-disk artifacts. Supports `--all` to dump every
+  kind in one object, `--format pretty|json`, and `--output <path>` to
+  write to disk. Markdown-only kinds exit with an explanatory error
+  listing required `## <Section>` headings instead of fabricating a
+  schema.
+- **`surge_core::json_schema_for` / `contract_summary` / `markdown_outline`**
+  — pure introspection API that agents and external tools can call without
+  shelling out. Every exported schema carries `$id`
+  (`https://surge.dev/schema/v1/<artifact>.json`) and
+  `x-surge-schema-version` for change tracking.
+- **`#[derive(JsonSchema)]` across TOML artifact types** — `SpecArtifact`,
+  `Spec`, `Subtask`, `AcceptanceCriteria`, `Complexity`, `SubtaskExecution`,
+  `SubtaskState`, `RoadmapArtifact`, `RoadmapMilestone`, `RoadmapTask`,
+  `RoadmapDependency`, `RoadmapRisk`, `RoadmapStatus`, `RoadmapPatch`,
+  `RoadmapPatchOperation`, `RoadmapPatchItem`, `InsertionPoint`,
+  `RoadmapItemRef`, and the rest of the roadmap-patch enum tree now derive
+  JSON Schema. Custom-serde newtypes (`SpecId`, `SubtaskId`, `RunId`,
+  `NodeKey` family, `ContentHash`, `RoadmapPatchId`) carry hand-written
+  `JsonSchema` impls describing them as strings with the appropriate
+  pattern/length constraints. On-disk serialization is unchanged.
+- **Snapshot tests for every exported schema** in
+  `crates/surge-core/tests/artifact_schema_snapshots.rs`. Breaking changes
+  to a contract now surface as a diff that prompt profiles, IDE plugins,
+  and external validators can track in lockstep.
+- **`docs/artifact-schemas.md`** — quick-start, coverage matrix, and
+  recommended consumption pattern for agents.
+
 ### Added — Bootstrap & adaptive flow generation
 
 - **`surge bootstrap` CLI** — runs the bundled Description Author →

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7295,6 +7295,7 @@ dependencies = [
  "humantime-serde",
  "insta",
  "proptest",
+ "schemars",
  "semver",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,9 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "0.8"
 
+# JSON Schema generation for artifact contracts
+schemars = { version = "1", features = ["preserve_order", "chrono04"] }
+
 # CLI
 clap = { version = "4", features = ["derive"] }
 

--- a/crates/surge-cli/src/commands/artifact.rs
+++ b/crates/surge-cli/src/commands/artifact.rs
@@ -103,14 +103,21 @@ fn schema_command(
 }
 
 fn single_schema_value(kind: ArtifactKind) -> Result<serde_json::Value> {
-    match json_schema_for(kind) {
-        Some(schema) => Ok(schema),
-        None => bail!(
-            "no JSON schema for {kind}; primary format is {} and the contract is described by required markdown sections instead: {}",
-            describe_primary_format(kind),
-            describe_outline(kind)
-        ),
+    if let Some(schema) = json_schema_for(kind) {
+        return Ok(schema);
     }
+
+    if kind == ArtifactKind::Flow {
+        bail!(
+            "no JSON schema for {kind}: flow.toml schema export is pending — the contract is currently enforced by `surge_core::Graph` and engine-level validation. Use `surge artifact validate --kind flow <path>` to check a flow artifact."
+        );
+    }
+
+    bail!(
+        "no JSON schema for {kind}; primary format is {} and the contract is described by required markdown sections instead: {}",
+        describe_primary_format(kind),
+        describe_outline(kind)
+    )
 }
 
 fn all_schemas_value() -> serde_json::Value {
@@ -119,15 +126,28 @@ fn all_schemas_value() -> serde_json::Value {
         let key = contract.kind.as_str().to_string();
         let entry = match json_schema_for(contract.kind) {
             Some(schema) => schema,
-            None => serde_json::json!({
-                "x-surge-no-json-schema": true,
-                "primary_format": describe_primary_format(contract.kind),
-                "required_markdown_sections": markdown_outline(contract.kind),
-            }),
+            None => no_schema_placeholder(contract.kind),
         };
         map.insert(key, entry);
     }
     serde_json::Value::Object(map)
+}
+
+fn no_schema_placeholder(kind: ArtifactKind) -> serde_json::Value {
+    let primary_format = describe_primary_format(kind);
+    if kind == ArtifactKind::Flow {
+        return serde_json::json!({
+            "x-surge-no-json-schema": true,
+            "primary_format": primary_format,
+            "x-surge-schema-status": "pending",
+            "x-surge-schema-note": "flow.toml schema export is pending; the contract is currently enforced by surge_core::Graph and engine-level validation.",
+        });
+    }
+    serde_json::json!({
+        "x-surge-no-json-schema": true,
+        "primary_format": primary_format,
+        "required_markdown_sections": markdown_outline(kind),
+    })
 }
 
 fn describe_primary_format(kind: ArtifactKind) -> &'static str {
@@ -145,8 +165,7 @@ fn describe_outline(kind: ArtifactKind) -> String {
             .map(|section| format!("## {section}"))
             .collect::<Vec<_>>()
             .join(", "),
-        None => "(no markdown outline registered; this kind currently lacks a JSON schema export)"
-            .to_string(),
+        None => "(no markdown outline registered for this kind)".to_string(),
     }
 }
 

--- a/crates/surge-cli/src/commands/artifact.rs
+++ b/crates/surge-cli/src/commands/artifact.rs
@@ -95,8 +95,7 @@ fn schema_command(
     };
 
     if let Some(path) = output {
-        std::fs::write(path, &rendered)
-            .with_context(|| format!("write {}", path.display()))?;
+        std::fs::write(path, &rendered).with_context(|| format!("write {}", path.display()))?;
     } else {
         println!("{rendered}");
     }

--- a/crates/surge-cli/src/commands/artifact.rs
+++ b/crates/surge-cli/src/commands/artifact.rs
@@ -6,7 +6,7 @@ use anyhow::{Context, Result, bail};
 use clap::{Subcommand, ValueEnum};
 use surge_core::{
     ArtifactDiagnosticCode, ArtifactKind, ArtifactValidationDiagnostic, ArtifactValidationReport,
-    Graph, validate_artifact,
+    Graph, all_contracts, json_schema_for, markdown_outline, validate_artifact,
 };
 
 /// Subcommands under `surge artifact`.
@@ -23,6 +23,33 @@ pub enum ArtifactCommands {
         #[arg(long, value_enum, default_value_t = ArtifactOutputFormat::Human)]
         format: ArtifactOutputFormat,
     },
+    /// Export the JSON Schema (draft 2020-12) describing one artifact contract.
+    ///
+    /// Use `--all` to emit a single JSON object keyed by artifact kind. For
+    /// markdown-only kinds the command lists required `## <Section>` headings
+    /// instead of a schema.
+    Schema {
+        /// Artifact contract kind. Omit when using `--all`.
+        kind: Option<ArtifactKind>,
+        /// Emit every kind as one JSON object.
+        #[arg(long, conflicts_with = "kind")]
+        all: bool,
+        /// Output format.
+        #[arg(long, value_enum, default_value_t = SchemaOutputFormat::Pretty)]
+        format: SchemaOutputFormat,
+        /// Optional path to write the schema to instead of stdout.
+        #[arg(long)]
+        output: Option<PathBuf>,
+    },
+}
+
+/// JSON output style for `surge artifact schema`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum SchemaOutputFormat {
+    /// Pretty-printed JSON (multi-line, indented).
+    Pretty,
+    /// Compact single-line JSON.
+    Json,
 }
 
 /// Validation output format.
@@ -38,6 +65,89 @@ pub enum ArtifactOutputFormat {
 pub fn run(command: ArtifactCommands) -> Result<()> {
     match command {
         ArtifactCommands::Validate { kind, path, format } => validate_command(kind, &path, format),
+        ArtifactCommands::Schema {
+            kind,
+            all,
+            format,
+            output,
+        } => schema_command(kind, all, format, output.as_deref()),
+    }
+}
+
+fn schema_command(
+    kind: Option<ArtifactKind>,
+    all: bool,
+    format: SchemaOutputFormat,
+    output: Option<&Path>,
+) -> Result<()> {
+    let value = if all {
+        all_schemas_value()
+    } else {
+        let kind = kind.context(
+            "specify an artifact kind (for example `surge artifact schema spec`) or pass --all",
+        )?;
+        single_schema_value(kind)?
+    };
+
+    let rendered = match format {
+        SchemaOutputFormat::Pretty => serde_json::to_string_pretty(&value)?,
+        SchemaOutputFormat::Json => serde_json::to_string(&value)?,
+    };
+
+    if let Some(path) = output {
+        std::fs::write(path, &rendered)
+            .with_context(|| format!("write {}", path.display()))?;
+    } else {
+        println!("{rendered}");
+    }
+    Ok(())
+}
+
+fn single_schema_value(kind: ArtifactKind) -> Result<serde_json::Value> {
+    match json_schema_for(kind) {
+        Some(schema) => Ok(schema),
+        None => bail!(
+            "no JSON schema for {kind}; primary format is {} and the contract is described by required markdown sections instead: {}",
+            describe_primary_format(kind),
+            describe_outline(kind)
+        ),
+    }
+}
+
+fn all_schemas_value() -> serde_json::Value {
+    let mut map = serde_json::Map::new();
+    for contract in all_contracts() {
+        let key = contract.kind.as_str().to_string();
+        let entry = match json_schema_for(contract.kind) {
+            Some(schema) => schema,
+            None => serde_json::json!({
+                "x-surge-no-json-schema": true,
+                "primary_format": describe_primary_format(contract.kind),
+                "required_markdown_sections": markdown_outline(contract.kind),
+            }),
+        };
+        map.insert(key, entry);
+    }
+    serde_json::Value::Object(map)
+}
+
+fn describe_primary_format(kind: ArtifactKind) -> &'static str {
+    match surge_core::contract_for(kind).primary_format {
+        surge_core::ArtifactFormat::Markdown => "markdown",
+        surge_core::ArtifactFormat::Toml => "toml",
+        surge_core::ArtifactFormat::FlowToml => "flow-toml",
+    }
+}
+
+fn describe_outline(kind: ArtifactKind) -> String {
+    match markdown_outline(kind) {
+        Some(sections) => sections
+            .iter()
+            .map(|section| format!("## {section}"))
+            .collect::<Vec<_>>()
+            .join(", "),
+        None => "(no markdown outline registered; this kind currently lacks a JSON schema export)"
+            .to_string(),
     }
 }
 

--- a/crates/surge-cli/tests/cli_artifact_schema.rs
+++ b/crates/surge-cli/tests/cli_artifact_schema.rs
@@ -36,9 +36,14 @@ fn schema_spec_emits_valid_json_with_expected_keys() {
             .is_some(),
         "spec schema must describe the schema_version envelope field"
     );
-    assert!(object.contains_key("$defs"), "spec schema must inline Spec/Subtask/etc.");
+    assert!(
+        object.contains_key("$defs"),
+        "spec schema must inline Spec/Subtask/etc."
+    );
     assert_eq!(
-        object.get("x-surge-schema-version").and_then(|v| v.as_u64()),
+        object
+            .get("x-surge-schema-version")
+            .and_then(|v| v.as_u64()),
         Some(u64::from(surge_core::ARTIFACT_SCHEMA_VERSION))
     );
 }

--- a/crates/surge-cli/tests/cli_artifact_schema.rs
+++ b/crates/surge-cli/tests/cli_artifact_schema.rs
@@ -1,6 +1,7 @@
 //! CLI smoke tests for `surge artifact schema`.
 
 use assert_cmd::Command;
+use predicates::prelude::*;
 use predicates::str::contains;
 
 #[test]
@@ -96,4 +97,22 @@ fn schema_plan_reports_markdown_only_error() {
         .stderr(contains("no JSON schema for plan"))
         .stderr(contains("## Settings"))
         .stderr(contains("## Tasks"));
+}
+
+#[test]
+fn schema_flow_reports_pending_message_not_markdown_sections() {
+    // flow.toml has no JSON schema today and no markdown outline either.
+    // The CLI must surface that explicitly as a pending-schema message
+    // rather than pretending the contract is described by markdown
+    // sections.
+    Command::cargo_bin("surge")
+        .unwrap()
+        .args(["artifact", "schema", "flow"])
+        .assert()
+        .failure()
+        .stderr(contains("no JSON schema for flow"))
+        .stderr(contains("pending"))
+        // Sanity: the error must NOT promise markdown sections that don't
+        // exist for flow.
+        .stderr(predicates::str::contains("## ").not());
 }

--- a/crates/surge-cli/tests/cli_artifact_schema.rs
+++ b/crates/surge-cli/tests/cli_artifact_schema.rs
@@ -1,0 +1,94 @@
+//! CLI smoke tests for `surge artifact schema`.
+
+use assert_cmd::Command;
+use predicates::str::contains;
+
+#[test]
+fn schema_spec_emits_valid_json_with_expected_keys() {
+    let output = Command::cargo_bin("surge")
+        .unwrap()
+        .args(["artifact", "schema", "spec"])
+        .output()
+        .expect("invoke surge artifact schema spec");
+    assert!(output.status.success(), "command failed: {output:?}");
+
+    let stdout = String::from_utf8(output.stdout).expect("stdout is UTF-8");
+    let value: serde_json::Value = serde_json::from_str(&stdout).expect("stdout is valid JSON");
+    let object = value.as_object().expect("schema is a JSON object");
+
+    assert_eq!(
+        object.get("title").and_then(|v| v.as_str()),
+        Some("SpecArtifact")
+    );
+    assert!(object.contains_key("$schema"));
+    assert!(
+        object
+            .get("$id")
+            .and_then(|v| v.as_str())
+            .unwrap_or_default()
+            .starts_with("https://surge.dev/schema/v1/"),
+        "expected canonical Surge $id namespace"
+    );
+    assert!(
+        object
+            .get("properties")
+            .and_then(|p| p.get("schema_version"))
+            .is_some(),
+        "spec schema must describe the schema_version envelope field"
+    );
+    assert!(object.contains_key("$defs"), "spec schema must inline Spec/Subtask/etc.");
+    assert_eq!(
+        object.get("x-surge-schema-version").and_then(|v| v.as_u64()),
+        Some(u64::from(surge_core::ARTIFACT_SCHEMA_VERSION))
+    );
+}
+
+#[test]
+fn schema_all_emits_every_kind_in_one_object() {
+    let output = Command::cargo_bin("surge")
+        .unwrap()
+        .args(["artifact", "schema", "--all"])
+        .output()
+        .expect("invoke surge artifact schema --all");
+    assert!(output.status.success(), "command failed: {output:?}");
+
+    let stdout = String::from_utf8(output.stdout).expect("stdout is UTF-8");
+    let value: serde_json::Value = serde_json::from_str(&stdout).expect("stdout is valid JSON");
+    let object = value.as_object().expect("--all returns a JSON object");
+
+    for key in [
+        "description",
+        "requirements",
+        "roadmap",
+        "roadmap-patch",
+        "spec",
+        "adr",
+        "story",
+        "plan",
+        "flow",
+    ] {
+        assert!(object.contains_key(key), "--all must include key {key}");
+    }
+
+    let spec = object.get("spec").and_then(|v| v.as_object()).unwrap();
+    assert!(spec.contains_key("$id"));
+
+    let plan = object.get("plan").and_then(|v| v.as_object()).unwrap();
+    assert_eq!(
+        plan.get("x-surge-no-json-schema").and_then(|v| v.as_bool()),
+        Some(true),
+        "markdown-only kinds report no-schema sentinel under --all"
+    );
+}
+
+#[test]
+fn schema_plan_reports_markdown_only_error() {
+    Command::cargo_bin("surge")
+        .unwrap()
+        .args(["artifact", "schema", "plan"])
+        .assert()
+        .failure()
+        .stderr(contains("no JSON schema for plan"))
+        .stderr(contains("## Settings"))
+        .stderr(contains("## Tasks"));
+}

--- a/crates/surge-core/Cargo.toml
+++ b/crates/surge-core/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 [dependencies]
 serde      = { workspace = true }
 serde_json = { workspace = true }
+schemars   = { workspace = true }
 toml       = { workspace = true }
 ulid       = { workspace = true }
 thiserror  = { workspace = true }

--- a/crates/surge-core/src/artifact_contract.rs
+++ b/crates/surge-core/src/artifact_contract.rs
@@ -1206,8 +1206,14 @@ const CONTRACTS: [ArtifactContract; 9] = [
 ///
 /// Returns `Some(&[...])` for kinds whose primary format is Markdown — the
 /// returned slice is the same set of `## <Section>` headings the validator
-/// requires. Returns `None` for TOML/FlowToml kinds where the contract is
-/// expressed by a JSON Schema instead (see [`json_schema_for`]).
+/// requires. Returns `None` for kinds whose canonical contract is *not*
+/// a markdown outline:
+///
+/// - `spec`, `roadmap`, `roadmap-patch`: the contract is captured by the
+///   JSON Schema returned from [`json_schema_for`].
+/// - `flow`: there is currently no exported JSON Schema; the contract is
+///   enforced by [`crate::graph::Graph`] in Rust plus engine-level
+///   validation. Schema export for flow is tracked separately.
 #[must_use]
 pub const fn markdown_outline(kind: ArtifactKind) -> Option<&'static [&'static str]> {
     match kind {
@@ -1273,6 +1279,7 @@ fn schema_value<T: schemars::JsonSchema>(filename: &str) -> serde_json::Value {
     let mut value = serde_json::to_value(&schema)
         .expect("schemars::Schema is JSON-serializable by construction");
     if let Some(object) = value.as_object_mut() {
+        ensure_schema_version_required(object);
         object.insert(
             "$id".to_string(),
             serde_json::Value::String(format!("{SCHEMA_ID_PREFIX}/{filename}")),
@@ -1283,6 +1290,37 @@ fn schema_value<T: schemars::JsonSchema>(filename: &str) -> serde_json::Value {
         );
     }
     value
+}
+
+/// Force `schema_version` into the root `required` array.
+///
+/// Surge-owned TOML artifacts (`spec`, `roadmap`, `roadmap-patch`) keep
+/// `#[serde(default = "...")]` on `schema_version` so that legacy in-memory
+/// constructors do not have to thread the constant — but the on-disk
+/// contract treats a missing `schema_version` as an error (see
+/// [`validate_schema_version`]). Without this post-processing step,
+/// schemars would mark the field optional and external validators would
+/// accept artifacts that the orchestrator later rejects.
+fn ensure_schema_version_required(object: &mut serde_json::Map<String, serde_json::Value>) {
+    let has_property = object
+        .get("properties")
+        .and_then(serde_json::Value::as_object)
+        .is_some_and(|properties| properties.contains_key("schema_version"));
+    if !has_property {
+        return;
+    }
+    let required = object
+        .entry("required".to_string())
+        .or_insert_with(|| serde_json::Value::Array(Vec::new()));
+    let Some(array) = required.as_array_mut() else {
+        return;
+    };
+    let already_present = array
+        .iter()
+        .any(|value| value.as_str() == Some("schema_version"));
+    if !already_present {
+        array.insert(0, serde_json::Value::String("schema_version".to_string()));
+    }
 }
 
 fn adr_frontmatter_schema() -> serde_json::Value {

--- a/crates/surge-core/src/artifact_contract.rs
+++ b/crates/surge-core/src/artifact_contract.rs
@@ -15,6 +15,7 @@ use crate::roadmap_patch::{
     InsertionPoint, RoadmapItemRef, RoadmapPatch, RoadmapPatchItem, RoadmapPatchOperation,
     RoadmapPatchValidationCode, RoadmapPatchValidationIssue,
 };
+use crate::spec::SpecArtifact;
 
 /// Current schema version used by Surge-owned artifact contracts.
 pub const ARTIFACT_SCHEMA_VERSION: u32 = 1;
@@ -1200,6 +1201,156 @@ const CONTRACTS: [ArtifactContract; 9] = [
     PLAN_CONTRACT,
     FLOW_CONTRACT,
 ];
+
+/// Required markdown headings (level-2) for markdown-format artifacts.
+///
+/// Returns `Some(&[...])` for kinds whose primary format is Markdown — the
+/// returned slice is the same set of `## <Section>` headings the validator
+/// requires. Returns `None` for TOML/FlowToml kinds where the contract is
+/// expressed by a JSON Schema instead (see [`json_schema_for`]).
+#[must_use]
+pub const fn markdown_outline(kind: ArtifactKind) -> Option<&'static [&'static str]> {
+    match kind {
+        ArtifactKind::Description => Some(&["Goal", "Context", "Requirements", "Out of Scope"]),
+        ArtifactKind::Requirements => Some(&[
+            "Overview",
+            "User Stories",
+            "Functional Requirements",
+            "Success Criteria",
+            "Out of Scope",
+        ]),
+        ArtifactKind::Adr => Some(&[
+            "Status",
+            "Context",
+            "Decision",
+            "Alternatives considered",
+            "Consequences",
+        ]),
+        ArtifactKind::Story => Some(&[
+            "Context",
+            "What needs to be done",
+            "Architecture decisions",
+            "Files to modify",
+            "Acceptance criteria",
+            "Out of scope",
+        ]),
+        ArtifactKind::Plan => Some(&["Settings", "Tasks"]),
+        ArtifactKind::Roadmap
+        | ArtifactKind::RoadmapPatch
+        | ArtifactKind::Spec
+        | ArtifactKind::Flow => None,
+    }
+}
+
+/// Stable `$id` prefix for exported JSON Schemas.
+const SCHEMA_ID_PREFIX: &str = "https://surge.dev/schema/v1";
+
+/// Export the JSON Schema (draft 2020-12) for `kind`, when one is available.
+///
+/// Returns `Some(schema)` for kinds whose primary format is TOML and which
+/// Surge owns as a typed artifact contract (`spec`, `roadmap`, `roadmap-patch`),
+/// plus an inline schema for the ADR TOML frontmatter. Returns `None` for
+/// markdown-only kinds (`description`, `requirements`, `story`, `plan`) and
+/// for `flow` — the latter is currently described by [`crate::graph::Graph`]
+/// in Rust and tracked separately for schema export.
+#[must_use]
+pub fn json_schema_for(kind: ArtifactKind) -> Option<serde_json::Value> {
+    match kind {
+        ArtifactKind::Spec => Some(schema_value::<SpecArtifact>("spec.json")),
+        ArtifactKind::Roadmap => Some(schema_value::<RoadmapArtifact>("roadmap.json")),
+        ArtifactKind::RoadmapPatch => Some(schema_value::<RoadmapPatch>("roadmap-patch.json")),
+        ArtifactKind::Adr => Some(adr_frontmatter_schema()),
+        ArtifactKind::Flow
+        | ArtifactKind::Description
+        | ArtifactKind::Requirements
+        | ArtifactKind::Story
+        | ArtifactKind::Plan => None,
+    }
+}
+
+fn schema_value<T: schemars::JsonSchema>(filename: &str) -> serde_json::Value {
+    let schema = schemars::schema_for!(T);
+    let mut value = serde_json::to_value(&schema)
+        .expect("schemars::Schema is JSON-serializable by construction");
+    if let Some(object) = value.as_object_mut() {
+        object.insert(
+            "$id".to_string(),
+            serde_json::Value::String(format!("{SCHEMA_ID_PREFIX}/{filename}")),
+        );
+        object.insert(
+            "x-surge-schema-version".to_string(),
+            serde_json::Value::Number(ARTIFACT_SCHEMA_VERSION.into()),
+        );
+    }
+    value
+}
+
+fn adr_frontmatter_schema() -> serde_json::Value {
+    serde_json::json!({
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$id": format!("{SCHEMA_ID_PREFIX}/adr-frontmatter.json"),
+        "title": "AdrFrontmatter",
+        "description": "Required TOML frontmatter fields for an ADR markdown file. The full ADR body is markdown-only; see `markdown_outline(ArtifactKind::Adr)` for the required body sections.",
+        "type": "object",
+        "required": ["status", "deciders", "date"],
+        "properties": {
+            "status": {
+                "type": "string",
+                "description": "ADR lifecycle status, for example `proposed`, `accepted`, `superseded`."
+            },
+            "deciders": {
+                "type": "array",
+                "description": "Humans or teams who own this decision.",
+                "items": { "type": "string", "minLength": 1 },
+                "minItems": 1
+            },
+            "date": {
+                "type": "string",
+                "description": "ISO-8601 calendar date the decision was recorded (`YYYY-MM-DD`).",
+                "pattern": r"^\d{4}-\d{2}-\d{2}$"
+            }
+        },
+        "additionalProperties": true,
+        "x-surge-schema-version": ARTIFACT_SCHEMA_VERSION
+    })
+}
+
+/// Self-describing summary for one artifact contract.
+///
+/// Convenience aggregate for prompt generators and external tooling that wants
+/// a single call to introspect a kind: canonical path, primary format,
+/// required markdown sections (when applicable), and the JSON Schema (when
+/// available).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ContractSummary {
+    /// Artifact family.
+    pub kind: ArtifactKind,
+    /// Canonical path or path pattern relative to the run worktree.
+    pub canonical_path: &'static str,
+    /// Primary representation agents should produce.
+    pub primary_format: ArtifactFormat,
+    /// Markdown sections that must be present, when applicable.
+    pub required_markdown_sections: Option<&'static [&'static str]>,
+    /// JSON Schema describing the on-disk format, when available.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub json_schema: Option<serde_json::Value>,
+    /// Current `schema_version` for the kind.
+    pub schema_version: u32,
+}
+
+/// Build the [`ContractSummary`] for `kind`.
+#[must_use]
+pub fn contract_summary(kind: ArtifactKind) -> ContractSummary {
+    let contract = contract_for(kind);
+    ContractSummary {
+        kind,
+        canonical_path: contract.canonical_path,
+        primary_format: contract.primary_format,
+        required_markdown_sections: markdown_outline(kind),
+        json_schema: json_schema_for(kind),
+        schema_version: schema_version_for_kind(kind),
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/crates/surge-core/src/content_hash.rs
+++ b/crates/surge-core/src/content_hash.rs
@@ -82,6 +82,24 @@ impl<'de> serde::Deserialize<'de> for ContentHash {
     }
 }
 
+impl schemars::JsonSchema for ContentHash {
+    fn schema_name() -> std::borrow::Cow<'static, str> {
+        std::borrow::Cow::Borrowed("ContentHash")
+    }
+
+    fn schema_id() -> std::borrow::Cow<'static, str> {
+        std::borrow::Cow::Borrowed("surge::content_hash::ContentHash")
+    }
+
+    fn json_schema(_generator: &mut schemars::SchemaGenerator) -> schemars::Schema {
+        schemars::json_schema!({
+            "type": "string",
+            "description": "Content hash in the canonical `sha256:<64 hex chars>` form. The bare 64-char hex form is also accepted on parse.",
+            "pattern": "^(sha256:)?[0-9a-fA-F]{64}$"
+        })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/surge-core/src/id.rs
+++ b/crates/surge-core/src/id.rs
@@ -1,6 +1,8 @@
 //! Type-safe identifiers for Surge entities.
 
+use schemars::{JsonSchema, Schema, SchemaGenerator};
 use serde::{Deserialize, Serialize};
+use std::borrow::Cow;
 use std::fmt;
 use ulid::Ulid;
 
@@ -62,6 +64,29 @@ macro_rules! define_id {
             fn from_str(s: &str) -> Result<Self, Self::Err> {
                 let ulid_str = s.strip_prefix(concat!($prefix, "-")).unwrap_or(s);
                 ulid_str.parse::<Ulid>().map(Self)
+            }
+        }
+
+        impl JsonSchema for $name {
+            fn schema_name() -> Cow<'static, str> {
+                Cow::Borrowed(stringify!($name))
+            }
+
+            fn schema_id() -> Cow<'static, str> {
+                Cow::Borrowed(concat!("surge::id::", stringify!($name)))
+            }
+
+            fn json_schema(_generator: &mut SchemaGenerator) -> Schema {
+                schemars::json_schema!({
+                    "type": "string",
+                    "description": concat!(
+                        "ULID identifier (26-char Crockford base32). Serialized as a bare ULID; ",
+                        "the prefixed form `",
+                        $prefix,
+                        "-<ulid>` is accepted for FromStr but not produced during JSON serialization."
+                    ),
+                    "pattern": "^[0-9A-HJKMNP-TV-Z]{26}$"
+                })
             }
         }
     };

--- a/crates/surge-core/src/keys.rs
+++ b/crates/surge-core/src/keys.rs
@@ -53,9 +53,14 @@ pub fn validate_key_chars(s: &str, max_len: usize, extras: &[u8]) -> Result<(), 
 /// Define a string-newtype key with character-set validation, custom
 /// serde, `Display`, `FromStr`, and `TryFrom<String>`/`TryFrom<&str>`.
 ///
-/// Usage: `define_key!(NodeKey, max_len = 32, extras = b"_");`
+/// Usage: `define_key!(NodeKey, max_len = 32, extras = b"_", pattern = r"^[A-Za-z][A-Za-z0-9_]*$");`
+///
+/// `pattern` MUST mirror the rules enforced by `validate_key_chars`:
+/// leading ASCII letter followed by ASCII alphanumeric plus the configured
+/// `extras`. The pattern is embedded into the exported JSON Schema so
+/// external validators reject the same identifiers Surge rejects.
 macro_rules! define_key {
-    ($name:ident, max_len = $max:expr, extras = $extras:expr $(,)?) => {
+    ($name:ident, max_len = $max:expr, extras = $extras:expr, pattern = $pattern:expr $(,)?) => {
         #[doc = concat!("Stable string identifier (max ", stringify!($max), " chars).")]
         #[derive(Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
         pub struct $name(String);
@@ -156,12 +161,13 @@ macro_rules! define_key {
                     "type": "string",
                     "description": concat!(
                         stringify!($name),
-                        ": validated identifier (ASCII alphanumeric plus configured extras, starts with a letter, max ",
+                        ": validated identifier (leading ASCII letter, followed by ASCII alphanumeric plus the configured extras; max ",
                         stringify!($max),
-                        " chars)."
+                        " chars). External validators MUST use the embedded `pattern` to reject identifiers the Surge parser would reject."
                     ),
                     "minLength": 1,
-                    "maxLength": $max
+                    "maxLength": $max,
+                    "pattern": $pattern
                 })
             }
         }
@@ -171,15 +177,47 @@ macro_rules! define_key {
 // ── Public key types ────────────────────────────────────────────────
 
 // Strict charset (alphanumeric + underscore, leading letter), max 32 chars.
-define_key!(NodeKey, max_len = 32, extras = b"_");
-define_key!(EdgeKey, max_len = 32, extras = b"_");
-define_key!(OutcomeKey, max_len = 32, extras = b"_");
-define_key!(SubgraphKey, max_len = 32, extras = b"_");
+define_key!(
+    NodeKey,
+    max_len = 32,
+    extras = b"_",
+    pattern = r"^[A-Za-z][A-Za-z0-9_]*$"
+);
+define_key!(
+    EdgeKey,
+    max_len = 32,
+    extras = b"_",
+    pattern = r"^[A-Za-z][A-Za-z0-9_]*$"
+);
+define_key!(
+    OutcomeKey,
+    max_len = 32,
+    extras = b"_",
+    pattern = r"^[A-Za-z][A-Za-z0-9_]*$"
+);
+define_key!(
+    SubgraphKey,
+    max_len = 32,
+    extras = b"_",
+    pattern = r"^[A-Za-z][A-Za-z0-9_]*$"
+);
 
 // Extended charset (alphanumeric + `_-.@`), max 64 chars. Allows
 // `"implementer@1.0"`, `"rust-crate-tdd@1.2.3"`.
-define_key!(ProfileKey, max_len = 64, extras = b"_-.@");
-define_key!(TemplateKey, max_len = 64, extras = b"_-.@");
+// The `-` is intentionally last inside the character class to avoid being
+// interpreted as a range.
+define_key!(
+    ProfileKey,
+    max_len = 64,
+    extras = b"_-.@",
+    pattern = r"^[A-Za-z][A-Za-z0-9_.@-]*$"
+);
+define_key!(
+    TemplateKey,
+    max_len = 64,
+    extras = b"_-.@",
+    pattern = r"^[A-Za-z][A-Za-z0-9_.@-]*$"
+);
 
 #[cfg(test)]
 mod tests {

--- a/crates/surge-core/src/keys.rs
+++ b/crates/surge-core/src/keys.rs
@@ -141,6 +141,30 @@ macro_rules! define_key {
                 Self::try_new(s).map_err(::serde::de::Error::custom)
             }
         }
+
+        impl ::schemars::JsonSchema for $name {
+            fn schema_name() -> ::std::borrow::Cow<'static, str> {
+                ::std::borrow::Cow::Borrowed(stringify!($name))
+            }
+
+            fn schema_id() -> ::std::borrow::Cow<'static, str> {
+                ::std::borrow::Cow::Borrowed(concat!("surge::keys::", stringify!($name)))
+            }
+
+            fn json_schema(_generator: &mut ::schemars::SchemaGenerator) -> ::schemars::Schema {
+                ::schemars::json_schema!({
+                    "type": "string",
+                    "description": concat!(
+                        stringify!($name),
+                        ": validated identifier (ASCII alphanumeric plus configured extras, starts with a letter, max ",
+                        stringify!($max),
+                        " chars)."
+                    ),
+                    "minLength": 1,
+                    "maxLength": $max
+                })
+            }
+        }
     };
 }
 

--- a/crates/surge-core/src/lib.rs
+++ b/crates/surge-core/src/lib.rs
@@ -89,8 +89,9 @@ pub use archetype::{ArchetypeMetadata, ArchetypeName};
 pub use artifact_contract::{
     ARTIFACT_SCHEMA_VERSION, ArtifactContract, ArtifactContractRef, ArtifactDiagnosticCode,
     ArtifactDiagnosticSeverity, ArtifactFormat, ArtifactKind, ArtifactValidationDiagnostic,
-    ArtifactValidationError, ArtifactValidationReport, SchemaVersionOwner, all_contracts,
-    contract_for, validate_artifact, validate_artifact_path, validate_artifact_text,
+    ArtifactValidationError, ArtifactValidationReport, ContractSummary, SchemaVersionOwner,
+    all_contracts, contract_for, contract_summary, json_schema_for, markdown_outline,
+    validate_artifact, validate_artifact_path, validate_artifact_text,
     validate_roadmap_patch_text_with_context,
 };
 pub use bundled_flows::{BUNDLED_FLOW_COUNT, BundledFlow, BundledFlows};

--- a/crates/surge-core/src/roadmap.rs
+++ b/crates/surge-core/src/roadmap.rs
@@ -14,7 +14,10 @@ use crate::spec::Complexity;
 /// available for runtime planning; this wrapper captures the authored roadmap
 /// shape and schema version.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
-#[schemars(title = "RoadmapArtifact", description = "Surge `roadmap.toml` artifact: ordered milestones, cross-milestone dependencies, and tracked risks.")]
+#[schemars(
+    title = "RoadmapArtifact",
+    description = "Surge `roadmap.toml` artifact: ordered milestones, cross-milestone dependencies, and tracked risks."
+)]
 pub struct RoadmapArtifact {
     /// Artifact contract schema version.
     #[serde(default = "default_artifact_schema_version")]

--- a/crates/surge-core/src/roadmap.rs
+++ b/crates/surge-core/src/roadmap.rs
@@ -1,5 +1,6 @@
 //! Roadmap types — project-level planning across multiple specs.
 
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::artifact_contract::ARTIFACT_SCHEMA_VERSION;
@@ -12,7 +13,8 @@ use crate::spec::Complexity;
 /// `flow.toml` is generated. The older [`Timeline`] scheduling model remains
 /// available for runtime planning; this wrapper captures the authored roadmap
 /// shape and schema version.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[schemars(title = "RoadmapArtifact", description = "Surge `roadmap.toml` artifact: ordered milestones, cross-milestone dependencies, and tracked risks.")]
 pub struct RoadmapArtifact {
     /// Artifact contract schema version.
     #[serde(default = "default_artifact_schema_version")]
@@ -105,7 +107,7 @@ impl Default for RoadmapArtifact {
 }
 
 /// One deliverable-focused roadmap milestone.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 pub struct RoadmapMilestone {
     /// Stable human-authored identifier, for example `m1`.
     pub id: String,
@@ -133,7 +135,7 @@ impl RoadmapMilestone {
 }
 
 /// One task within a roadmap milestone.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 pub struct RoadmapTask {
     /// Stable human-authored identifier, for example `m1-t1`.
     pub id: String,
@@ -165,7 +167,7 @@ impl RoadmapTask {
 }
 
 /// Directed dependency between roadmap milestones.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 pub struct RoadmapDependency {
     /// Milestone that must finish first.
     pub from: String,
@@ -177,7 +179,7 @@ pub struct RoadmapDependency {
 }
 
 /// Risk tracked by the roadmap artifact.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 pub struct RoadmapRisk {
     /// Risk description.
     pub description: String,
@@ -229,7 +231,7 @@ impl std::fmt::Display for Priority {
 }
 
 /// Execution status of a roadmap item.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default, JsonSchema)]
 #[serde(rename_all = "lowercase")]
 pub enum RoadmapStatus {
     /// Not yet started.

--- a/crates/surge-core/src/roadmap_patch.rs
+++ b/crates/surge-core/src/roadmap_patch.rs
@@ -112,7 +112,10 @@ pub enum RoadmapPatchIdError {
 
 /// Machine-readable roadmap amendment artifact.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
-#[schemars(title = "RoadmapPatch", description = "Surge `roadmap-patch.toml` artifact: an ordered sequence of operations amending an existing roadmap, plus dependencies, conflicts, and lifecycle status.")]
+#[schemars(
+    title = "RoadmapPatch",
+    description = "Surge `roadmap-patch.toml` artifact: an ordered sequence of operations amending an existing roadmap, plus dependencies, conflicts, and lifecycle status."
+)]
 pub struct RoadmapPatch {
     /// Artifact schema version.
     #[serde(default = "default_schema_version")]

--- a/crates/surge-core/src/roadmap_patch.rs
+++ b/crates/surge-core/src/roadmap_patch.rs
@@ -87,11 +87,19 @@ impl schemars::JsonSchema for RoadmapPatchId {
     }
 
     fn json_schema(_generator: &mut schemars::SchemaGenerator) -> schemars::Schema {
+        // `RoadmapPatchId::new` trims surrounding whitespace before
+        // validating, so inputs such as `"  rpatch-abc  "` are accepted
+        // and normalized to `"rpatch-abc"`. The pattern below mirrors that
+        // exactly: optional leading/trailing whitespace, then a non-empty
+        // canonical core of ASCII alphanumeric plus `-`, `_`, `.`. The
+        // canonical/serialized form never carries whitespace, but external
+        // validators should still accept the same inputs Surge does on
+        // deserialization.
         schemars::json_schema!({
             "type": "string",
-            "description": "Stable roadmap patch identifier. ASCII alphanumeric plus `-`, `_`, `.`. Non-empty after trimming.",
+            "description": "Stable roadmap patch identifier. Canonical form: ASCII alphanumeric plus `-`, `_`, `.` (non-empty). Optional surrounding whitespace is accepted on parse and stripped; serialized output never carries whitespace.",
             "minLength": 1,
-            "pattern": r"^[A-Za-z0-9._-]+$"
+            "pattern": r"^\s*[A-Za-z0-9._-]+\s*$"
         })
     }
 }

--- a/crates/surge-core/src/roadmap_patch.rs
+++ b/crates/surge-core/src/roadmap_patch.rs
@@ -10,6 +10,7 @@ use crate::id::RunId;
 use crate::roadmap::{
     RoadmapArtifact, RoadmapDependency, RoadmapMilestone, RoadmapStatus, RoadmapTask,
 };
+use schemars::JsonSchema;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
@@ -76,6 +77,25 @@ impl<'de> Deserialize<'de> for RoadmapPatchId {
     }
 }
 
+impl schemars::JsonSchema for RoadmapPatchId {
+    fn schema_name() -> std::borrow::Cow<'static, str> {
+        std::borrow::Cow::Borrowed("RoadmapPatchId")
+    }
+
+    fn schema_id() -> std::borrow::Cow<'static, str> {
+        std::borrow::Cow::Borrowed("surge::roadmap_patch::RoadmapPatchId")
+    }
+
+    fn json_schema(_generator: &mut schemars::SchemaGenerator) -> schemars::Schema {
+        schemars::json_schema!({
+            "type": "string",
+            "description": "Stable roadmap patch identifier. ASCII alphanumeric plus `-`, `_`, `.`. Non-empty after trimming.",
+            "minLength": 1,
+            "pattern": r"^[A-Za-z0-9._-]+$"
+        })
+    }
+}
+
 /// Error returned when a roadmap patch ID is malformed.
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 pub enum RoadmapPatchIdError {
@@ -91,7 +111,8 @@ pub enum RoadmapPatchIdError {
 }
 
 /// Machine-readable roadmap amendment artifact.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[schemars(title = "RoadmapPatch", description = "Surge `roadmap-patch.toml` artifact: an ordered sequence of operations amending an existing roadmap, plus dependencies, conflicts, and lifecycle status.")]
 pub struct RoadmapPatch {
     /// Artifact schema version.
     #[serde(default = "default_schema_version")]
@@ -783,7 +804,7 @@ fn dependency_dfs_has_cycle<'a>(
 }
 
 /// Target amended by a roadmap patch.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum RoadmapPatchTarget {
     /// Project-level roadmap file.
@@ -808,7 +829,7 @@ pub enum RoadmapPatchTarget {
 }
 
 /// Active-run pickup policy for a patch target.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum ActivePickupPolicy {
     /// Runner may pick up new work at a safe loop boundary.
@@ -821,7 +842,7 @@ pub enum ActivePickupPolicy {
 }
 
 /// Insertion point for append/insert operations.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum InsertionPoint {
     /// Append a milestone to the end of the roadmap.
@@ -877,7 +898,7 @@ impl InsertionPoint {
 }
 
 /// One operation inside a roadmap patch.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(tag = "op", rename_all = "snake_case")]
 pub enum RoadmapPatchOperation {
     /// Insert a new milestone.
@@ -932,7 +953,7 @@ impl RoadmapPatchOperation {
 }
 
 /// Reference to a roadmap milestone or task.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum RoadmapItemRef {
     /// Milestone reference.
@@ -962,7 +983,7 @@ impl RoadmapItemRef {
 }
 
 /// Replacement item for a draft-only roadmap item.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum RoadmapPatchItem {
     /// Replacement milestone.
@@ -978,7 +999,7 @@ pub enum RoadmapPatchItem {
 }
 
 /// Dependency edge introduced by a patch.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 pub struct RoadmapPatchDependency {
     /// Source item that must complete first.
     pub from: RoadmapItemRef,
@@ -1023,7 +1044,7 @@ impl RoadmapPatchDependency {
 }
 
 /// Conflict metadata attached to a roadmap patch.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 pub struct RoadmapPatchConflict {
     /// Stable conflict code.
     pub code: RoadmapPatchConflictCode,
@@ -1060,7 +1081,7 @@ impl RoadmapPatchConflict {
 }
 
 /// Stable conflict classes.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum RoadmapPatchConflictCode {
     /// Referenced item could not be found.
@@ -1078,7 +1099,7 @@ pub enum RoadmapPatchConflictCode {
 }
 
 /// Operator choice for resolving an amendment conflict.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum OperatorConflictChoice {
     /// Defer the new work to the next safe milestone.
@@ -1115,7 +1136,7 @@ pub fn conflict_choices_for_code(code: RoadmapPatchConflictCode) -> Vec<Operator
 }
 
 /// Lifecycle state for a roadmap patch.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum RoadmapPatchStatus {
     /// Patch has been drafted by Feature Planner.

--- a/crates/surge-core/src/spec.rs
+++ b/crates/surge-core/src/spec.rs
@@ -2,6 +2,7 @@
 
 use crate::artifact_contract::ARTIFACT_SCHEMA_VERSION;
 use crate::id::{SpecId, SubtaskId};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 /// Machine-readable `spec.toml` artifact wrapper.
@@ -9,7 +10,8 @@ use serde::{Deserialize, Serialize};
 /// The existing [`Spec`] type remains the execution model. This wrapper adds
 /// the artifact contract schema version around it so authored files can evolve
 /// independently from the in-memory spec fields.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[schemars(title = "SpecArtifact", description = "Surge `spec.toml` artifact: schema version envelope around the executable spec payload.")]
 pub struct SpecArtifact {
     /// Artifact contract schema version.
     #[serde(default = "default_artifact_schema_version")]
@@ -48,7 +50,7 @@ impl From<SpecArtifact> for Spec {
 }
 
 /// Execution state of a single subtask.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default, JsonSchema)]
 #[serde(rename_all = "lowercase")]
 pub enum SubtaskState {
     #[default]
@@ -74,7 +76,7 @@ impl SubtaskState {
 }
 
 /// Execution metadata for a single subtask, persisted to spec.toml.
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, JsonSchema)]
 pub struct SubtaskExecution {
     /// Current execution state.
     #[serde(default)]
@@ -91,7 +93,7 @@ pub struct SubtaskExecution {
 }
 
 /// Complexity level for a task or subtask.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "lowercase")]
 pub enum Complexity {
     Simple,
@@ -100,7 +102,7 @@ pub enum Complexity {
 }
 
 /// Acceptance criteria for a subtask.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct AcceptanceCriteria {
     /// Human-readable description of what must be true.
     pub description: String,
@@ -110,7 +112,7 @@ pub struct AcceptanceCriteria {
 }
 
 /// A subtask within a spec.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct Subtask {
     /// Unique identifier.
     pub id: SubtaskId,
@@ -142,7 +144,7 @@ pub struct Subtask {
 }
 
 /// A complete spec describing a unit of work.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct Spec {
     /// Unique identifier.
     pub id: SpecId,

--- a/crates/surge-core/src/spec.rs
+++ b/crates/surge-core/src/spec.rs
@@ -11,7 +11,10 @@ use serde::{Deserialize, Serialize};
 /// the artifact contract schema version around it so authored files can evolve
 /// independently from the in-memory spec fields.
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
-#[schemars(title = "SpecArtifact", description = "Surge `spec.toml` artifact: schema version envelope around the executable spec payload.")]
+#[schemars(
+    title = "SpecArtifact",
+    description = "Surge `spec.toml` artifact: schema version envelope around the executable spec payload."
+)]
 pub struct SpecArtifact {
     /// Artifact contract schema version.
     #[serde(default = "default_artifact_schema_version")]

--- a/crates/surge-core/tests/artifact_schema_snapshots.rs
+++ b/crates/surge-core/tests/artifact_schema_snapshots.rs
@@ -74,8 +74,9 @@ fn contract_summary_combines_schema_and_outline() {
     let plan = contract_summary(ArtifactKind::Plan);
     assert_eq!(plan.kind, ArtifactKind::Plan);
     assert!(plan.json_schema.is_none());
-    let sections =
-        plan.required_markdown_sections.expect("plan must expose markdown outline");
+    let sections = plan
+        .required_markdown_sections
+        .expect("plan must expose markdown outline");
     assert_eq!(sections, &["Settings", "Tasks"]);
 }
 

--- a/crates/surge-core/tests/artifact_schema_snapshots.rs
+++ b/crates/surge-core/tests/artifact_schema_snapshots.rs
@@ -1,0 +1,106 @@
+//! Snapshot tests for JSON Schemas exported by the artifact contract module.
+//!
+//! Snapshots capture the current canonical shape of every TOML-format artifact
+//! contract that Surge exposes. Any breaking schema change will surface as a
+//! diff here, so external prompt profiles and validators can be updated in
+//! lockstep.
+//!
+//! Run: `cargo test -p surge-core --test artifact_schema_snapshots`
+//! Accept new snapshots after intentional changes: `cargo insta accept`.
+
+use surge_core::{ArtifactKind, contract_summary, json_schema_for, markdown_outline};
+
+#[test]
+fn spec_json_schema_is_stable() {
+    let schema = json_schema_for(ArtifactKind::Spec).expect("spec exports a JSON schema");
+    insta::assert_json_snapshot!("spec_json_schema", schema);
+}
+
+#[test]
+fn roadmap_json_schema_is_stable() {
+    let schema = json_schema_for(ArtifactKind::Roadmap).expect("roadmap exports a JSON schema");
+    insta::assert_json_snapshot!("roadmap_json_schema", schema);
+}
+
+#[test]
+fn roadmap_patch_json_schema_is_stable() {
+    let schema =
+        json_schema_for(ArtifactKind::RoadmapPatch).expect("roadmap-patch exports a JSON schema");
+    insta::assert_json_snapshot!("roadmap_patch_json_schema", schema);
+}
+
+#[test]
+fn adr_frontmatter_schema_is_stable() {
+    let schema = json_schema_for(ArtifactKind::Adr).expect("ADR exports a frontmatter schema");
+    insta::assert_json_snapshot!("adr_frontmatter_json_schema", schema);
+}
+
+#[test]
+fn markdown_only_kinds_have_no_json_schema() {
+    for kind in [
+        ArtifactKind::Description,
+        ArtifactKind::Requirements,
+        ArtifactKind::Story,
+        ArtifactKind::Plan,
+    ] {
+        assert!(
+            json_schema_for(kind).is_none(),
+            "{kind} should not expose a JSON schema (markdown-only contract)"
+        );
+        assert!(
+            markdown_outline(kind).is_some(),
+            "{kind} should expose a markdown outline"
+        );
+    }
+}
+
+#[test]
+fn flow_currently_has_no_exported_schema() {
+    // Flow is described by [`surge_core::Graph`] in Rust. Schema export for
+    // flow is tracked separately; until then `json_schema_for` returns None
+    // and `markdown_outline` returns None (flow has no markdown body).
+    assert!(json_schema_for(ArtifactKind::Flow).is_none());
+    assert!(markdown_outline(ArtifactKind::Flow).is_none());
+}
+
+#[test]
+fn contract_summary_combines_schema_and_outline() {
+    let spec = contract_summary(ArtifactKind::Spec);
+    assert_eq!(spec.kind, ArtifactKind::Spec);
+    assert_eq!(spec.canonical_path, "spec.toml");
+    assert!(spec.json_schema.is_some());
+    assert!(spec.required_markdown_sections.is_none());
+
+    let plan = contract_summary(ArtifactKind::Plan);
+    assert_eq!(plan.kind, ArtifactKind::Plan);
+    assert!(plan.json_schema.is_none());
+    let sections =
+        plan.required_markdown_sections.expect("plan must expose markdown outline");
+    assert_eq!(sections, &["Settings", "Tasks"]);
+}
+
+#[test]
+fn exported_schemas_carry_surge_id_and_version() {
+    for kind in [
+        ArtifactKind::Spec,
+        ArtifactKind::Roadmap,
+        ArtifactKind::RoadmapPatch,
+        ArtifactKind::Adr,
+    ] {
+        let schema = json_schema_for(kind).expect("kind exports a schema");
+        let object = schema.as_object().expect("schema is a JSON object");
+        let id = object
+            .get("$id")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or_else(|| panic!("{kind} schema missing $id"));
+        assert!(
+            id.starts_with("https://surge.dev/schema/v1/"),
+            "{kind} $id should start with the canonical Surge namespace, got {id}"
+        );
+        let version = object
+            .get("x-surge-schema-version")
+            .and_then(serde_json::Value::as_u64)
+            .unwrap_or_else(|| panic!("{kind} schema missing x-surge-schema-version"));
+        assert_eq!(version, u64::from(surge_core::ARTIFACT_SCHEMA_VERSION));
+    }
+}

--- a/crates/surge-core/tests/snapshots/artifact_schema_snapshots__adr_frontmatter_json_schema.snap
+++ b/crates/surge-core/tests/snapshots/artifact_schema_snapshots__adr_frontmatter_json_schema.snap
@@ -1,0 +1,38 @@
+---
+source: crates/surge-core/tests/artifact_schema_snapshots.rs
+expression: schema
+---
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://surge.dev/schema/v1/adr-frontmatter.json",
+  "title": "AdrFrontmatter",
+  "description": "Required TOML frontmatter fields for an ADR markdown file. The full ADR body is markdown-only; see `markdown_outline(ArtifactKind::Adr)` for the required body sections.",
+  "type": "object",
+  "required": [
+    "status",
+    "deciders",
+    "date"
+  ],
+  "properties": {
+    "status": {
+      "type": "string",
+      "description": "ADR lifecycle status, for example `proposed`, `accepted`, `superseded`."
+    },
+    "deciders": {
+      "type": "array",
+      "description": "Humans or teams who own this decision.",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "minItems": 1
+    },
+    "date": {
+      "type": "string",
+      "description": "ISO-8601 calendar date the decision was recorded (`YYYY-MM-DD`).",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+    }
+  },
+  "additionalProperties": true,
+  "x-surge-schema-version": 1
+}

--- a/crates/surge-core/tests/snapshots/artifact_schema_snapshots__roadmap_json_schema.snap
+++ b/crates/surge-core/tests/snapshots/artifact_schema_snapshots__roadmap_json_schema.snap
@@ -186,6 +186,9 @@ expression: schema
       ]
     }
   },
+  "required": [
+    "schema_version"
+  ],
   "$id": "https://surge.dev/schema/v1/roadmap.json",
   "x-surge-schema-version": 1
 }

--- a/crates/surge-core/tests/snapshots/artifact_schema_snapshots__roadmap_json_schema.snap
+++ b/crates/surge-core/tests/snapshots/artifact_schema_snapshots__roadmap_json_schema.snap
@@ -1,0 +1,191 @@
+---
+source: crates/surge-core/tests/artifact_schema_snapshots.rs
+expression: schema
+---
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "RoadmapArtifact",
+  "description": "Surge `roadmap.toml` artifact: ordered milestones, cross-milestone dependencies, and tracked risks.",
+  "type": "object",
+  "properties": {
+    "schema_version": {
+      "description": "Artifact contract schema version.",
+      "type": "integer",
+      "format": "uint32",
+      "minimum": 0,
+      "default": 1
+    },
+    "milestones": {
+      "description": "Deliverable-focused milestones in execution order.",
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/RoadmapMilestone"
+      },
+      "default": []
+    },
+    "dependencies": {
+      "description": "Cross-milestone dependencies.",
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/RoadmapDependency"
+      },
+      "default": []
+    },
+    "risks": {
+      "description": "Known delivery risks.",
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/RoadmapRisk"
+      },
+      "default": []
+    }
+  },
+  "$defs": {
+    "RoadmapMilestone": {
+      "description": "One deliverable-focused roadmap milestone.",
+      "type": "object",
+      "properties": {
+        "id": {
+          "description": "Stable human-authored identifier, for example `m1`.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Human-readable milestone title.",
+          "type": "string"
+        },
+        "status": {
+          "description": "Current execution status for amendment safety checks.",
+          "$ref": "#/$defs/RoadmapStatus"
+        },
+        "tasks": {
+          "description": "Ordered tasks within this milestone.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/RoadmapTask"
+          },
+          "default": []
+        }
+      },
+      "required": [
+        "id",
+        "title"
+      ]
+    },
+    "RoadmapStatus": {
+      "description": "Execution status of a roadmap item.",
+      "oneOf": [
+        {
+          "description": "Not yet started.",
+          "type": "string",
+          "const": "pending"
+        },
+        {
+          "description": "Currently being executed by the orchestrator.",
+          "type": "string",
+          "const": "running"
+        },
+        {
+          "description": "Paused, waiting for human input or gate.",
+          "type": "string",
+          "const": "paused"
+        },
+        {
+          "description": "Completed successfully.",
+          "type": "string",
+          "const": "completed"
+        },
+        {
+          "description": "Failed — may be retried.",
+          "type": "string",
+          "const": "failed"
+        },
+        {
+          "description": "Skipped (dependency failed or user cancelled).",
+          "type": "string",
+          "const": "skipped"
+        }
+      ]
+    },
+    "RoadmapTask": {
+      "description": "One task within a roadmap milestone.",
+      "type": "object",
+      "properties": {
+        "id": {
+          "description": "Stable human-authored identifier, for example `m1-t1`.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Human-readable task title.",
+          "type": "string"
+        },
+        "status": {
+          "description": "Current execution status for amendment safety checks.",
+          "$ref": "#/$defs/RoadmapStatus"
+        },
+        "description": {
+          "description": "Optional short description.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "acceptance_criteria": {
+          "description": "Acceptance criteria that downstream spec/story authors can refine.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": []
+        }
+      },
+      "required": [
+        "id",
+        "title"
+      ]
+    },
+    "RoadmapDependency": {
+      "description": "Directed dependency between roadmap milestones.",
+      "type": "object",
+      "properties": {
+        "from": {
+          "description": "Milestone that must finish first.",
+          "type": "string"
+        },
+        "to": {
+          "description": "Milestone that depends on `from`.",
+          "type": "string"
+        },
+        "reason": {
+          "description": "Human-readable reason for the dependency.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "from",
+        "to"
+      ]
+    },
+    "RoadmapRisk": {
+      "description": "Risk tracked by the roadmap artifact.",
+      "type": "object",
+      "properties": {
+        "description": {
+          "description": "Risk description.",
+          "type": "string"
+        },
+        "mitigation": {
+          "description": "Optional mitigation plan.",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "description"
+      ]
+    }
+  },
+  "$id": "https://surge.dev/schema/v1/roadmap.json",
+  "x-surge-schema-version": 1
+}

--- a/crates/surge-core/tests/snapshots/artifact_schema_snapshots__roadmap_patch_json_schema.snap
+++ b/crates/surge-core/tests/snapshots/artifact_schema_snapshots__roadmap_patch_json_schema.snap
@@ -58,15 +58,16 @@ expression: schema
     }
   },
   "required": [
+    "schema_version",
     "id",
     "target"
   ],
   "$defs": {
     "RoadmapPatchId": {
-      "description": "Stable roadmap patch identifier. ASCII alphanumeric plus `-`, `_`, `.`. Non-empty after trimming.",
+      "description": "Stable roadmap patch identifier. Canonical form: ASCII alphanumeric plus `-`, `_`, `.` (non-empty). Optional surrounding whitespace is accepted on parse and stripped; serialized output never carries whitespace.",
       "type": "string",
       "minLength": 1,
-      "pattern": "^[A-Za-z0-9._-]+$"
+      "pattern": "^\\s*[A-Za-z0-9._-]+\\s*$"
     },
     "RoadmapPatchTarget": {
       "description": "Target amended by a roadmap patch.",

--- a/crates/surge-core/tests/snapshots/artifact_schema_snapshots__roadmap_patch_json_schema.snap
+++ b/crates/surge-core/tests/snapshots/artifact_schema_snapshots__roadmap_patch_json_schema.snap
@@ -1,0 +1,739 @@
+---
+source: crates/surge-core/tests/artifact_schema_snapshots.rs
+expression: schema
+---
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "RoadmapPatch",
+  "description": "Surge `roadmap-patch.toml` artifact: an ordered sequence of operations amending an existing roadmap, plus dependencies, conflicts, and lifecycle status.",
+  "type": "object",
+  "properties": {
+    "schema_version": {
+      "description": "Artifact schema version.",
+      "type": "integer",
+      "format": "uint32",
+      "minimum": 0,
+      "default": 1
+    },
+    "id": {
+      "description": "Stable patch identifier.",
+      "$ref": "#/$defs/RoadmapPatchId"
+    },
+    "target": {
+      "description": "Roadmap or run this patch amends.",
+      "$ref": "#/$defs/RoadmapPatchTarget"
+    },
+    "rationale": {
+      "description": "Human-readable reason for the amendment.",
+      "type": "string"
+    },
+    "operations": {
+      "description": "Ordered patch operations.",
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/RoadmapPatchOperation"
+      },
+      "default": []
+    },
+    "dependencies": {
+      "description": "Cross-item dependencies introduced by this patch.",
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/RoadmapPatchDependency"
+      },
+      "default": []
+    },
+    "conflicts": {
+      "description": "Conflicts detected while drafting or applying the patch.",
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/RoadmapPatchConflict"
+      },
+      "default": []
+    },
+    "status": {
+      "description": "Current lifecycle state.",
+      "$ref": "#/$defs/RoadmapPatchStatus",
+      "default": "drafted"
+    }
+  },
+  "required": [
+    "id",
+    "target"
+  ],
+  "$defs": {
+    "RoadmapPatchId": {
+      "description": "Stable roadmap patch identifier. ASCII alphanumeric plus `-`, `_`, `.`. Non-empty after trimming.",
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^[A-Za-z0-9._-]+$"
+    },
+    "RoadmapPatchTarget": {
+      "description": "Target amended by a roadmap patch.",
+      "oneOf": [
+        {
+          "description": "Project-level roadmap file.",
+          "type": "object",
+          "properties": {
+            "roadmap_path": {
+              "description": "Portable path relative to the project root.",
+              "type": "string"
+            },
+            "kind": {
+              "type": "string",
+              "const": "project_roadmap"
+            }
+          },
+          "required": [
+            "kind",
+            "roadmap_path"
+          ]
+        },
+        {
+          "description": "Roadmap artifact belonging to a run.",
+          "type": "object",
+          "properties": {
+            "run_id": {
+              "description": "Target run.",
+              "$ref": "#/$defs/RunId"
+            },
+            "roadmap_artifact": {
+              "description": "Stored roadmap artifact hash, when known.",
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/ContentHash"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "flow_artifact": {
+              "description": "Stored flow artifact hash, when known.",
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/ContentHash"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "active_pickup": {
+              "description": "Whether the active runner may pick up this amendment.",
+              "$ref": "#/$defs/ActivePickupPolicy",
+              "default": "allowed"
+            },
+            "kind": {
+              "type": "string",
+              "const": "run_roadmap"
+            }
+          },
+          "required": [
+            "kind",
+            "run_id"
+          ]
+        }
+      ]
+    },
+    "RunId": {
+      "description": "ULID identifier (26-char Crockford base32). Serialized as a bare ULID; the prefixed form `run-<ulid>` is accepted for FromStr but not produced during JSON serialization.",
+      "type": "string",
+      "pattern": "^[0-9A-HJKMNP-TV-Z]{26}$"
+    },
+    "ContentHash": {
+      "description": "Content hash in the canonical `sha256:<64 hex chars>` form. The bare 64-char hex form is also accepted on parse.",
+      "type": "string",
+      "pattern": "^(sha256:)?[0-9a-fA-F]{64}$"
+    },
+    "ActivePickupPolicy": {
+      "description": "Active-run pickup policy for a patch target.",
+      "oneOf": [
+        {
+          "description": "Runner may pick up new work at a safe loop boundary.",
+          "type": "string",
+          "const": "allowed"
+        },
+        {
+          "description": "Always create a follow-up run rather than amending the active graph.",
+          "type": "string",
+          "const": "follow_up_only"
+        },
+        {
+          "description": "Keep the patch pending until an operator chooses a resolution.",
+          "type": "string",
+          "const": "disabled"
+        }
+      ]
+    },
+    "RoadmapPatchOperation": {
+      "description": "One operation inside a roadmap patch.",
+      "oneOf": [
+        {
+          "description": "Insert a new milestone.",
+          "type": "object",
+          "properties": {
+            "milestone": {
+              "description": "New milestone.",
+              "$ref": "#/$defs/RoadmapMilestone"
+            },
+            "insertion": {
+              "description": "Position for the new milestone.",
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/InsertionPoint"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "op": {
+              "type": "string",
+              "const": "add_milestone"
+            }
+          },
+          "required": [
+            "op",
+            "milestone"
+          ]
+        },
+        {
+          "description": "Insert a new task into an existing milestone.",
+          "type": "object",
+          "properties": {
+            "milestone_id": {
+              "description": "Existing milestone ID.",
+              "type": "string"
+            },
+            "task": {
+              "description": "New task.",
+              "$ref": "#/$defs/RoadmapTask"
+            },
+            "insertion": {
+              "description": "Position for the new task.",
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/InsertionPoint"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "op": {
+              "type": "string",
+              "const": "add_task"
+            }
+          },
+          "required": [
+            "op",
+            "milestone_id",
+            "task"
+          ]
+        },
+        {
+          "description": "Replace an item that is still draft-only and not part of completed history.",
+          "type": "object",
+          "properties": {
+            "target": {
+              "description": "Existing draft item to replace.",
+              "$ref": "#/$defs/RoadmapItemRef"
+            },
+            "replacement": {
+              "description": "Replacement item.",
+              "$ref": "#/$defs/RoadmapPatchItem"
+            },
+            "reason": {
+              "description": "Human-readable replacement reason.",
+              "type": "string"
+            },
+            "op": {
+              "type": "string",
+              "const": "replace_draft_item"
+            }
+          },
+          "required": [
+            "op",
+            "target",
+            "replacement"
+          ]
+        }
+      ]
+    },
+    "RoadmapMilestone": {
+      "description": "One deliverable-focused roadmap milestone.",
+      "type": "object",
+      "properties": {
+        "id": {
+          "description": "Stable human-authored identifier, for example `m1`.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Human-readable milestone title.",
+          "type": "string"
+        },
+        "status": {
+          "description": "Current execution status for amendment safety checks.",
+          "$ref": "#/$defs/RoadmapStatus"
+        },
+        "tasks": {
+          "description": "Ordered tasks within this milestone.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/RoadmapTask"
+          },
+          "default": []
+        }
+      },
+      "required": [
+        "id",
+        "title"
+      ]
+    },
+    "RoadmapStatus": {
+      "description": "Execution status of a roadmap item.",
+      "oneOf": [
+        {
+          "description": "Not yet started.",
+          "type": "string",
+          "const": "pending"
+        },
+        {
+          "description": "Currently being executed by the orchestrator.",
+          "type": "string",
+          "const": "running"
+        },
+        {
+          "description": "Paused, waiting for human input or gate.",
+          "type": "string",
+          "const": "paused"
+        },
+        {
+          "description": "Completed successfully.",
+          "type": "string",
+          "const": "completed"
+        },
+        {
+          "description": "Failed — may be retried.",
+          "type": "string",
+          "const": "failed"
+        },
+        {
+          "description": "Skipped (dependency failed or user cancelled).",
+          "type": "string",
+          "const": "skipped"
+        }
+      ]
+    },
+    "RoadmapTask": {
+      "description": "One task within a roadmap milestone.",
+      "type": "object",
+      "properties": {
+        "id": {
+          "description": "Stable human-authored identifier, for example `m1-t1`.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Human-readable task title.",
+          "type": "string"
+        },
+        "status": {
+          "description": "Current execution status for amendment safety checks.",
+          "$ref": "#/$defs/RoadmapStatus"
+        },
+        "description": {
+          "description": "Optional short description.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "acceptance_criteria": {
+          "description": "Acceptance criteria that downstream spec/story authors can refine.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": []
+        }
+      },
+      "required": [
+        "id",
+        "title"
+      ]
+    },
+    "InsertionPoint": {
+      "description": "Insertion point for append/insert operations.",
+      "oneOf": [
+        {
+          "description": "Append a milestone to the end of the roadmap.",
+          "type": "object",
+          "properties": {
+            "kind": {
+              "type": "string",
+              "const": "append_to_roadmap"
+            }
+          },
+          "required": [
+            "kind"
+          ]
+        },
+        {
+          "description": "Insert before an existing milestone.",
+          "type": "object",
+          "properties": {
+            "milestone_id": {
+              "description": "Existing milestone ID.",
+              "type": "string"
+            },
+            "kind": {
+              "type": "string",
+              "const": "before_milestone"
+            }
+          },
+          "required": [
+            "kind",
+            "milestone_id"
+          ]
+        },
+        {
+          "description": "Insert after an existing milestone.",
+          "type": "object",
+          "properties": {
+            "milestone_id": {
+              "description": "Existing milestone ID.",
+              "type": "string"
+            },
+            "kind": {
+              "type": "string",
+              "const": "after_milestone"
+            }
+          },
+          "required": [
+            "kind",
+            "milestone_id"
+          ]
+        },
+        {
+          "description": "Append a task to an existing milestone.",
+          "type": "object",
+          "properties": {
+            "milestone_id": {
+              "description": "Existing milestone ID.",
+              "type": "string"
+            },
+            "kind": {
+              "type": "string",
+              "const": "append_to_milestone"
+            }
+          },
+          "required": [
+            "kind",
+            "milestone_id"
+          ]
+        },
+        {
+          "description": "Insert before an existing task.",
+          "type": "object",
+          "properties": {
+            "milestone_id": {
+              "description": "Existing milestone ID.",
+              "type": "string"
+            },
+            "task_id": {
+              "description": "Existing task ID.",
+              "type": "string"
+            },
+            "kind": {
+              "type": "string",
+              "const": "before_task"
+            }
+          },
+          "required": [
+            "kind",
+            "milestone_id",
+            "task_id"
+          ]
+        },
+        {
+          "description": "Insert after an existing task.",
+          "type": "object",
+          "properties": {
+            "milestone_id": {
+              "description": "Existing milestone ID.",
+              "type": "string"
+            },
+            "task_id": {
+              "description": "Existing task ID.",
+              "type": "string"
+            },
+            "kind": {
+              "type": "string",
+              "const": "after_task"
+            }
+          },
+          "required": [
+            "kind",
+            "milestone_id",
+            "task_id"
+          ]
+        }
+      ]
+    },
+    "RoadmapItemRef": {
+      "description": "Reference to a roadmap milestone or task.",
+      "oneOf": [
+        {
+          "description": "Milestone reference.",
+          "type": "object",
+          "properties": {
+            "milestone_id": {
+              "description": "Milestone ID.",
+              "type": "string"
+            },
+            "kind": {
+              "type": "string",
+              "const": "milestone"
+            }
+          },
+          "required": [
+            "kind",
+            "milestone_id"
+          ]
+        },
+        {
+          "description": "Task reference.",
+          "type": "object",
+          "properties": {
+            "milestone_id": {
+              "description": "Milestone ID containing the task.",
+              "type": "string"
+            },
+            "task_id": {
+              "description": "Task ID.",
+              "type": "string"
+            },
+            "kind": {
+              "type": "string",
+              "const": "task"
+            }
+          },
+          "required": [
+            "kind",
+            "milestone_id",
+            "task_id"
+          ]
+        }
+      ]
+    },
+    "RoadmapPatchItem": {
+      "description": "Replacement item for a draft-only roadmap item.",
+      "oneOf": [
+        {
+          "description": "Replacement milestone.",
+          "type": "object",
+          "properties": {
+            "milestone": {
+              "description": "Milestone contents.",
+              "$ref": "#/$defs/RoadmapMilestone"
+            },
+            "kind": {
+              "type": "string",
+              "const": "milestone"
+            }
+          },
+          "required": [
+            "kind",
+            "milestone"
+          ]
+        },
+        {
+          "description": "Replacement task.",
+          "type": "object",
+          "properties": {
+            "task": {
+              "description": "Task contents.",
+              "$ref": "#/$defs/RoadmapTask"
+            },
+            "kind": {
+              "type": "string",
+              "const": "task"
+            }
+          },
+          "required": [
+            "kind",
+            "task"
+          ]
+        }
+      ]
+    },
+    "RoadmapPatchDependency": {
+      "description": "Dependency edge introduced by a patch.",
+      "type": "object",
+      "properties": {
+        "from": {
+          "description": "Source item that must complete first.",
+          "$ref": "#/$defs/RoadmapItemRef"
+        },
+        "to": {
+          "description": "Dependent item.",
+          "$ref": "#/$defs/RoadmapItemRef"
+        },
+        "reason": {
+          "description": "Human-readable reason.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "from",
+        "to"
+      ]
+    },
+    "RoadmapPatchConflict": {
+      "description": "Conflict metadata attached to a roadmap patch.",
+      "type": "object",
+      "properties": {
+        "code": {
+          "description": "Stable conflict code.",
+          "$ref": "#/$defs/RoadmapPatchConflictCode"
+        },
+        "item": {
+          "description": "Roadmap item involved in the conflict, when known.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RoadmapItemRef"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "message": {
+          "description": "Operator-facing explanation.",
+          "type": "string"
+        },
+        "choices": {
+          "description": "Available operator choices.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/OperatorConflictChoice"
+          },
+          "default": []
+        },
+        "selected_choice": {
+          "description": "Selected choice, once the operator has resolved the conflict.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/OperatorConflictChoice"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": [
+        "code",
+        "message"
+      ]
+    },
+    "RoadmapPatchConflictCode": {
+      "description": "Stable conflict classes.",
+      "oneOf": [
+        {
+          "description": "Referenced item could not be found.",
+          "type": "string",
+          "const": "missing_target"
+        },
+        {
+          "description": "Patch references an item already running.",
+          "type": "string",
+          "const": "running_milestone"
+        },
+        {
+          "description": "Patch would mutate completed history.",
+          "type": "string",
+          "const": "completed_history"
+        },
+        {
+          "description": "Patch would duplicate an existing item ID.",
+          "type": "string",
+          "const": "duplicate_item"
+        },
+        {
+          "description": "Patch would introduce a dependency cycle.",
+          "type": "string",
+          "const": "dependency_cycle"
+        },
+        {
+          "description": "Operation cannot be represented safely.",
+          "type": "string",
+          "const": "unsupported_operation"
+        }
+      ]
+    },
+    "OperatorConflictChoice": {
+      "description": "Operator choice for resolving an amendment conflict.",
+      "oneOf": [
+        {
+          "description": "Defer the new work to the next safe milestone.",
+          "type": "string",
+          "const": "defer_to_next_milestone"
+        },
+        {
+          "description": "Abort the current run before applying the patch.",
+          "type": "string",
+          "const": "abort_current_run"
+        },
+        {
+          "description": "Create a follow-up run instead of amending the active run.",
+          "type": "string",
+          "const": "create_follow_up_run"
+        },
+        {
+          "description": "Reject the patch.",
+          "type": "string",
+          "const": "reject_patch"
+        }
+      ]
+    },
+    "RoadmapPatchStatus": {
+      "description": "Lifecycle state for a roadmap patch.",
+      "oneOf": [
+        {
+          "description": "Patch has been drafted by Feature Planner.",
+          "type": "string",
+          "const": "drafted"
+        },
+        {
+          "description": "Patch is waiting for operator approval.",
+          "type": "string",
+          "const": "pending_approval"
+        },
+        {
+          "description": "Operator approved the patch.",
+          "type": "string",
+          "const": "approved"
+        },
+        {
+          "description": "Patch was applied to a roadmap or follow-up run.",
+          "type": "string",
+          "const": "applied"
+        },
+        {
+          "description": "Operator rejected the patch.",
+          "type": "string",
+          "const": "rejected"
+        },
+        {
+          "description": "Patch was superseded by a later draft.",
+          "type": "string",
+          "const": "superseded"
+        }
+      ]
+    }
+  },
+  "$id": "https://surge.dev/schema/v1/roadmap-patch.json",
+  "x-surge-schema-version": 1
+}

--- a/crates/surge-core/tests/snapshots/artifact_schema_snapshots__spec_json_schema.snap
+++ b/crates/surge-core/tests/snapshots/artifact_schema_snapshots__spec_json_schema.snap
@@ -21,6 +21,7 @@ expression: schema
     }
   },
   "required": [
+    "schema_version",
     "spec"
   ],
   "$defs": {

--- a/crates/surge-core/tests/snapshots/artifact_schema_snapshots__spec_json_schema.snap
+++ b/crates/surge-core/tests/snapshots/artifact_schema_snapshots__spec_json_schema.snap
@@ -1,0 +1,223 @@
+---
+source: crates/surge-core/tests/artifact_schema_snapshots.rs
+expression: schema
+---
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "SpecArtifact",
+  "description": "Surge `spec.toml` artifact: schema version envelope around the executable spec payload.",
+  "type": "object",
+  "properties": {
+    "schema_version": {
+      "description": "Artifact contract schema version.",
+      "type": "integer",
+      "format": "uint32",
+      "minimum": 0,
+      "default": 1
+    },
+    "spec": {
+      "description": "Executable spec payload.",
+      "$ref": "#/$defs/Spec"
+    }
+  },
+  "required": [
+    "spec"
+  ],
+  "$defs": {
+    "Spec": {
+      "description": "A complete spec describing a unit of work.",
+      "type": "object",
+      "properties": {
+        "id": {
+          "description": "Unique identifier.",
+          "$ref": "#/$defs/SpecId"
+        },
+        "title": {
+          "description": "Short title.",
+          "type": "string"
+        },
+        "description": {
+          "description": "Detailed description.",
+          "type": "string"
+        },
+        "complexity": {
+          "description": "Overall complexity.",
+          "$ref": "#/$defs/Complexity"
+        },
+        "subtasks": {
+          "description": "Ordered list of subtasks.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Subtask"
+          },
+          "default": []
+        }
+      },
+      "required": [
+        "id",
+        "title",
+        "description",
+        "complexity"
+      ]
+    },
+    "SpecId": {
+      "description": "ULID identifier (26-char Crockford base32). Serialized as a bare ULID; the prefixed form `spec-<ulid>` is accepted for FromStr but not produced during JSON serialization.",
+      "type": "string",
+      "pattern": "^[0-9A-HJKMNP-TV-Z]{26}$"
+    },
+    "Complexity": {
+      "description": "Complexity level for a task or subtask.",
+      "type": "string",
+      "enum": [
+        "simple",
+        "standard",
+        "complex"
+      ]
+    },
+    "Subtask": {
+      "description": "A subtask within a spec.",
+      "type": "object",
+      "properties": {
+        "id": {
+          "description": "Unique identifier.",
+          "$ref": "#/$defs/SubtaskId"
+        },
+        "title": {
+          "description": "Short title.",
+          "type": "string"
+        },
+        "description": {
+          "description": "Detailed description of work to do.",
+          "type": "string"
+        },
+        "complexity": {
+          "description": "Estimated complexity.",
+          "$ref": "#/$defs/Complexity"
+        },
+        "files": {
+          "description": "Files this subtask will touch.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": []
+        },
+        "acceptance_criteria": {
+          "description": "Acceptance criteria that must pass.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/AcceptanceCriteria"
+          },
+          "default": []
+        },
+        "depends_on": {
+          "description": "Dependencies on other subtask IDs (must complete first).",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/SubtaskId"
+          },
+          "default": []
+        },
+        "story_file": {
+          "description": "Relative path to the story file (e.g. `stories/story-001.md`).\nWhen set, the agent receives the story file content instead of field-assembled prompt.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "agent": {
+          "description": "Which agent to use for this subtask (overrides routing config).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "execution": {
+          "description": "Execution state and timing. Persisted to spec.toml.",
+          "$ref": "#/$defs/SubtaskExecution",
+          "default": {
+            "state": "pending"
+          }
+        }
+      },
+      "required": [
+        "id",
+        "title",
+        "description",
+        "complexity"
+      ]
+    },
+    "SubtaskId": {
+      "description": "ULID identifier (26-char Crockford base32). Serialized as a bare ULID; the prefixed form `sub-<ulid>` is accepted for FromStr but not produced during JSON serialization.",
+      "type": "string",
+      "pattern": "^[0-9A-HJKMNP-TV-Z]{26}$"
+    },
+    "AcceptanceCriteria": {
+      "description": "Acceptance criteria for a subtask.",
+      "type": "object",
+      "properties": {
+        "description": {
+          "description": "Human-readable description of what must be true.",
+          "type": "string"
+        },
+        "met": {
+          "description": "Whether this criterion is currently met.",
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "required": [
+        "description"
+      ]
+    },
+    "SubtaskExecution": {
+      "description": "Execution metadata for a single subtask, persisted to spec.toml.",
+      "type": "object",
+      "properties": {
+        "state": {
+          "description": "Current execution state.",
+          "$ref": "#/$defs/SubtaskState",
+          "default": "pending"
+        },
+        "started_at": {
+          "description": "When execution started (Unix timestamp ms). None if not yet started.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 0
+        },
+        "finished_at": {
+          "description": "When execution finished (Unix timestamp ms). None if not yet finished.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 0
+        },
+        "error": {
+          "description": "Error message if state is Failed.",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "SubtaskState": {
+      "description": "Execution state of a single subtask.",
+      "type": "string",
+      "enum": [
+        "pending",
+        "running",
+        "completed",
+        "failed",
+        "skipped"
+      ]
+    }
+  },
+  "$id": "https://surge.dev/schema/v1/spec.json",
+  "x-surge-schema-version": 1
+}

--- a/docs/artifact-schemas.md
+++ b/docs/artifact-schemas.md
@@ -1,0 +1,96 @@
+# Artifact JSON Schemas
+
+Surge owns a small set of **artifact contracts** — the on-disk shapes that
+agents (Surge-internal orchestrator, Copilot CLI, Zed Agent, any
+ACP-compatible implementation) exchange. Until now those shapes were
+documented prose-first and re-encoded by hand in every agent prompt profile.
+
+`surge artifact schema` makes the contract **self-describing**: surge-core
+generates a JSON Schema (draft 2020-12) for every TOML-format artifact and
+exposes a small introspection API. Agents and IDEs can consume these schemas
+directly instead of guessing from documentation.
+
+## Quick start
+
+```bash
+# Print the spec.toml schema to stdout
+surge artifact schema spec
+
+# Compact (single-line) JSON
+surge artifact schema spec --format json
+
+# All nine kinds in one JSON object — useful for prompt rendering
+surge artifact schema --all
+
+# Write a schema to disk
+surge artifact schema roadmap --output roadmap.schema.json
+```
+
+For markdown-only kinds (`description`, `requirements`, `story`, `plan`) the
+command exits non-zero with the list of required `## <Section>` headings —
+JSON Schema does not describe free-form markdown bodies, so the required
+sections are surfaced explicitly instead.
+
+## Coverage matrix
+
+| Kind             | Primary format | JSON Schema?                            |
+| ---------------- | -------------- | --------------------------------------- |
+| `description`    | markdown       | no — required sections only             |
+| `requirements`   | markdown       | no — required sections only             |
+| `roadmap`        | TOML           | **yes** (`roadmap.json`)                |
+| `roadmap-patch`  | TOML           | **yes** (`roadmap-patch.json`)          |
+| `spec`           | TOML           | **yes** (`spec.json`)                   |
+| `adr`            | markdown + TOML frontmatter | **yes** (frontmatter only) |
+| `story`          | markdown       | no — required sections only             |
+| `plan`           | markdown       | no — required sections only             |
+| `flow`           | flow-toml      | pending — described by `surge_core::Graph` in Rust |
+
+Each generated schema carries:
+
+- `"$schema": "https://json-schema.org/draft/2020-12/schema"`
+- `"$id": "https://surge.dev/schema/v1/<artifact>.json"`
+- `"x-surge-schema-version": <ARTIFACT_SCHEMA_VERSION>`
+
+`ARTIFACT_SCHEMA_VERSION` is the version baked into `schema_version` for every
+TOML artifact. Bumping this constant is a coordinated, semver-significant
+change.
+
+## How an agent should use it
+
+1. At session start, run `surge artifact schema --all` and stash the result.
+2. When the agent is about to produce a `spec.toml`, render the spec schema
+   into its system prompt as ground truth.
+3. Before writing the file, run the resulting TOML through a local JSON
+   Schema validator (most languages have one). Treat validation errors as a
+   pre-flight check before invoking `surge artifact validate`.
+4. For markdown kinds, include the array of required sections from
+   `markdown_outline()` (also surfaced by `surge artifact schema --all` under
+   `x-surge-no-json-schema` entries) into the prompt.
+
+This keeps prompt profiles aligned with the canonical contract automatically
+— if Surge bumps a schema, every consumer can re-fetch and diff in CI.
+
+## Library API
+
+The same data is available to Rust callers without spawning the CLI:
+
+```rust
+use surge_core::{contract_summary, json_schema_for, ArtifactKind};
+
+let schema = json_schema_for(ArtifactKind::Spec).unwrap();
+let summary = contract_summary(ArtifactKind::Plan);
+assert!(summary.json_schema.is_none());
+assert_eq!(summary.required_markdown_sections, Some(&["Settings", "Tasks"][..]));
+```
+
+See `crates/surge-core/src/artifact_contract.rs` for the full surface.
+
+## Why no schema for `flow.toml` yet
+
+`flow.toml` deserializes into `surge_core::Graph`, which transitively pulls
+in the full node, edge, and per-archetype configuration tree. Exporting that
+schema requires adding `JsonSchema` derives across roughly two dozen
+graph-domain types — a larger surface than the rest of the artifact set
+combined. Until that lands, the flow contract continues to be enforced by
+`validate_artifact(ArtifactKind::Flow, …)` plus engine-level graph
+validation, and the schema export returns an explanatory error.


### PR DESCRIPTION
## Summary

Make Surge's artifact contracts self-describing so external agents — Copilot CLI, Zed Agent, any ACP-compatible implementation — can consume the canonical shape directly instead of re-encoding it by hand in prompt profiles.

- New CLI: `surge artifact schema <kind> [--all] [--format pretty|json] [--output <path>]` emits JSON Schema (draft 2020-12) for every TOML artifact (spec, roadmap, roadmap-patch) plus the ADR TOML frontmatter. Markdown-only kinds exit with an explanatory error listing required `## <Section>` headings.
- New library API in `surge_core::artifact_contract`: `json_schema_for`, `markdown_outline`, `contract_summary` + the new `ContractSummary` struct. Schemas carry stable `\$id` (`https://surge.dev/schema/v1/<artifact>.json`) and `x-surge-schema-version` for change tracking.

## What changed

- Workspace: add `schemars = \"1\"` (features `preserve_order`, `chrono04`).
- `#[derive(JsonSchema)]` on every TOML-format artifact type: `SpecArtifact`, `Spec`, `Subtask`, `AcceptanceCriteria`, `Complexity`, `SubtaskExecution`, `SubtaskState`, `RoadmapArtifact`, `RoadmapMilestone`/`Task`/`Dependency`/`Risk`/`Status`, plus the full `RoadmapPatch` enum tree (`RoadmapPatchOperation`, `RoadmapPatchItem`, `InsertionPoint`, `RoadmapItemRef`, conflict/dependency/status enums).
- Hand-written `JsonSchema` impls for custom-serde newtypes so the schema describes them accurately as constrained strings: `SpecId`/`SubtaskId`/`RunId`/`SessionId`/`TaskId` (id.rs), `NodeKey`/`EdgeKey`/`OutcomeKey`/`SubgraphKey`/`ProfileKey`/`TemplateKey` (keys.rs), `ContentHash`, `RoadmapPatchId`.
- Snapshot tests (insta JSON) for spec, roadmap, roadmap-patch, and the ADR frontmatter schema — any breaking change to the contract now surfaces as a reviewable diff.
- CLI smoke tests cover the happy path (`schema spec` produces valid JSON with expected keys), `--all` (one object keyed by kind), and the markdown-only failure mode (`schema plan` exits non-zero listing `## Settings`/`## Tasks`).
- Docs: `docs/artifact-schemas.md` (quick-start, coverage matrix, agent integration guide) and a CHANGELOG `[Unreleased]` entry.

## Why

External agents currently learn the artifact shape from prose-first prompt profiles that have to be re-encoded by hand. If a contract evolves, every profile drifts silently. This PR makes the contract the single source of truth: anyone — IDE plugins (red-squiggle on invalid `spec.toml`), CI validators, prompt renderers — can fetch the schema directly. Per the project's artifact-contract principle, Surge owns the on-disk shape and now publishes it in a machine-readable form.

## Scope note: `flow.toml` deferred

`flow.toml` deserializes into `surge_core::Graph`, which transitively pulls in roughly two dozen graph-domain types (`AgentConfig`, `HumanGateConfig`, `LoopConfig`, `BranchConfig`, `NotifyConfig`, `TerminalConfig`, `SubgraphConfig`, and the rest of the node/edge config tree). Deriving `JsonSchema` across that surface is larger than the rest of the artifact set combined and is tracked separately. The CLI returns an explanatory pending message for `flow`; flow validation continues to flow through `validate_artifact(ArtifactKind::Flow, …)` + engine-level graph validation. This is a deliberate decide-or-defer call — no half-implemented flow schema.

## Test plan

- [x] \`cargo build --workspace\` succeeds.
- [x] \`cargo test -p surge-core\` — full suite passes (~420 tests), including 8 new tests in \`artifact_schema_snapshots.rs\`.
- [x] \`cargo test -p surge-cli --test cli_artifact_schema\` — 3 new smoke tests pass.
- [x] \`cargo clippy --workspace -- -D warnings\` is clean.
- [x] \`cargo run -p surge-cli -- artifact schema spec\` emits a valid draft-2020-12 schema with the expected \`\$id\` / \`x-surge-schema-version\` fields.
- [x] \`cargo run -p surge-cli -- artifact schema --all | python -m json.tool\` parses (valid JSON, all 9 kinds present).
- [x] \`surge artifact schema plan\` exits non-zero and prints the required markdown sections.
- [x] On-disk artifact serialization is unchanged (existing roundtrip tests in spec.rs / roadmap.rs / roadmap_patch.rs continue to pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)