### PR TITLE
feat: production-wire Telegram cockpit (polling, commands, replies)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1128,7 +1128,7 @@ dependencies = [
  "cocoa-foundation 0.1.2",
  "core-foundation 0.9.4",
  "core-graphics 0.23.2",
- "foreign-types",
+ "foreign-types 0.5.0",
  "libc",
  "objc",
 ]
@@ -1144,7 +1144,7 @@ dependencies = [
  "cocoa-foundation 0.2.0",
  "core-foundation 0.10.0",
  "core-graphics 0.24.0",
- "foreign-types",
+ "foreign-types 0.5.0",
  "libc",
  "objc",
 ]
@@ -1318,7 +1318,7 @@ dependencies = [
  "bitflags 1.3.2",
  "core-foundation 0.9.4",
  "core-graphics-types 0.1.3",
- "foreign-types",
+ "foreign-types 0.5.0",
  "libc",
 ]
 
@@ -1331,7 +1331,7 @@ dependencies = [
  "bitflags 2.11.0",
  "core-foundation 0.10.0",
  "core-graphics-types 0.2.0",
- "foreign-types",
+ "foreign-types 0.5.0",
  "libc",
 ]
 
@@ -1344,7 +1344,7 @@ dependencies = [
  "bitflags 2.11.0",
  "core-foundation 0.9.4",
  "core-graphics-types 0.1.3",
- "foreign-types",
+ "foreign-types 0.5.0",
  "libc",
 ]
 
@@ -1391,7 +1391,7 @@ checksum = "a593227b66cbd4007b2a050dfdd9e1d1318311409c8d600dc82ba1b15ca9c130"
 dependencies = [
  "core-foundation 0.10.0",
  "core-graphics 0.24.0",
- "foreign-types",
+ "foreign-types 0.5.0",
  "libc",
 ]
 
@@ -2394,12 +2394,21 @@ dependencies = [
 
 [[package]]
 name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared 0.1.1",
+]
+
+[[package]]
+name = "foreign-types"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
 dependencies = [
  "foreign-types-macros",
- "foreign-types-shared",
+ "foreign-types-shared 0.3.1",
 ]
 
 [[package]]
@@ -2412,6 +2421,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "foreign-types-shared"
@@ -2786,7 +2801,7 @@ dependencies = [
  "etagere",
  "filedescriptor",
  "flume",
- "foreign-types",
+ "foreign-types 0.5.0",
  "futures",
  "gpui-macros",
  "gpui_collections",
@@ -2981,7 +2996,7 @@ dependencies = [
  "core-foundation 0.10.0",
  "core-video",
  "ctor",
- "foreign-types",
+ "foreign-types 0.5.0",
  "metal",
  "objc",
 ]
@@ -3393,20 +3408,6 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
-dependencies = [
- "futures-util",
- "http 0.2.12",
- "hyper 0.14.32",
- "rustls 0.21.12",
- "tokio",
- "tokio-rustls 0.24.1",
-]
-
-[[package]]
-name = "hyper-rustls"
 version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
@@ -3415,13 +3416,13 @@ dependencies = [
  "hyper 1.8.1",
  "hyper-util",
  "log",
- "rustls 0.23.37",
+ "rustls",
  "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tower-service",
- "webpki-roots 1.0.6",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -3435,6 +3436,19 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tower-service",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes",
+ "hyper 0.14.32",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
 ]
 
 [[package]]
@@ -4032,12 +4046,12 @@ dependencies = [
  "nom 8.0.0",
  "percent-encoding",
  "quoted_printable",
- "rustls 0.23.37",
+ "rustls",
  "socket2 0.6.3",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "url",
- "webpki-roots 1.0.6",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -4403,7 +4417,7 @@ dependencies = [
  "bitflags 2.11.0",
  "block",
  "core-graphics-types 0.1.3",
- "foreign-types",
+ "foreign-types 0.5.0",
  "log",
  "objc",
  "paste",
@@ -4501,6 +4515,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe 0.2.1",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
 ]
 
 [[package]]
@@ -4935,7 +4966,7 @@ dependencies = [
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.8.1",
- "hyper-rustls 0.27.7",
+ "hyper-rustls",
  "hyper-timeout",
  "hyper-util",
  "jsonwebtoken",
@@ -5018,6 +5049,32 @@ dependencies = [
  "is-wsl",
  "libc",
  "pathdiff",
+]
+
+[[package]]
+name = "openssl"
+version = "0.10.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "951c002c75e16ea2c65b8c7e4d3d51d5530d8dfa7d060b4776828c88cfb18ecf"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if",
+ "foreign-types 0.3.2",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5682,7 +5739,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash 2.1.1",
- "rustls 0.23.37",
+ "rustls",
  "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
@@ -5702,7 +5759,7 @@ dependencies = [
  "rand 0.9.2",
  "ring",
  "rustc-hash 2.1.1",
- "rustls 0.23.37",
+ "rustls",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.18",
@@ -6091,16 +6148,16 @@ dependencies = [
  "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.32",
- "hyper-rustls 0.24.2",
+ "hyper-tls",
  "ipnet",
  "js-sys",
  "log",
  "mime",
  "mime_guess",
+ "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls 0.21.12",
  "rustls-pemfile 1.0.4",
  "serde",
  "serde_json",
@@ -6108,7 +6165,7 @@ dependencies = [
  "sync_wrapper 0.1.2",
  "system-configuration 0.5.1",
  "tokio",
- "tokio-rustls 0.24.1",
+ "tokio-native-tls",
  "tokio-util",
  "tower-service",
  "url",
@@ -6116,7 +6173,6 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots 0.25.4",
  "winreg 0.50.0",
 ]
 
@@ -6133,21 +6189,21 @@ dependencies = [
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.8.1",
- "hyper-rustls 0.27.7",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.37",
+ "rustls",
  "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper 1.0.2",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tower",
  "tower-http",
  "tower-service",
@@ -6155,7 +6211,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots 1.0.6",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -6401,18 +6457,6 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
-dependencies = [
- "log",
- "ring",
- "rustls-webpki 0.101.7",
- "sct",
-]
-
-[[package]]
-name = "rustls"
 version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
@@ -6421,7 +6465,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.13",
+ "rustls-webpki",
  "subtle",
  "zeroize",
 ]
@@ -6464,16 +6508,6 @@ checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
  "web-time",
  "zeroize",
-]
-
-[[package]]
-name = "rustls-webpki"
-version = "0.101.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
-dependencies = [
- "ring",
- "untrusted",
 ]
 
 [[package]]
@@ -6633,16 +6667,6 @@ dependencies = [
  "objc-foundation",
  "objc_id",
  "once_cell",
-]
-
-[[package]]
-name = "sct"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
-dependencies = [
- "ring",
- "untrusted",
 ]
 
 [[package]]
@@ -8182,12 +8206,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-rustls"
-version = "0.24.1"
+name = "tokio-native-tls"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
 dependencies = [
- "rustls 0.21.12",
+ "native-tls",
  "tokio",
 ]
 
@@ -8197,7 +8221,7 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls 0.23.37",
+ "rustls",
  "tokio",
 ]
 
@@ -9115,12 +9139,6 @@ dependencies = [
  "serde",
  "wasm-bindgen",
 ]
-
-[[package]]
-name = "webpki-roots"
-version = "0.25.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "webpki-roots"
@@ -10244,7 +10262,7 @@ dependencies = [
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.8.1",
- "hyper-rustls 0.27.7",
+ "hyper-rustls",
  "hyper-util",
  "ipnet",
  "js-sys",
@@ -10255,7 +10273,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.37",
+ "rustls",
  "rustls-native-certs",
  "rustls-pemfile 2.2.0",
  "rustls-pki-types",
@@ -10265,7 +10283,7 @@ dependencies = [
  "sync_wrapper 1.0.2",
  "system-configuration 0.6.1",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tokio-socks",
  "tokio-util",
  "tower",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3393,6 +3393,20 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
+dependencies = [
+ "futures-util",
+ "http 0.2.12",
+ "hyper 0.14.32",
+ "rustls 0.21.12",
+ "tokio",
+ "tokio-rustls 0.24.1",
+]
+
+[[package]]
+name = "hyper-rustls"
 version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
@@ -3401,13 +3415,13 @@ dependencies = [
  "hyper 1.8.1",
  "hyper-util",
  "log",
- "rustls",
+ "rustls 0.23.37",
  "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.4",
  "tower-service",
- "webpki-roots",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -4018,12 +4032,12 @@ dependencies = [
  "nom 8.0.0",
  "percent-encoding",
  "quoted_printable",
- "rustls",
+ "rustls 0.23.37",
  "socket2 0.6.3",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.4",
  "url",
- "webpki-roots",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -4921,7 +4935,7 @@ dependencies = [
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.8.1",
- "hyper-rustls",
+ "hyper-rustls 0.27.7",
  "hyper-timeout",
  "hyper-util",
  "jsonwebtoken",
@@ -5668,7 +5682,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash 2.1.1",
- "rustls",
+ "rustls 0.23.37",
  "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
@@ -5688,7 +5702,7 @@ dependencies = [
  "rand 0.9.2",
  "ring",
  "rustc-hash 2.1.1",
- "rustls",
+ "rustls 0.23.37",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.18",
@@ -6077,6 +6091,7 @@ dependencies = [
  "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.32",
+ "hyper-rustls 0.24.2",
  "ipnet",
  "js-sys",
  "log",
@@ -6085,12 +6100,15 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
+ "rustls 0.21.12",
+ "rustls-pemfile 1.0.4",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper 0.1.2",
  "system-configuration 0.5.1",
  "tokio",
+ "tokio-rustls 0.24.1",
  "tokio-util",
  "tower-service",
  "url",
@@ -6098,6 +6116,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
+ "webpki-roots 0.25.4",
  "winreg 0.50.0",
 ]
 
@@ -6114,21 +6133,21 @@ dependencies = [
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.8.1",
- "hyper-rustls",
+ "hyper-rustls 0.27.7",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls",
+ "rustls 0.23.37",
  "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper 1.0.2",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.4",
  "tower",
  "tower-http",
  "tower-service",
@@ -6136,7 +6155,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -6382,6 +6401,18 @@ dependencies = [
 
 [[package]]
 name = "rustls"
+version = "0.21.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-webpki 0.101.7",
+ "sct",
+]
+
+[[package]]
+name = "rustls"
 version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
@@ -6390,7 +6421,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki",
+ "rustls-webpki 0.103.13",
  "subtle",
  "zeroize",
 ]
@@ -6405,6 +6436,15 @@ dependencies = [
  "rustls-pki-types",
  "schannel",
  "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
+dependencies = [
+ "base64 0.21.7",
 ]
 
 [[package]]
@@ -6424,6 +6464,16 @@ checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
  "web-time",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.101.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+dependencies = [
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
@@ -6583,6 +6633,16 @@ dependencies = [
  "objc-foundation",
  "objc_id",
  "once_cell",
+]
+
+[[package]]
+name = "sct"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
+dependencies = [
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
@@ -7321,6 +7381,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-stream",
  "tokio-util",
  "toml 0.8.23",
  "tracing",
@@ -8122,11 +8183,21 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+dependencies = [
+ "rustls 0.21.12",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls",
+ "rustls 0.23.37",
  "tokio",
 ]
 
@@ -9044,6 +9115,12 @@ dependencies = [
  "serde",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "webpki-roots"
+version = "0.25.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "webpki-roots"
@@ -10167,7 +10244,7 @@ dependencies = [
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.8.1",
- "hyper-rustls",
+ "hyper-rustls 0.27.7",
  "hyper-util",
  "ipnet",
  "js-sys",
@@ -10178,9 +10255,9 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls",
+ "rustls 0.23.37",
  "rustls-native-certs",
- "rustls-pemfile",
+ "rustls-pemfile 2.2.0",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -10188,7 +10265,7 @@ dependencies = [
  "sync_wrapper 1.0.2",
  "system-configuration 0.6.1",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.4",
  "tokio-socks",
  "tokio-util",
  "tower",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,7 +105,7 @@ lineark-sdk = "3"
 octocrab = "0.42"
 
 # Telegram bot framework (surge-daemon inbox, surge-telegram cockpit)
-teloxide = { version = "0.13", default-features = false, features = ["macros", "ctrlc_handler"] }
+teloxide = { version = "0.13", default-features = false, features = ["macros", "ctrlc_handler", "rustls"] }
 
 # Notification channels (surge-notify)
 notify-rust = "4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,7 +105,7 @@ lineark-sdk = "3"
 octocrab = "0.42"
 
 # Telegram bot framework (surge-daemon inbox, surge-telegram cockpit)
-teloxide = { version = "0.13", default-features = false, features = ["macros", "ctrlc_handler", "rustls"] }
+teloxide = { version = "0.13", default-features = false, features = ["macros", "ctrlc_handler", "native-tls"] }
 
 # Notification channels (surge-notify)
 notify-rust = "4"

--- a/crates/surge-daemon/Cargo.toml
+++ b/crates/surge-daemon/Cargo.toml
@@ -43,6 +43,7 @@ teloxide.workspace = true
 reqwest.workspace = true
 ulid.workspace = true
 futures = "0.3"
+tokio-stream = { workspace = true }
 
 # Unix signal handling
 [target.'cfg(unix)'.dependencies]

--- a/crates/surge-daemon/src/inbox/tg_bot.rs
+++ b/crates/surge-daemon/src/inbox/tg_bot.rs
@@ -32,6 +32,15 @@ impl TgInboxBot {
     }
 
     /// Drive both legs (outgoing + incoming) until cancellation.
+    ///
+    /// **Deprecated for cockpit deployments**: spawning a teloxide
+    /// `Dispatcher` here issues its own `getUpdates` call against the
+    /// same bot token the cockpit polls, which Telegram rejects with
+    /// `Conflict: terminated by other getUpdates request`. Callers that
+    /// also run the cockpit must use [`Self::run_outgoing_only`] and
+    /// route inbox `inbox:*` callbacks through the cockpit's shared
+    /// update stream instead. This method stays for callers that run
+    /// inbox **without** the cockpit (legacy single-bot deployments).
     pub async fn run(self, shutdown: CancellationToken) {
         let outgoing = {
             let bot = self.bot.clone();
@@ -50,6 +59,31 @@ impl TgInboxBot {
             }
             _ = outgoing => {}
             _ = incoming => {}
+        }
+    }
+
+    /// Drive only the outgoing delivery loop. Skips the teloxide
+    /// `Dispatcher`-based incoming callback loop so it can coexist with
+    /// the cockpit's polling listener on the same bot token (running
+    /// both produces a `getUpdates` conflict on Telegram's side).
+    ///
+    /// Inbox `inbox:*` callbacks are intended to land in the cockpit's
+    /// shared update router as a follow-up; until that lands, callbacks
+    /// from inbox cards stay unprocessed under this path. The outgoing
+    /// delivery (sending tracker inbox cards to Telegram) is unaffected.
+    pub async fn run_outgoing_only(self, shutdown: CancellationToken) {
+        let outgoing_shutdown = shutdown.clone();
+        let outgoing = tokio::spawn(outgoing_loop(
+            self.bot,
+            self.chat_id,
+            self.storage,
+            outgoing_shutdown,
+        ));
+        tokio::select! {
+            () = shutdown.cancelled() => {
+                info!("TgInboxBot: shutdown signalled (outgoing-only)");
+            }
+            _ = outgoing => {}
         }
     }
 }

--- a/crates/surge-daemon/src/main.rs
+++ b/crates/surge-daemon/src/main.rs
@@ -1569,8 +1569,9 @@ fn spawn_telegram_cockpit(
         }
     });
 
-    let updates: Box<dyn futures::Stream<Item = teloxide::types::Update> + Send + Unpin> =
-        Box::new(tokio_stream::wrappers::UnboundedReceiverStream::new(update_rx));
+    let updates: Box<dyn futures::Stream<Item = teloxide::types::Update> + Send + Unpin> = Box::new(
+        tokio_stream::wrappers::UnboundedReceiverStream::new(update_rx),
+    );
     tracing::info!(
         target: "daemon::cockpit",
         "live polling listener active"

--- a/crates/surge-daemon/src/main.rs
+++ b/crates/surge-daemon/src/main.rs
@@ -1393,11 +1393,29 @@ async fn spawn_inbox_subsystems(
         });
         match (chat_id, token) {
             (Some(chat_id), Some(token)) => {
-                let bot = teloxide::Bot::new(token.clone());
-                let tg =
-                    TgInboxBot::new(bot, teloxide::types::ChatId(chat_id), Arc::clone(&storage));
+                // Two subsystems share the bot:
+                //  1. `TgInboxBot` — tracker-inbox card delivery. Its
+                //     outgoing loop posts pending inbox cards every
+                //     500ms; the legacy incoming loop runs its own
+                //     `getUpdates` via teloxide's `Dispatcher`.
+                //  2. The cockpit (`spawn_telegram_cockpit`) — its
+                //     polling adapter also calls `getUpdates`.
+                //
+                // Telegram rejects two concurrent `getUpdates` requests
+                // with `Conflict: terminated by other getUpdates`. We
+                // therefore run TgInboxBot in outgoing-only mode so it
+                // keeps delivering inbox cards while the cockpit owns
+                // the single bot poll. Inbox `inbox:*` callbacks will
+                // be routed through the cockpit's shared update stream
+                // in a follow-up.
+                let bot_for_inbox = teloxide::Bot::new(token.clone());
+                let tg = TgInboxBot::new(
+                    bot_for_inbox,
+                    teloxide::types::ChatId(chat_id),
+                    Arc::clone(&storage),
+                );
                 let shutdown_for_tg = shutdown.clone();
-                tokio::spawn(tg.run(shutdown_for_tg));
+                tokio::spawn(tg.run_outgoing_only(shutdown_for_tg));
 
                 spawn_telegram_cockpit(
                     &token,
@@ -1469,22 +1487,93 @@ fn spawn_telegram_cockpit(
 ) {
     let bot = teloxide::Bot::new(token.to_owned());
 
-    // Production update stream is deferred — the live
-    // `teloxide::update_listeners::polling_default` wiring (which
-    // requires adapting the `UpdateListener` into a
-    // `Stream<Item = Update>`) lands in a follow-up. For now the
-    // cockpit runs with the engine-tap loop active and the callback
-    // path dormant; the snooze rescheduler still drives via its
-    // direct interval ticker. The cockpit's `dispatch_ctx` correctly
-    // sends cards into Telegram on every tap event, so operators
-    // already see card emission; only inline-button callbacks need
-    // the production update stream.
-    use futures::StreamExt as _;
+    // Live long-poll listener. Teloxide's Polling exposes its update
+    // stream via `AsUpdateStream::as_stream(&'a mut self)` — the stream is
+    // borrowed from `&mut Polling` (GAT workaround), so we cannot hand it
+    // back as a `'static Stream` directly. Bridge via an mpsc channel: a
+    // dedicated task owns the `Polling` value and forwards each update
+    // into the channel; the cockpit consumes the receiver side as a
+    // `Stream<Item = Update>`.
+    let (update_tx, update_rx) = tokio::sync::mpsc::unbounded_channel::<teloxide::types::Update>();
+    let bot_for_polling = bot.clone();
+    let shutdown_for_polling = shutdown.clone();
+    tokio::spawn(async move {
+        use futures::StreamExt as _;
+        use std::time::Duration;
+        use teloxide::types::AllowedUpdate;
+        use teloxide::update_listeners::{AsUpdateStream, Polling};
+        // Explicit `allowed_updates` is required: previous `TgInboxBot`
+        // sessions register `[callback_query]` server-side via teloxide's
+        // `Dispatcher`, and `polling_default` does not override it.
+        // Without this list, Telegram silently drops every text message
+        // — including `/pair`, `/status`, `/runs`, etc.
+        let mut listener = Polling::builder(bot_for_polling)
+            .timeout(Duration::from_secs(10))
+            .allowed_updates(vec![
+                AllowedUpdate::Message,
+                AllowedUpdate::EditedMessage,
+                AllowedUpdate::CallbackQuery,
+                AllowedUpdate::ChannelPost,
+                AllowedUpdate::EditedChannelPost,
+            ])
+            .delete_webhook()
+            .await
+            .build();
+        tracing::debug!(
+            target: "daemon::cockpit",
+            "polling listener built, entering stream loop"
+        );
+        let stream = listener.as_stream();
+        tokio::pin!(stream);
+        loop {
+            tokio::select! {
+                biased;
+                () = shutdown_for_polling.cancelled() => {
+                    tracing::info!(
+                        target: "daemon::cockpit",
+                        "polling listener shutting down"
+                    );
+                    break;
+                }
+                next = stream.next() => match next {
+                    Some(Ok(update)) => {
+                        tracing::debug!(
+                            target: "daemon::cockpit",
+                            update_id = update.id.0,
+                            "polling bridge: forwarding update"
+                        );
+                        if update_tx.send(update).is_err() {
+                            tracing::warn!(
+                                target: "daemon::cockpit",
+                                "polling bridge: receiver dropped, exiting"
+                            );
+                            break;
+                        }
+                    }
+                    Some(Err(e)) => {
+                        tracing::warn!(
+                            target: "daemon::cockpit",
+                            error = %e,
+                            "polling error; teloxide backoff will retry"
+                        );
+                    }
+                    None => {
+                        tracing::info!(
+                            target: "daemon::cockpit",
+                            "polling listener stream exhausted"
+                        );
+                        break;
+                    }
+                }
+            }
+        }
+    });
+
     let updates: Box<dyn futures::Stream<Item = teloxide::types::Update> + Send + Unpin> =
-        Box::new(futures::stream::empty().boxed());
-    tracing::warn!(
+        Box::new(tokio_stream::wrappers::UnboundedReceiverStream::new(update_rx));
+    tracing::info!(
         target: "daemon::cockpit",
-        "live polling listener deferred — engine-tap emission active, callbacks dormant"
+        "live polling listener active"
     );
 
     let wiring = surge_telegram::cockpit::production::CockpitWiring {

--- a/crates/surge-telegram/src/cockpit/dispatch.rs
+++ b/crates/surge-telegram/src/cockpit/dispatch.rs
@@ -87,7 +87,10 @@ where
         return Ok(DispatchOutcome::Ignored { event_kind });
     };
 
-    let rendered = render_for_action(&run_id_str, &action);
+    // First render with a placeholder card_id — its content_hash drives the
+    // INSERT OR IGNORE in `upsert`. The real card_id only exists after the
+    // upsert returns (it is generated server-side as a ULID).
+    let pre_rendered = render_for_action("00000000000000000000000000", &tap.run_id, &action);
 
     let card_id = ctx
         .emitter
@@ -96,12 +99,19 @@ where
             &run_id_str,
             action.node_key,
             action.attempt_index,
-            rendered.kind.as_str(),
+            pre_rendered.kind.as_str(),
             ctx.admin_chat_id,
-            &rendered.content_hash,
+            &pre_rendered.content_hash,
             now_ms,
         )
         .await?;
+
+    // Second render with the real card_id — this is what actually gets
+    // sent to Telegram, so the inline-keyboard callback_data carries the
+    // correct `cockpit:<verb>:<card_id>` payload. The `emit` path
+    // recognises the content_hash change and switches to `editMessageText`
+    // when a message_id is already known, or `sendMessage` for a fresh row.
+    let rendered = render_for_action(&card_id, &tap.run_id, &action);
 
     let emit = ctx.emitter.emit(&card_id, &rendered, now_ms).await?;
     let kind = rendered.kind;
@@ -231,29 +241,19 @@ fn decide_action(tap: &RunEventTap) -> Option<CardAction> {
 /// because the renderer bakes the id into `callback_data`; the cockpit
 /// upserts to learn the real id and renders again, which is acceptable for
 /// MVP — the content_hash will end up reflecting the real id either way.
-fn render_for_action(_run_id: &str, action: &CardAction) -> RenderedCard {
-    let placeholder_card_id = "00000000000000000000000000";
+fn render_for_action(
+    card_id: &str,
+    run_id: &surge_core::id::RunId,
+    action: &CardAction,
+) -> RenderedCard {
     match &action.payload {
-        ActionPayload::HumanGate { prompt } => render_human_gate(placeholder_card_id, prompt),
-        ActionPayload::Bootstrap { stage, summary } => {
-            render_bootstrap(placeholder_card_id, *stage, summary)
-        },
+        ActionPayload::HumanGate { prompt } => render_human_gate(card_id, prompt),
+        ActionPayload::Bootstrap { stage, summary } => render_bootstrap(card_id, *stage, summary),
         ActionPayload::Completion { terminal_node } => {
-            // RunId is not directly available in the renderer signature, so
-            // we use a synthetic placeholder for the body text — the
-            // production wiring threads the real RunId through.
-            render_completion(
-                placeholder_card_id,
-                &surge_core::id::RunId::nil(),
-                terminal_node,
-            )
+            render_completion(card_id, run_id, terminal_node)
         },
-        ActionPayload::Failure { error } => {
-            render_failure(placeholder_card_id, &surge_core::id::RunId::nil(), error)
-        },
-        ActionPayload::Escalation { stage, reason } => {
-            render_escalation(placeholder_card_id, *stage, reason)
-        },
+        ActionPayload::Failure { error } => render_failure(card_id, run_id, error),
+        ActionPayload::Escalation { stage, reason } => render_escalation(card_id, *stage, reason),
     }
 }
 

--- a/crates/surge-telegram/src/cockpit/production.rs
+++ b/crates/surge-telegram/src/cockpit/production.rs
@@ -458,11 +458,9 @@ impl crate::commands::CockpitSnoozeWriter for PersistenceCockpitSnoozeWriter {
             .map_err(|e| TelegramCockpitError::Persistence(e.to_string()))?;
         let wake_at = chrono::DateTime::<chrono::Utc>::from_timestamp_millis(wake_at_ms)
             .unwrap_or_else(chrono::Utc::now);
-        surge_persistence::inbox_queue::append_cockpit_snooze(
-            &conn, card_id, "telegram", wake_at,
-        )
-        .map(|_| ())
-        .map_err(|e| TelegramCockpitError::Persistence(e.to_string()))
+        surge_persistence::inbox_queue::append_cockpit_snooze(&conn, card_id, "telegram", wake_at)
+            .map(|_| ())
+            .map_err(|e| TelegramCockpitError::Persistence(e.to_string()))
     }
 }
 

--- a/crates/surge-telegram/src/cockpit/production.rs
+++ b/crates/surge-telegram/src/cockpit/production.rs
@@ -157,7 +157,6 @@ impl TelegramApi for TeloxideTelegramApi {
         let msg = self
             .bot
             .send_message(teloxide::types::ChatId(chat_id), body_md)
-            .parse_mode(teloxide::types::ParseMode::MarkdownV2)
             .reply_markup(markup)
             .await?;
         Ok(i64::from(msg.id.0))
@@ -180,7 +179,6 @@ impl TelegramApi for TeloxideTelegramApi {
                 teloxide::types::MessageId(message_id_i32),
                 body_md,
             )
-            .parse_mode(teloxide::types::ParseMode::MarkdownV2)
             .reply_markup(markup)
             .await?;
         Ok(())
@@ -332,6 +330,142 @@ impl Admission for PairingsAdmission {
     }
 }
 
+/// `PairingTokenConsumer` backed by `surge_persistence::telegram::pairing`.
+#[derive(Clone)]
+pub struct PersistencePairingConsumer {
+    /// Shared storage handle.
+    pub storage: Arc<Storage>,
+}
+
+#[async_trait]
+impl crate::commands::PairingTokenConsumer for PersistencePairingConsumer {
+    async fn consume(&self, token: &str, now_ms: i64) -> Result<String> {
+        use surge_persistence::telegram::pairing::{PairingError, consume_pairing_token};
+        let conn = self
+            .storage
+            .acquire_registry_conn()
+            .map_err(|e| TelegramCockpitError::Persistence(e.to_string()))?;
+        match consume_pairing_token(&conn, token, now_ms) {
+            Ok(label) => Ok(label),
+            Err(PairingError::NotFound) => Err(TelegramCockpitError::PairingTokenInvalid),
+            Err(PairingError::Expired) | Err(PairingError::AlreadyConsumed) => {
+                Err(TelegramCockpitError::PairingTokenExpired)
+            },
+            Err(other) => Err(TelegramCockpitError::Persistence(other.to_string())),
+        }
+    }
+}
+
+/// `PairingWriter` backed by `surge_persistence::telegram::pairings::pair`.
+#[derive(Clone)]
+pub struct PersistencePairingWriter {
+    /// Shared storage handle.
+    pub storage: Arc<Storage>,
+}
+
+#[async_trait]
+impl crate::commands::PairingWriter for PersistencePairingWriter {
+    async fn pair(&self, chat_id: i64, user_label: &str, now_ms: i64) -> Result<()> {
+        let conn = self
+            .storage
+            .acquire_registry_conn()
+            .map_err(|e| TelegramCockpitError::Persistence(e.to_string()))?;
+        surge_persistence::telegram::pairings::pair(&conn, chat_id, user_label, now_ms)
+            .map_err(|e| TelegramCockpitError::Persistence(e.to_string()))
+    }
+}
+
+/// `RunListProvider` backed by `surge_persistence::runs::registry::list_runs`.
+#[derive(Clone)]
+pub struct PersistenceRunList {
+    /// Shared storage handle.
+    pub storage: Arc<Storage>,
+}
+
+#[async_trait]
+impl crate::commands::RunListProvider for PersistenceRunList {
+    async fn list_recent(&self, limit: u32) -> Result<Vec<crate::commands::RunRow>> {
+        let filter = surge_persistence::runs::registry::RunFilter {
+            limit: Some(limit as usize),
+            ..Default::default()
+        };
+        let summaries = self
+            .storage
+            .list_runs(filter)
+            .await
+            .map_err(|e| TelegramCockpitError::Persistence(e.to_string()))?;
+        Ok(summaries
+            .into_iter()
+            .map(|s| crate::commands::RunRow {
+                run_id: s.id.to_string(),
+                status: format!("{:?}", s.status),
+                started_at_ms: s.started_at_ms,
+            })
+            .collect())
+    }
+}
+
+/// `RunAborter` backed by `EngineFacade::stop_run`.
+#[derive(Clone)]
+pub struct EngineFacadeAborter {
+    /// Engine facade.
+    pub engine: Arc<dyn EngineFacade>,
+}
+
+#[async_trait]
+impl crate::commands::RunAborter for EngineFacadeAborter {
+    async fn abort_run(&self, run_id: &str, reason: &str) -> Result<()> {
+        let parsed = run_id
+            .parse::<RunId>()
+            .map_err(|e| TelegramCockpitError::Persistence(format!("invalid run_id: {e}")))?;
+        self.engine
+            .stop_run(parsed, reason.to_owned())
+            .await
+            .map_err(TelegramCockpitError::EngineResolve)
+    }
+}
+
+/// `RunStarter` stub — full archetype resolution + start_run wiring is
+/// tracked in a follow-up that requires plumbing `ArchetypeRegistry`
+/// through `CockpitWiring`. For now this surfaces a recoverable
+/// "deferred" reply so operators see the gap explicitly.
+#[derive(Clone)]
+pub struct DeferredRunStarter;
+
+#[async_trait]
+impl crate::commands::RunStarter for DeferredRunStarter {
+    async fn start_run(&self, _archetype_or_path: &str) -> Result<String> {
+        Err(TelegramCockpitError::Persistence(
+            "/run via Telegram is not yet wired — use `surge engine run` from the CLI for now"
+                .into(),
+        ))
+    }
+}
+
+/// `CockpitSnoozeWriter` backed by `inbox_queue::append_cockpit_snooze`.
+#[derive(Clone)]
+pub struct PersistenceCockpitSnoozeWriter {
+    /// Shared storage handle.
+    pub storage: Arc<Storage>,
+}
+
+#[async_trait]
+impl crate::commands::CockpitSnoozeWriter for PersistenceCockpitSnoozeWriter {
+    async fn snooze(&self, card_id: &str, wake_at_ms: i64) -> Result<()> {
+        let conn = self
+            .storage
+            .acquire_registry_conn()
+            .map_err(|e| TelegramCockpitError::Persistence(e.to_string()))?;
+        let wake_at = chrono::DateTime::<chrono::Utc>::from_timestamp_millis(wake_at_ms)
+            .unwrap_or_else(chrono::Utc::now);
+        surge_persistence::inbox_queue::append_cockpit_snooze(
+            &conn, card_id, "telegram", wake_at,
+        )
+        .map(|_| ())
+        .map_err(|e| TelegramCockpitError::Persistence(e.to_string()))
+    }
+}
+
 /// Production routing surface — dispatches Telegram updates to the
 /// existing handler functions, gating commands on the pairings
 /// allowlist. Forced-reply messages currently log + drop; the
@@ -344,6 +478,22 @@ pub struct ProductionRoutes {
     pub engine: EngineFacadeResolver,
     /// Card store used by the callback router for lookups.
     pub store: SqliteCardStore,
+    /// teloxide bot handle for sending text replies to commands.
+    pub bot: teloxide::Bot,
+    /// Pairing token consumer (for `/pair`).
+    pub pairing_consumer: PersistencePairingConsumer,
+    /// Pairing writer (for `/pair`).
+    pub pairing_writer: PersistencePairingWriter,
+    /// Run-status snapshot provider (for `/status`).
+    pub snapshots: PersistenceSnapshots,
+    /// Run list provider (for `/runs`).
+    pub run_list: PersistenceRunList,
+    /// Run aborter (for `/abort`).
+    pub run_aborter: EngineFacadeAborter,
+    /// Run starter (for `/run` — currently a stub; see [`DeferredRunStarter`]).
+    pub run_starter: DeferredRunStarter,
+    /// Cockpit snooze writer (for `/snooze` as a reply).
+    pub snooze_writer: PersistenceCockpitSnoozeWriter,
 }
 
 impl ProductionRoutes {
@@ -390,52 +540,104 @@ impl UpdateRoutes for ProductionRoutes {
     }
 
     async fn handle_command(&self, chat_id: i64, text: &str) {
-        let (cmd, args) = split_command(text);
+        let (cmd_raw, args) = split_command(text);
+        // Strip an optional `@botname` suffix (group commands), then
+        // also collapse trailing whitespace.
+        let cmd = match cmd_raw.find('@') {
+            Some(i) => &cmd_raw[..i],
+            None => cmd_raw,
+        };
+
         // `/pair` is the only command available to UNPAIRED chats.
         if cmd != "/pair" && !self.admit(chat_id).await {
             // Silently drop — admission denial is INFO-logged inside admit().
             return;
         }
-        warn!(
-            target: "telegram::cmd",
-            %chat_id,
-            cmd = %cmd,
-            args_len = args.len(),
-            "command dispatched but server-side handlers not yet wired in production — \
-             /pair, /status, /runs, /run, /abort, /snooze, /feedback do nothing yet"
-        );
-        // Server-side wiring is gated on TWO follow-ups that must
-        // land together:
-        //   1. The live `polling_default(bot)` update stream (today
-        //      `spawn_telegram_cockpit` passes `stream::empty()`), so
-        //      this method is currently dead code in production — no
-        //      Telegram update ever reaches it.
-        //   2. Bot-reply integration: each handler in
-        //      `crate::commands::*` returns a `CommandReply` that
-        //      needs `bot.send_message(chat_id, reply.text)`. That
-        //      requires `ProductionRoutes` to carry the
-        //      `teloxide::Bot` (today only the dispatch context's
-        //      `TelegramApi` adapter does, and it is owned by the
-        //      emitter).
-        // Until both land, every command path is a deliberate no-op
-        // with a WARN so an operator who configured the cockpit but
-        // sees nothing happen knows where to look. Unit tests in
-        // `commands::*` exercise each handler with fake deps; the
-        // e2e tests in `tests/cockpit_e2e.rs` exercise the routing
-        // surface end-to-end on the callback path.
+
+        let now_ms = chrono::Utc::now().timestamp_millis();
+        let reply_res: crate::error::Result<crate::commands::CommandReply> = match cmd {
+            "/pair" => {
+                crate::commands::handle_pair(
+                    chat_id,
+                    args,
+                    &self.pairing_consumer,
+                    &self.pairing_writer,
+                    now_ms,
+                )
+                .await
+            },
+            "/status" => crate::commands::handle_status(chat_id, args, &self.snapshots).await,
+            "/runs" => crate::commands::handle_runs(chat_id, args, &self.run_list).await,
+            "/run" => crate::commands::handle_run(chat_id, args, &self.run_starter).await,
+            "/abort" => crate::commands::handle_abort(chat_id, args, &self.run_aborter).await,
+            "/feedback" => crate::commands::handle_feedback(chat_id, args, &self.engine).await,
+            "/snooze" => Ok(crate::commands::CommandReply::new(
+                "ℹ `/snooze <duration>` works only as a *reply* to a cockpit card — reply to the card you want to defer.",
+            )),
+            other => Ok(crate::commands::CommandReply::new(format!(
+                "❓ Unknown command `{other}`. Available: /pair, /status, /runs, /run, /abort, /feedback, /snooze (reply)."
+            ))),
+        };
+
+        match reply_res {
+            Ok(reply) => {
+                self.send_reply(chat_id, &reply.text).await;
+            },
+            Err(err) => {
+                warn!(
+                    target: "telegram::cmd",
+                    %chat_id,
+                    cmd = %cmd,
+                    error = %err,
+                    "command handler failed; sending generic error reply"
+                );
+                self.send_reply(
+                    chat_id,
+                    &format!("❌ Internal error while handling `{cmd}`. Check daemon logs."),
+                )
+                .await;
+            },
+        }
     }
 
     async fn handle_reply(&self, chat_id: i64, reply_to_message_id: i64, text: &str) {
         if !self.admit(chat_id).await {
             return;
         }
+        // Forced-reply paths (snooze-by-reply for cards, edit-feedback
+        // forced-reply) require a `CardStore::find_by_chat_message`
+        // lookup that has not been added yet — tracked as a follow-up
+        // alongside the snooze-by-card and Edit-prompt features. For
+        // now we INFO-log the reply and point the operator at the
+        // command equivalents.
         info!(
             target: "telegram::cmd::reply",
             %chat_id,
-            reply_to_message_id = reply_to_message_id,
+            reply_to_message_id,
             text_len = text.len(),
-            "forced-reply text received; use /feedback or /snooze for the live wiring",
+            "free-text reply received; use /feedback <run_id> <text> or /snooze (deferred)",
         );
+    }
+}
+
+impl ProductionRoutes {
+    /// Send a plain-text reply to the originating chat. No `parse_mode`
+    /// is set (text rendering uses literal Markdown that we keep as-is;
+    /// MarkdownV2 would require pervasive escaping of operator content).
+    async fn send_reply(&self, chat_id: i64, text: &str) {
+        use teloxide::prelude::Requester as _;
+        if let Err(err) = self
+            .bot
+            .send_message(teloxide::types::ChatId(chat_id), text)
+            .await
+        {
+            warn!(
+                target: "telegram::cmd::reply",
+                %chat_id,
+                error = %err,
+                "bot.send_message reply failed",
+            );
+        }
     }
 }
 
@@ -498,6 +700,7 @@ pub fn spawn_cockpit(wiring: CockpitWiring, shutdown: CancellationToken) -> Cock
     let card_store = SqliteCardStore {
         storage: Arc::clone(&storage),
     };
+    let bot_for_routes = bot.clone();
     let bot_api = TeloxideTelegramApi { bot };
     let snapshots = PersistenceSnapshots {
         storage: Arc::clone(&storage),
@@ -508,7 +711,24 @@ pub fn spawn_cockpit(wiring: CockpitWiring, shutdown: CancellationToken) -> Cock
     let admission = PairingsAdmission {
         storage: Arc::clone(&storage),
     };
-    let engine_resolver = EngineFacadeResolver { engine };
+    let engine_resolver = EngineFacadeResolver {
+        engine: Arc::clone(&engine),
+    };
+    let pairing_consumer = PersistencePairingConsumer {
+        storage: Arc::clone(&storage),
+    };
+    let pairing_writer = PersistencePairingWriter {
+        storage: Arc::clone(&storage),
+    };
+    let run_list = PersistenceRunList {
+        storage: Arc::clone(&storage),
+    };
+    let run_aborter = EngineFacadeAborter {
+        engine: Arc::clone(&engine),
+    };
+    let snooze_writer = PersistenceCockpitSnoozeWriter {
+        storage: Arc::clone(&storage),
+    };
 
     let emitter = crate::card::emit::CardEmitter::new(card_store.clone(), bot_api.clone());
     let dispatch_ctx = crate::cockpit::dispatch::CockpitCtx {
@@ -519,6 +739,14 @@ pub fn spawn_cockpit(wiring: CockpitWiring, shutdown: CancellationToken) -> Cock
         admission,
         engine: engine_resolver,
         store: card_store.clone(),
+        bot: bot_for_routes,
+        pairing_consumer,
+        pairing_writer,
+        snapshots: snapshots.clone(),
+        run_list,
+        run_aborter,
+        run_starter: DeferredRunStarter,
+        snooze_writer,
     };
     let runtime = Arc::new(crate::cockpit::run::CockpitRuntime {
         dispatch_ctx,

--- a/crates/surge-telegram/src/cockpit/run.rs
+++ b/crates/surge-telegram/src/cockpit/run.rs
@@ -233,6 +233,12 @@ pub async fn drive_update_loop<S, T, P, R>(
                     );
                     return;
                 };
+                debug!(
+                    target: "telegram::cockpit::update",
+                    update_id = update.id.0,
+                    kind = ?std::mem::discriminant(&update.kind),
+                    "received update",
+                );
                 route_update(&runtime, update).await;
             }
         }


### PR DESCRIPTION
## Summary

Lands the production wiring that was deferred in the cockpit MVP (#62). The cockpit on `main` emits cards via the engine-tap but silently drops every inbound Telegram update — `/pair`, `/status`, `/runs`, `/run`, `/abort`, `/feedback`, snooze-by-reply all no-op, and callback buttons short-circuit to `StaleTap`. This PR fixes the inbound path end-to-end.

The biggest gaps closed:

- **Live long-poll listener.** Was `Box::new(stream::empty())` in `spawn_telegram_cockpit`. Now an `mpsc`-bridge feeds a teloxide `Polling` listener with explicit `allowed_updates` into a `'static Stream<Update>`. The explicit list is required because the legacy `TgInboxBot::Dispatcher` registered `[callback_query]` server-side; `polling_default` doesn't override it, so plain text messages never reached the bot.
- **TLS for teloxide.** Workspace feature switched to include `rustls` — without it hyper rejected the `https://api.telegram.org` URL.
- **Single bot poll.** Added `TgInboxBot::run_outgoing_only` (outgoing inbox delivery loop only) so it coexists with the cockpit on the same bot token. Running both Dispatchers produced `Conflict: terminated by other getUpdates`.
- **Real `card_id` in inline keyboards.** `cockpit::dispatch::dispatch` now double-renders: placeholder for the `content_hash` driving `INSERT OR IGNORE`, then again with the real ULID for emit. Previously every button carried `cockpit:approve:00000…` and every callback decoded to a zero ULID → `StaleTap`.
- **Real `run_id` in completion/failure/escalation bodies.** `render_for_action` threads `tap.run_id` through instead of `RunId::nil()`.
- **Drop `MarkdownV2`.** Bodies contained literal `.` / `(` / `*` that MarkdownV2 reserves; Telegram returned `Bad Request: can't parse entities`. Bodies now ship as plain text; pervasive escaping is a follow-up.
- **Server-side command handlers.** `ProductionRoutes::handle_command` now strips `@botname` suffixes, gates everything but `/pair` on the pairings allowlist, dispatches to `handle_pair/status/runs/run/abort/feedback`, plus a usage hint for `/snooze` and unknown commands. Replies via `Bot::send_message` (no parse_mode).
- **Production trait adapters.** New `PersistencePairingConsumer`, `PersistencePairingWriter`, `PersistenceRunList`, `EngineFacadeAborter`, `PersistenceCockpitSnoozeWriter`. `DeferredRunStarter` returns a recoverable "not yet wired" reply for `/run` — full wiring needs `ArchetypeRegistry` plumbed through `CockpitWiring` (follow-up). `ProductionRoutes` carries the `Bot` for replies.

## Deferred (follow-ups)

- `/run <archetype>` proper wiring (needs `ArchetypeRegistry` in `CockpitWiring`).
- Forced-reply edit-feedback and snooze-by-reply (need `CardStore::find_by_chat_message` / `find_by_edit_prompt`).
- Routing legacy `inbox:*` callbacks through the cockpit's shared update stream (re-enables the legacy `TgInboxBot::run` incoming path without a second `getUpdates`).
- MarkdownV2 escaping pass for card bodies and replies.

## Test plan
- [x] `cargo test -p surge-telegram` — 109 unit + 7 cockpit_e2e tests green.
- [x] `cargo build --workspace` — clean.
- [x] Manual end-to-end against a real Telegram supergroup:
  - [x] `human_gate` card emits to chat, `Approve` resolves the gate via `Engine::resolve_human_input`.
  - [x] Resulting `RunCompleted` lands a completion card; `Acknowledge` round-trips through the callback router.
  - [x] `/runs` returns the 20 most recent runs.
  - [x] `/status` returns usage hint; `/status <run_id>` renders a `RunStatusSnapshot`.
  - [x] `/pair` returns usage hint.
  - [x] `/run` returns usage hint; `/run cockpit-test-flow` returns the `DeferredRunStarter` reply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Telegram commands for bot operations: `/pair` (pairing), `/status` (status check), `/runs` (list runs), `/abort` (stop runs), `/feedback`, and `/snooze` (reply-only snooze).
  * Implemented command admission gating and improved error messaging for invalid commands.

* **Improvements**
  * Resolved Telegram polling conflicts in cockpit deployments by optimizing bot update handling.
  * Updated message formatting behavior and enhanced command parsing with optional bot name suffix support.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vanyastaff/surge/pull/64)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->