### PR TITLE
fix(mcp): address PR #65 review feedback

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,6 +125,7 @@ r2d2_sqlite = "0.25"  # must match rusqlite 0.32 — bump together
 fd-lock = "4"
 async-stream = "0.3"
 tokio-stream = "0.1"
+tokio-util = "0.7"
 tempfile = "3"
 sysinfo = { version = "0.32", default-features = false, features = ["system"] }
 

--- a/crates/surge-daemon/src/server.rs
+++ b/crates/surge-daemon/src/server.rs
@@ -912,9 +912,7 @@ async fn dispatch(
                     return Some(DaemonResponse::Error {
                         request_id,
                         code: ErrorCode::EngineError,
-                        message: format!(
-                            "failed to read MCP stderr capture for '{name}': {e}"
-                        ),
+                        message: format!("failed to read MCP stderr capture for '{name}': {e}"),
                     });
                 },
             };

--- a/crates/surge-daemon/src/server.rs
+++ b/crates/surge-daemon/src/server.rs
@@ -903,7 +903,20 @@ async fn dispatch(
                         .map(|s| (*s).to_string())
                         .collect()
                 },
-                Err(_) => Vec::new(),
+                // No capture file yet is a legitimate "no logs" state.
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => Vec::new(),
+                // Permission / IO / encoding failures must surface as an
+                // error, not masquerade as an empty tail — masking them
+                // makes operator diagnostics actively misleading.
+                Err(e) => {
+                    return Some(DaemonResponse::Error {
+                        request_id,
+                        code: ErrorCode::EngineError,
+                        message: format!(
+                            "failed to read MCP stderr capture for '{name}': {e}"
+                        ),
+                    });
+                },
             };
             Some(DaemonResponse::McpLogsOk {
                 request_id,

--- a/crates/surge-mcp/Cargo.toml
+++ b/crates/surge-mcp/Cargo.toml
@@ -12,7 +12,7 @@ serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["full"] }
-tokio-util = "0.7"
+tokio-util.workspace = true
 tracing.workspace = true
 
 rmcp.workspace = true

--- a/crates/surge-mcp/src/connection.rs
+++ b/crates/surge-mcp/src/connection.rs
@@ -692,20 +692,26 @@ async fn stderr_forwarder(stderr: tokio::process::ChildStderr, server: String, p
         {
             use std::os::unix::fs::PermissionsExt;
             let _ =
-                tokio::fs::set_permissions(parent, std::fs::Permissions::from_mode(0o700))
-                    .await;
+                tokio::fs::set_permissions(parent, std::fs::Permissions::from_mode(0o700)).await;
         }
     }
-    // Pre-create the capture file 0600 so the per-line rewrites below
-    // (truncate-in-place) keep owner-only permissions for its lifetime.
+    // Capture file must be owner-only for its whole lifetime. Create
+    // it 0600 (atomic for a fresh file), then also tighten an
+    // already-existing one: a prior probe/run may have left it with a
+    // broader umask default, and `mode()` only applies on creation.
     #[cfg(unix)]
     {
-        let _ = tokio::fs::OpenOptions::new()
+        use std::os::unix::fs::PermissionsExt;
+        if tokio::fs::OpenOptions::new()
             .create(true)
             .write(true)
             .mode(0o600)
             .open(&path)
-            .await;
+            .await
+            .is_ok()
+        {
+            let _ = tokio::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600)).await;
+        }
     }
     let mut lines = BufReader::new(stderr).lines();
     let mut ring: VecDeque<String> = VecDeque::with_capacity(MAX_STDERR_LINES);

--- a/crates/surge-mcp/src/connection.rs
+++ b/crates/surge-mcp/src/connection.rs
@@ -682,6 +682,30 @@ pub fn stderr_log_path(cwd: Option<&Path>, server: &str) -> PathBuf {
 async fn stderr_forwarder(stderr: tokio::process::ChildStderr, server: String, path: PathBuf) {
     if let Some(parent) = path.parent() {
         let _ = tokio::fs::create_dir_all(parent).await;
+        // Owner-only capture dir. Daemon-scoped probes write under
+        // `temp_dir()/surge-mcp-stderr/`, which would otherwise inherit
+        // a world-readable umask default — and even redacted child
+        // stderr can carry hostnames, paths, and short tokens that slip
+        // past redaction (ADR-0014 decision 6). Run-scoped paths live
+        // under the user-owned worktree, so 0700 is harmless there too.
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let _ =
+                tokio::fs::set_permissions(parent, std::fs::Permissions::from_mode(0o700))
+                    .await;
+        }
+    }
+    // Pre-create the capture file 0600 so the per-line rewrites below
+    // (truncate-in-place) keep owner-only permissions for its lifetime.
+    #[cfg(unix)]
+    {
+        let _ = tokio::fs::OpenOptions::new()
+            .create(true)
+            .write(true)
+            .mode(0o600)
+            .open(&path)
+            .await;
     }
     let mut lines = BufReader::new(stderr).lines();
     let mut ring: VecDeque<String> = VecDeque::with_capacity(MAX_STDERR_LINES);

--- a/crates/surge-mcp/src/redact.rs
+++ b/crates/surge-mcp/src/redact.rs
@@ -39,6 +39,12 @@ const SENSITIVE_KEYS: &[&str] = &[
     "password",
     "passwd",
     "token",
+    // Connection strings routinely embed `user:pass@host` — mask the
+    // whole value when it arrives under one of these keys.
+    "database_url",
+    "database-url",
+    "dsn",
+    "connection_string",
 ];
 
 /// Lowercased standalone keywords that mark the *next whitespace token*
@@ -74,8 +80,25 @@ pub fn redact_line(line: &str) -> String {
             continue;
         }
 
-        // `key=value` / `key:value` where key is sensitive.
-        if let Some(masked) = mask_key_value(core, &lowered) {
+        // `key=value` / `key:value` where key is sensitive. The flag
+        // marks the masked value as itself a credential-scheme keyword:
+        // `Authorization:Bearer <tok>` packs key+scheme+delimiter into
+        // one whitespace token, so the real secret is the *next* token
+        // and must also be redacted (else it leaks — the compact form
+        // of `Authorization: Bearer <tok>`).
+        if let Some((masked, redact_next)) = mask_key_value(core, &lowered) {
+            out.push_str(&masked);
+            out.push_str(ws);
+            if redact_next {
+                redact_next_token = true;
+            }
+            continue;
+        }
+
+        // Connection-string URLs carry credentials inline
+        // (`postgres://user:pass@host`); mask just the userinfo and
+        // keep the scheme/host so the line stays useful for debugging.
+        if let Some(masked) = mask_url_userinfo(core) {
             out.push_str(&masked);
             out.push_str(ws);
             continue;
@@ -107,8 +130,11 @@ pub fn redact_line(line: &str) -> String {
 }
 
 /// If `core` is `<sensitive-key><delim><value>`, return the masked form
-/// `<sensitive-key><delim><redacted>`. Otherwise `None`.
-fn mask_key_value(core: &str, lowered: &str) -> Option<String> {
+/// `<sensitive-key><delim><redacted>` and a flag: when the value is
+/// itself a credential-scheme keyword (`bearer`/`token`/`basic`) the
+/// real secret is the *next* whitespace token, so the caller must
+/// redact that too. Returns `None` when the key is not sensitive.
+fn mask_key_value(core: &str, lowered: &str) -> Option<(String, bool)> {
     let delim = lowered.find(['=', ':'])?;
     let (key_raw, rest) = core.split_at(delim);
     let key =
@@ -117,8 +143,32 @@ fn mask_key_value(core: &str, lowered: &str) -> Option<String> {
         return None;
     }
     // `rest` starts with the delimiter char; keep it, mask the value.
+    // `delim` indexes an ASCII `=`/`:`, so `delim + 1` is a char boundary.
     let delim_char = &rest[..1];
-    Some(format!("{key_raw}{delim_char}{MASK}"))
+    let value_lc =
+        lowered[delim + 1..].trim_end_matches(|c: char| !c.is_ascii_alphanumeric());
+    let redact_next = SENSITIVE_PREFIXES.contains(&value_lc);
+    Some((format!("{key_raw}{delim_char}{MASK}"), redact_next))
+}
+
+/// Mask the `user:pass@` userinfo of a connection-string-style URL
+/// (`scheme://user:pass@host/...`), preserving scheme and host so the
+/// line stays diagnostically useful. Returns `None` when `core` has no
+/// URL authority with userinfo (ordinary `https://host/path` URLs and
+/// scp-style `git@host:path` refs are left untouched).
+fn mask_url_userinfo(core: &str) -> Option<String> {
+    let scheme_end = core.find("://")?;
+    let after = scheme_end + 3;
+    // The authority ends at the first '/', '?', or '#'.
+    let authority_end = core[after..]
+        .find(['/', '?', '#'])
+        .map_or(core.len(), |i| after + i);
+    let at = after + core[after..authority_end].find('@')?;
+    if at == after {
+        // Empty userinfo ("scheme://@host") — nothing to mask.
+        return None;
+    }
+    Some(format!("{}://{}{}", &core[..scheme_end], MASK, &core[at..]))
 }
 
 /// Heuristic: a long run of base64 / hex / url-safe characters with no
@@ -189,5 +239,44 @@ mod tests {
     fn preserves_blank_and_whitespace() {
         assert_eq!(redact_line(""), "");
         assert_eq!(redact_line("   "), "   ");
+    }
+
+    #[test]
+    fn masks_compact_authorization_bearer() {
+        // No space between the key and `Bearer`: the scheme keyword is
+        // packed into the key token, the secret is the next token.
+        let r = redact_line("INFO Authorization:Bearer abc123def456ghi789tok");
+        assert!(
+            !r.contains("abc123def456ghi789tok"),
+            "compact bearer token leaked: {r}"
+        );
+        assert!(r.contains("Authorization:"), "structure lost: {r}");
+    }
+
+    #[test]
+    fn masks_connection_string_userinfo() {
+        let r = redact_line("INFO connecting postgres://admin:s3cr3tpw@db.internal:5432/app");
+        assert!(!r.contains("s3cr3tpw"), "db password leaked: {r}");
+        assert!(!r.contains("admin:s3cr3tpw"), "userinfo leaked: {r}");
+        assert!(r.contains("postgres://"), "scheme lost: {r}");
+        assert!(r.contains("db.internal"), "host lost (debuggability): {r}");
+    }
+
+    #[test]
+    fn masks_database_url_env_assignment() {
+        let r = redact_line("DATABASE_URL=postgres://u:p@h:5432/db starting");
+        assert!(
+            !r.contains("postgres://u:p@h"),
+            "DATABASE_URL value leaked: {r}"
+        );
+        assert!(r.contains("DATABASE_URL="), "key preserved: {r}");
+        assert!(r.contains("starting"), "trailing context preserved: {r}");
+    }
+
+    #[test]
+    fn ordinary_url_without_userinfo_passes_through() {
+        // No credentials in the authority — keep it readable.
+        let line = "fetched https://example.com/path?q=1 ok";
+        assert_eq!(redact_line(line), line);
     }
 }

--- a/crates/surge-mcp/src/redact.rs
+++ b/crates/surge-mcp/src/redact.rs
@@ -145,8 +145,7 @@ fn mask_key_value(core: &str, lowered: &str) -> Option<(String, bool)> {
     // `rest` starts with the delimiter char; keep it, mask the value.
     // `delim` indexes an ASCII `=`/`:`, so `delim + 1` is a char boundary.
     let delim_char = &rest[..1];
-    let value_lc =
-        lowered[delim + 1..].trim_end_matches(|c: char| !c.is_ascii_alphanumeric());
+    let value_lc = lowered[delim + 1..].trim_end_matches(|c: char| !c.is_ascii_alphanumeric());
     let redact_next = SENSITIVE_PREFIXES.contains(&value_lc);
     Some((format!("{key_raw}{delim_char}{MASK}"), redact_next))
 }

--- a/crates/surge-orchestrator/src/engine/tools/routing.rs
+++ b/crates/surge-orchestrator/src/engine/tools/routing.rs
@@ -159,9 +159,13 @@ impl RoutingToolDispatcher {
     /// swallowed — an escalation is best-effort telemetry, not
     /// load-bearing control flow.
     fn record_escalation(&self, server: &str, attempts: u32) {
+        // Hot path (server already exhausted, hit by every later tool
+        // call) does a borrow-keyed lookup with no allocation; only a
+        // newly-seen server allocates.
         if let Ok(mut st) = self.escalations.lock()
-            && st.seen.insert(server.to_owned())
+            && !st.seen.contains(server)
         {
+            st.seen.insert(server.to_owned());
             st.pending.push(McpEscalation {
                 server: server.to_owned(),
                 attempts,
@@ -375,7 +379,11 @@ mod tests {
         r.record_escalation("flaky", 5);
         r.record_escalation("other", 5);
         let drained = r.drain_mcp_escalations();
-        assert_eq!(drained.len(), 2, "one escalation per server, got {drained:?}");
+        assert_eq!(
+            drained.len(),
+            2,
+            "one escalation per server, got {drained:?}"
+        );
         // A post-drain repeat of an already-escalated server stays
         // suppressed: the give-up fact is recorded once per run.
         r.record_escalation("flaky", 5);

--- a/crates/surge-orchestrator/src/engine/tools/routing.rs
+++ b/crates/surge-orchestrator/src/engine/tools/routing.rs
@@ -8,7 +8,7 @@ use crate::engine::tools::{
     DeclaredTool, McpEscalation, ToolCall, ToolDispatchContext, ToolDispatcher, ToolResultPayload,
 };
 use async_trait::async_trait;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use surge_mcp::{McpContent, McpError, McpRegistry, McpToolEntry};
@@ -32,6 +32,17 @@ enum ToolOrigin {
     Mcp { server: String, timeout: Duration },
 }
 
+/// Restart-exhaustion escalation accumulator. `pending` is drained by
+/// the agent stage into `EscalationRequested` events; `seen` records
+/// every server already escalated so a single permanent outage emits
+/// exactly one card instead of one per subsequent tool call — the
+/// give-up fact is stable (see `engine::stage::agent`).
+#[derive(Default)]
+struct EscalationState {
+    pending: Vec<McpEscalation>,
+    seen: HashSet<String>,
+}
+
 /// `ToolDispatcher` impl that routes between engine + MCP. Constructed
 /// once per engine session (per agent stage), with the routing table
 /// precomputed from the merged catalog.
@@ -42,7 +53,9 @@ pub struct RoutingToolDispatcher {
     declared: Vec<DeclaredTool>,
     /// MCP restart-exhaustion escalations observed during dispatch,
     /// drained by the agent stage into `EscalationRequested` events.
-    escalations: Mutex<Vec<McpEscalation>>,
+    /// De-duplicated per server so one outage cannot spam the
+    /// operator surface.
+    escalations: Mutex<EscalationState>,
 }
 
 impl RoutingToolDispatcher {
@@ -134,7 +147,25 @@ impl RoutingToolDispatcher {
             mcp_registry,
             routing_table: table,
             declared,
-            escalations: Mutex::new(Vec::new()),
+            escalations: Mutex::new(EscalationState::default()),
+        }
+    }
+
+    /// Record a restart-exhaustion escalation, de-duplicated per
+    /// server: the first exhaustion of `server` is queued for the
+    /// stage to escalate; later ones (every subsequent tool call hits
+    /// the already-`Exhausted` connection) are dropped so one outage
+    /// cannot spam the AFK/operator surface. Lock poisoning is
+    /// swallowed — an escalation is best-effort telemetry, not
+    /// load-bearing control flow.
+    fn record_escalation(&self, server: &str, attempts: u32) {
+        if let Ok(mut st) = self.escalations.lock()
+            && st.seen.insert(server.to_owned())
+        {
+            st.pending.push(McpEscalation {
+                server: server.to_owned(),
+                attempts,
+            });
         }
     }
 }
@@ -167,13 +198,10 @@ impl ToolDispatcher for RoutingToolDispatcher {
                         // Type-safe escalation capture (no string
                         // sniffing): a restart-exhausted server is a
                         // permanent failure the AFK operator must see.
-                        if let McpError::RestartExhausted { server, attempts } = &e
-                            && let Ok(mut q) = self.escalations.lock()
-                        {
-                            q.push(McpEscalation {
-                                server: server.clone(),
-                                attempts: *attempts,
-                            });
+                        // De-duplicated per server inside
+                        // `record_escalation`.
+                        if let McpError::RestartExhausted { server, attempts } = &e {
+                            self.record_escalation(server, *attempts);
                         }
                         ToolResultPayload::Error {
                             message: format!("MCP error: {e}"),
@@ -194,7 +222,7 @@ impl ToolDispatcher for RoutingToolDispatcher {
     fn drain_mcp_escalations(&self) -> Vec<McpEscalation> {
         self.escalations
             .lock()
-            .map(|mut q| std::mem::take(&mut *q))
+            .map(|mut st| std::mem::take(&mut st.pending))
             .unwrap_or_default()
     }
 
@@ -334,6 +362,26 @@ mod tests {
                 .description
                 .as_deref(),
             Some("from a")
+        );
+    }
+
+    #[test]
+    fn escalations_dedupe_per_server() {
+        let mcp = Arc::new(McpRegistry::from_config(&[], None));
+        let r = RoutingToolDispatcher::new(Arc::new(EngineStub), mcp, &[], &HashMap::new());
+        // A permanently-exhausted server is hit by every later tool
+        // call — only the first must escalate.
+        r.record_escalation("flaky", 5);
+        r.record_escalation("flaky", 5);
+        r.record_escalation("other", 5);
+        let drained = r.drain_mcp_escalations();
+        assert_eq!(drained.len(), 2, "one escalation per server, got {drained:?}");
+        // A post-drain repeat of an already-escalated server stays
+        // suppressed: the give-up fact is recorded once per run.
+        r.record_escalation("flaky", 5);
+        assert!(
+            r.drain_mcp_escalations().is_empty(),
+            "re-escalation after drain must stay suppressed"
         );
     }
 

--- a/crates/surge-persistence/src/telegram/cards.rs
+++ b/crates/surge-persistence/src/telegram/cards.rs
@@ -66,6 +66,7 @@ pub enum CardsError {
 ///
 /// Returns [`CardsError::Sqlite`] on storage failure.
 #[allow(clippy::too_many_arguments)]
+#[must_use = "the canonical card_id must be used to address the row"]
 pub fn upsert(
     conn: &Connection,
     run_id: &str,

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -38,7 +38,7 @@ sandbox = "workspace-write"                             # optional per-server ov
 Connections are lazy: the child process spawns on first tool use, not at
 config load. State machine (runtime-only — never event-sourced):
 
-```
+```text
 Disconnected → Connecting → Running ──(transport-dead)──▶ Crashed
                                  ▲                            │ backoff(attempt)
                                  └──── reconnect ◀────────────┘


### PR DESCRIPTION
## Summary

Follow-up to #65 (squash-merged into `main`). Addresses the Copilot /
CodeRabbit inline review threads on that PR. Each finding was verified
against current code; only still-valid issues were fixed, scope kept
minimal.

## Addressed

| Area | Change | Threads |
|---|---|---|
| Security | Compact `Authorization:Bearer <tok>` no longer leaks the token; connection-string userinfo (`postgres://u:p@h`) masked; `DATABASE_URL`/`DSN` keys added | `redact.rs` 3254689166, 3254689187 |
| Security | Daemon-scoped stderr capture: dir `0700` / file `0600` on Unix (was world-readable umask default — ADR-0014 dec. 6) | `connection.rs` 3254685177 |
| Reliability | Dedupe `RestartExhausted` escalations per server — one permanent outage → one `EscalationRequested`, not one per later tool call | `routing.rs` 3254689169 |
| Reliability | `McpLogs` surfaces non-`NotFound` read failures as an IPC error instead of an empty tail | `server.rs` 3254689159 |
| Conventions | `#[must_use]` on telegram cards `upsert` | `cards.rs` 3254689172 |
| Build | `tokio-util` is now workspace-managed | `Cargo.toml` 3254689164 |
| Docs | Language identifier on the `mcp.md` lifecycle fence (MD040) | `mcp.md` 3254689177 |

New test coverage: compact-Bearer / connection-string / `DATABASE_URL`
redaction cases, ordinary-URL pass-through, and per-server escalation
dedup.

## Intentionally not changed (verified, tracked)

- **Drain MCP escalations outside tool-call handling** (3254689168 /
  3254689191) — verified against current code: escalations are enqueued
  only inside `dispatch()` on `RestartExhausted` and drained in the same
  loop iteration (`agent.rs` right after the dispatch), so there is no
  post-last-call stranding via the tool path. The real gap (health
  monitor has no channel into the escalation queue) needs a registry→
  stage escalation stream — an architectural change explicitly labelled
  "heavy lift" and already tracked as residual finding #6.
- **Unbounded `McpProbe`** (3254689190) — architectural availability
  concern, tracked as residual finding #2 (per-server probe timeout is
  the documented follow-up).
- **Plan/residual-doc narrative comments** (3254689182, 3254689183) —
  the plan and residual-findings docs are merged decision/record
  artifacts; the underlying redaction gap they reference is fixed in
  code here rather than by rewriting historical docs. The "ready with
  fixes" verdict is intentional (production-grade milestone with
  explicitly documented deferred hardening).

## Validation

- `cargo build --workspace` clean
- `cargo clippy --workspace --all-targets` clean
- Targeted tests green: `surge-mcp` (25), `surge-orchestrator` routing
  (5), `surge-persistence` cards (10), `surge-daemon` (all)
- `tokio::fs::OpenOptions::mode()` verified against pinned tokio 1.50.0
  source (inherent, `#[cfg(unix)]`); Unix-gated blocks compile-checked
  by Linux CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
