### PR TITLE
feat(acp): surface agent auth failures as a clear, actionable error

### DIFF
--- a/crates/surge-acp/src/bridge/error.rs
+++ b/crates/surge-acp/src/bridge/error.rs
@@ -83,6 +83,21 @@ pub enum SendMessageError {
         reason: SessionEndReason,
     },
 
+    /// The agent rejected the prompt because it could not authenticate
+    /// (e.g. HTTP 401 / `authentication_error`). This is almost always an
+    /// operator/environment problem — the agent runtime is not logged in or
+    /// its credentials are invalid — rather than a bridge transport failure,
+    /// so it gets a dedicated, actionable message instead of being buried in
+    /// a generic `Bridge` error.
+    #[error(
+        "agent failed to authenticate — verify the agent runtime is logged in \
+         (run the agent's own login, or set its API key); details: {details}"
+    )]
+    AgentAuthenticationFailed {
+        /// Raw error text from the agent/ACP layer, kept for debugging.
+        details: String,
+    },
+
     /// Bridge worker communication failed.
     #[error("bridge: {0}")]
     Bridge(#[source] BridgeError),

--- a/crates/surge-acp/src/bridge/worker.rs
+++ b/crates/surge-acp/src/bridge/worker.rs
@@ -1087,13 +1087,34 @@ pub(crate) async fn send_message_impl(
             })?;
 
     connection.prompt(req).await.map_err(|e| {
-        warn!(session = %session, error = %e, "ACP prompt dispatch failed");
-        super::error::SendMessageError::Bridge(super::error::BridgeError::CommandSendFailed(
-            e.to_string(),
-        ))
+        let details = e.to_string();
+        if crate::pool::is_auth_failure(&details) {
+            warn!(session = %session, error = %details, "ACP prompt dispatch failed: agent authentication error");
+        } else {
+            warn!(session = %session, error = %details, "ACP prompt dispatch failed");
+        }
+        classify_prompt_dispatch_error(details)
     })?;
 
     Ok(())
+}
+
+/// Map a failed `connection.prompt(...)` error into the most accurate
+/// `SendMessageError`.
+///
+/// An authentication failure (HTTP 401 / `authentication_error`) becomes the
+/// dedicated [`SendMessageError::AgentAuthenticationFailed`] variant, which
+/// carries operator-facing guidance — the agent runtime is almost certainly
+/// not logged in. Every other failure stays a generic bridge transport error,
+/// preserving the previous behaviour.
+pub(crate) fn classify_prompt_dispatch_error(details: String) -> super::error::SendMessageError {
+    if crate::pool::is_auth_failure(&details) {
+        super::error::SendMessageError::AgentAuthenticationFailed { details }
+    } else {
+        super::error::SendMessageError::Bridge(super::error::BridgeError::CommandSendFailed(
+            details,
+        ))
+    }
 }
 
 /// Close a session gracefully.
@@ -1229,6 +1250,44 @@ mod tests {
     use crate::bridge::sandbox::DenyListSandbox;
     use crate::bridge::tools::{ToolCategory, ToolDef};
     use serde_json::json;
+
+    #[test]
+    fn classify_prompt_error_maps_401_to_agent_auth_failed() {
+        let details = "Internal error: Failed to authenticate. API Error: 401 {\"type\":\"error\",\
+             \"error\":{\"type\":\"authentication_error\"}}"
+            .to_string();
+        let err = classify_prompt_dispatch_error(details.clone());
+        assert!(
+            matches!(
+                err,
+                super::super::error::SendMessageError::AgentAuthenticationFailed { .. }
+            ),
+            "401 prompt error should map to AgentAuthenticationFailed, got: {err:?}"
+        );
+        let rendered = err.to_string();
+        assert!(
+            rendered.contains("failed to authenticate") && rendered.contains("logged in"),
+            "auth error should carry actionable guidance, got: {rendered}"
+        );
+        assert!(
+            rendered.contains(&details),
+            "auth error should preserve the raw details for debugging, got: {rendered}"
+        );
+    }
+
+    #[test]
+    fn classify_prompt_error_keeps_non_auth_as_bridge_error() {
+        let err = classify_prompt_dispatch_error("connection reset by peer".to_string());
+        assert!(
+            matches!(
+                err,
+                super::super::error::SendMessageError::Bridge(
+                    super::super::error::BridgeError::CommandSendFailed(_)
+                )
+            ),
+            "non-auth prompt error should stay a bridge transport error, got: {err:?}"
+        );
+    }
 
     #[test]
     fn resolve_program_finds_path_extension_shim() {

--- a/crates/surge-acp/src/bridge/worker.rs
+++ b/crates/surge-acp/src/bridge/worker.rs
@@ -1103,10 +1103,10 @@ pub(crate) async fn send_message_impl(
 /// `SendMessageError`.
 ///
 /// An authentication failure (HTTP 401 / `authentication_error`) becomes the
-/// dedicated [`SendMessageError::AgentAuthenticationFailed`] variant, which
-/// carries operator-facing guidance — the agent runtime is almost certainly
-/// not logged in. Every other failure stays a generic bridge transport error,
-/// preserving the previous behaviour.
+/// dedicated [`super::error::SendMessageError::AgentAuthenticationFailed`]
+/// variant, which carries operator-facing guidance — the agent runtime is
+/// almost certainly not logged in. Every other failure stays a generic bridge
+/// transport error, preserving the previous behaviour.
 pub(crate) fn classify_prompt_dispatch_error(details: String) -> super::error::SendMessageError {
     if crate::pool::is_auth_failure(&details) {
         super::error::SendMessageError::AgentAuthenticationFailed { details }

--- a/crates/surge-acp/src/pool.rs
+++ b/crates/surge-acp/src/pool.rs
@@ -1187,7 +1187,10 @@ async fn prompt(
 /// - HTTP 401 status code
 /// - "Unauthorized" or "authentication failed"
 /// - API key errors
-fn is_auth_failure(error_msg: &str) -> bool {
+///
+/// Shared with the bridge worker, which uses it to map a failed
+/// `connection.prompt(...)` into a dedicated auth-error variant.
+pub(crate) fn is_auth_failure(error_msg: &str) -> bool {
     let msg_lower = error_msg.to_lowercase();
     msg_lower.contains("401")
         || msg_lower.contains("unauthorized")


### PR DESCRIPTION
## What

A failed `connection.prompt(...)` in the ACP bridge was always wrapped in `BridgeError::CommandSendFailed`. So an agent that simply isn't authenticated surfaced to the operator as:

```
stage error at impl_1: bridge error: send_message: bridge: command channel send failed:
Internal error: Failed to authenticate. API Error: 401 {"type":"error","error":{"type":"authentication_error",...}}
```

The command channel didn't fail — the agent **rejected the prompt** because it isn't logged in. The message buries a common first-run problem inside a transport-error string.

## Change

Classify the prompt-dispatch error:

- A `401` / `authentication_error` (detected by the **existing** `pool::is_auth_failure`, now `pub(crate)` and shared) maps to a dedicated `SendMessageError::AgentAuthenticationFailed { details }` variant.
- Its `Display` is actionable: *"agent failed to authenticate — verify the agent runtime is logged in (run the agent's own login, or set its API key); details: …"* — and preserves the raw error text for debugging.
- Every other failure keeps the previous `Bridge(CommandSendFailed)` behaviour (minimal blast radius).

The variant flows through the orchestrator — which only `Display`s `SendMessageError` (`format!("send_message: {e}")`, three call sites) — into the `Terminal::Failed` reason and the Telegram/cockpit failure surfaces. So a first-run auth problem now reads as an auth problem, not a transport bug.

## Why a variant (not EscalationRequested)

The variant flows naturally into the existing failure-reason surfaces with no new lifecycle. EscalationRequested would be a larger change for no extra operator benefit here.

## Tests (TDD)

- `classify_prompt_error_maps_401_to_agent_auth_failed` — a 401-shaped prompt error (the exact string observed from a live `claude-agent-acp` run) maps to `AgentAuthenticationFailed`, Display carries the guidance, and the raw details are preserved.
- `classify_prompt_error_keeps_non_auth_as_bridge_error` — a non-auth error stays `Bridge(CommandSendFailed)`.

Red→green verified. `surge-acp` strict clippy (`-D warnings`) clean; 198 lib tests pass.

## Background

Found via the empirical dogfooding run in #70: the real ACP loop reaches `session/prompt` and fails only on the external 401 — but the operator-facing message was misleading. This makes that failure self-explanatory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling for authentication failures. When the agent runtime fails authentication, users now receive a specific, actionable error message instructing them to verify the agent runtime login status and API key, rather than a generic bridge communication failure.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vanyastaff/surge/pull/71?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->