### PR TITLE
fix(orchestrator): insulate Claude runtime from global permission mode

### DIFF
--- a/crates/surge-orchestrator/src/engine/stage/agent.rs
+++ b/crates/surge-orchestrator/src/engine/stage/agent.rs
@@ -238,6 +238,19 @@ pub async fn execute_agent_stage(p: AgentStageParams<'_>) -> StageResult {
         None => derive_agent_kind(profile_str, None)?,
     };
 
+    // Headless-runtime insulation. For the Claude Code runtime, ensure the
+    // worktree carries a project-level `.claude/settings.json` that pins a
+    // valid, non-interactive `permissions.defaultMode`. Otherwise the agent
+    // inherits the operator's GLOBAL `~/.claude/settings.json` mode — which
+    // may be a value the claude-agent-acp adapter rejects at session setup
+    // (e.g. "auto" → "Invalid permissions.defaultMode"), breaking the run
+    // before any turn. Auth and other global settings still apply; only the
+    // project-level mode is pinned, and an existing project file is never
+    // clobbered. No-op for non-Claude runtimes.
+    if let Some(rp) = resolved_profile.as_ref() {
+        seed_headless_runtime_settings(rp.profile.runtime.agent_id.as_str(), p.worktree_path);
+    }
+
     // Derive declared outcomes from the node's OutcomeDecl list.
     // Fall back to ["done"] when the node has no declared_outcomes so the
     // session is always valid (SessionConfig::validate requires at least one).
@@ -1670,6 +1683,19 @@ fn derive_agent_kind_from_id(profile_str: &str, agent_id: &str) -> Result<AgentK
     })?;
     let binary = std::path::PathBuf::from(&entry.command);
     let extra_args = entry.default_args.clone();
+    // The builtin registry launches agents through an npx adapter
+    // (`command = "npx"`, `default_args = ["@vendor/pkg", ...]`), where
+    // `default_args` already encodes the COMPLETE invocation (including any
+    // `--acp` flag the adapter needs, e.g. gemini/copilot). Those registry
+    // ids ("claude-acp"/"codex-acp"/"gemini") deliberately fall through to
+    // `Custom`, which spawns `command + args` verbatim. The typed
+    // `ClaudeCode`/`Codex`/`GeminiCli` arms exist for the DIRECT-CLI launch
+    // model (e.g. `claude --acp`, exercised by the env-gated
+    // `real_acp_smoke` test), where `build_agent_command` injects the
+    // runtime's subcommand. Mapping the registry ids onto the typed arms
+    // would double/misplace `--acp` for the npx model and break the launch —
+    // so the runtime is tracked separately (registry `entry.runtime`, used
+    // by `seed_headless_runtime_settings`) rather than via the AgentKind.
     let kind = match entry.id.as_str() {
         "claude-code" => AgentKind::ClaudeCode { binary, extra_args },
         "codex" => AgentKind::Codex { binary, extra_args },
@@ -1688,6 +1714,51 @@ fn derive_agent_kind_from_id(profile_str: &str, agent_id: &str) -> Result<AgentK
         "derived AgentKind from profile registry"
     );
     Ok(kind)
+}
+
+/// Best-effort: pin a headless permission mode for the Claude Code runtime by
+/// seeding `<worktree>/.claude/settings.json` when absent.
+///
+/// The claude-agent-acp adapter reads `permissions.defaultMode` from Claude's
+/// settings cascade at ACP `new_session`; an operator's global value the
+/// adapter doesn't accept (e.g. `"auto"`) aborts the handshake. A project-
+/// level settings file overrides the global mode while auth and other global
+/// settings still apply. An existing project file is left untouched (the
+/// operator's explicit choice wins). No-op for non-Claude runtimes or when
+/// the agent id is unknown.
+fn seed_headless_runtime_settings(agent_id: &str, worktree: &std::path::Path) {
+    let registry = surge_acp::Registry::builtin();
+    let is_claude = registry
+        .normalize_agent_id(agent_id)
+        .and_then(|id| registry.find(&id).and_then(|e| e.runtime))
+        .map_or_else(
+            || matches!(agent_id, "claude-code" | "claude-acp"),
+            |rt| matches!(rt, surge_core::RuntimeKind::ClaudeCode),
+        );
+    if !is_claude {
+        return;
+    }
+
+    let dir = worktree.join(".claude");
+    let settings = dir.join("settings.json");
+    if settings.exists() {
+        return;
+    }
+
+    let body = "{\n  \"permissions\": {\n    \"defaultMode\": \"default\"\n  }\n}\n";
+    match std::fs::create_dir_all(&dir).and_then(|()| std::fs::write(&settings, body)) {
+        Ok(()) => tracing::debug!(
+            target: "engine::stage::agent",
+            worktree = %worktree.display(),
+            "seeded headless .claude/settings.json (permissions.defaultMode=default)"
+        ),
+        Err(e) => tracing::warn!(
+            target: "engine::stage::agent",
+            worktree = %worktree.display(),
+            error = %e,
+            "failed to seed headless .claude/settings.json; agent may inherit the global permission mode"
+        ),
+    }
 }
 
 /// Whether an MCP server may be spawned/exposed for a stage.
@@ -1752,6 +1823,43 @@ fn warn_if_unconstrained_mcp(server: &str, effective: surge_core::sandbox::Sandb
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn seed_headless_settings_writes_default_mode_for_claude() {
+        let tmp = tempfile::tempdir().unwrap();
+        seed_headless_runtime_settings("claude-code", tmp.path());
+        let settings = tmp.path().join(".claude").join("settings.json");
+        let body = std::fs::read_to_string(&settings).expect("settings.json written");
+        assert!(
+            body.contains("\"defaultMode\"") && body.contains("\"default\""),
+            "expected headless defaultMode, got: {body}"
+        );
+    }
+
+    #[test]
+    fn seed_headless_settings_does_not_clobber_existing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join(".claude");
+        std::fs::create_dir_all(&dir).unwrap();
+        let settings = dir.join("settings.json");
+        std::fs::write(&settings, "{ \"keep\": true }").unwrap();
+        seed_headless_runtime_settings("claude-code", tmp.path());
+        assert_eq!(
+            std::fs::read_to_string(&settings).unwrap(),
+            "{ \"keep\": true }",
+            "existing project settings must not be overwritten"
+        );
+    }
+
+    #[test]
+    fn seed_headless_settings_noop_for_non_claude_runtime() {
+        let tmp = tempfile::tempdir().unwrap();
+        seed_headless_runtime_settings("mock", tmp.path());
+        assert!(
+            !tmp.path().join(".claude").exists(),
+            "non-Claude runtime must not seed .claude/"
+        );
+    }
 
     #[test]
     fn mcp_spawn_policy_read_only_denies_writable_allows() {


### PR DESCRIPTION
@
## What

When launching a **Claude Code runtime** agent, Surge now seeds a project-level `<worktree>/.claude/settings.json` with a valid, non-interactive `permissions.defaultMode` (`"default"`) when that file is absent.

## Why

The `claude-agent-acp` adapter reads `permissions.defaultMode` from Claude's settings cascade at ACP `new_session`. If the operator's **global** `~/.claude/settings.json` carries a value the adapter does not accept (notably `"auto"`), the handshake aborts with `Invalid permissions.defaultMode` **before any turn runs** — so a perfectly valid run dies at launch purely because of an interactive-mode global config.

Pinning a project-level mode overrides **only** the mode; auth and every other global setting still apply. An existing project `settings.json` is never clobbered — the operator's explicit choice wins. No-op for non-Claude runtimes.

## Empirical validation (live agent)

Ran a real `npx @zed-industries/claude-agent-acp` session in a fresh worktree, with the global `defaultMode = "auto"` present in the cascade:

```
DEBUG engine::stage::agent: seeded headless .claude/settings.json (permissions.defaultMode=default)
 WARN surge_acp::bridge::worker: ACP prompt dispatch ... method: 'session/prompt' ...
      Internal error: Failed to authenticate. API Error: 401 ...
```

The run **auto-seeds the worktree, passes `new_session`, and reaches `session/prompt`** — failing only on the external **401 auth** boundary (out of scope). Before this fix the same setup was rejected at the permission-mode check. No `Invalid permissions.defaultMode` anywhere in the log.

## Also

Documents why builtin-registry agents resolve to `AgentKind::Custom` (the npx launch model — `default_args` already encodes the complete invocation) while the typed `ClaudeCode`/`Codex`/`GeminiCli` arms serve the direct-CLI model. The runtime is tracked via the registry entry (`entry.runtime`), not the `AgentKind` — so this resolution is intentional, not a bug. Mapping registry ids onto the typed arms would double/misplace `--acp` and break the npx launch.

## Tests

- `seed_headless_settings_writes_default_mode_for_claude` — seeds when Claude runtime + file absent
- `seed_headless_settings_does_not_clobber_existing` — leaves an existing project file untouched
- `seed_headless_settings_noop_for_non_claude_runtime` — no `.claude/` for non-Claude runtimes

> Stacked on #68 (`fix/windows-npx-agent-spawn`); base auto-retargets to `main` when #68 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@