### PR TITLE
feat: live budget enforcement (v0.2 M1)

### DIFF
--- a/crates/surge-cli/src/commands/engine.rs
+++ b/crates/surge-cli/src/commands/engine.rs
@@ -215,11 +215,14 @@ async fn run_command(
 
     let app_config =
         SurgeConfig::discover_from(&worktree_path).context("load surge config for worktree")?;
-    let run_config = surge_orchestrator::project_context::with_project_context_seed(
+    let mut run_config = surge_orchestrator::project_context::with_project_context_seed(
         EngineRunConfig::default(),
         &worktree_path,
         &app_config,
     );
+    // Freeze the operator's [analytics] budget into the run so the engine
+    // enforces it at every stage boundary (warn → abort by default).
+    run_config.budget = app_config.analytics.budget_guard();
 
     let handle = facade
         .start_run(run_id, graph, worktree_path, run_config)

--- a/crates/surge-core/src/budget.rs
+++ b/crates/surge-core/src/budget.rs
@@ -1,0 +1,263 @@
+//! Budget evaluation for run cost/token enforcement.
+//!
+//! Pure, deterministic comparison of accrued [`CostSummary`] against resolved
+//! [`BudgetLimits`]. The engine evaluates this at stage boundaries — where the
+//! run's cumulative cost has already been folded into run memory — and acts on
+//! the verdict (warn → notify, exceeded → escalate/abort per policy).
+//!
+//! No I/O, no wall-clock: the same `(limits, costs)` always yields the same
+//! [`BudgetVerdict`], so budget decisions replay identically.
+
+use crate::run_state::CostSummary;
+
+/// Which budget dimension a verdict refers to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BudgetDimension {
+    /// US-dollar spend.
+    Usd,
+    /// Total tokens (prompt + output).
+    Tokens,
+}
+
+/// Resolved spend limits for a run.
+///
+/// `None` on a dimension means "no limit". A non-positive `usd` or zero
+/// `tokens` limit is treated as unset (degenerate, never triggers). Override
+/// resolution (global → run → milestone) happens upstream; this type holds the
+/// already-resolved effective limits.
+#[derive(Debug, Clone, Copy, Default, PartialEq)]
+pub struct BudgetLimits {
+    /// Hard USD ceiling. `None` = unlimited.
+    pub usd: Option<f64>,
+    /// Hard token ceiling (prompt + output). `None` = unlimited.
+    pub tokens: Option<u64>,
+    /// Warn once accrued spend reaches this percentage (1–100) of a limit.
+    /// `0` disables the warn band (only `Exceeded` can fire).
+    pub warn_threshold_pct: u8,
+}
+
+/// Result of comparing accrued cost against limits.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum BudgetVerdict {
+    /// Within budget, or no effective limits set.
+    Ok,
+    /// Crossed the warn threshold on a dimension but not yet exceeded.
+    Warn {
+        /// Dimension that triggered the warning.
+        dimension: BudgetDimension,
+        /// Percentage of the limit reached, clamped to `1..=100`.
+        pct: u8,
+    },
+    /// Reached or passed a limit on a dimension.
+    Exceeded {
+        /// Dimension that was exceeded.
+        dimension: BudgetDimension,
+    },
+}
+
+impl BudgetLimits {
+    /// Whether no effective limit is set (both dimensions unset/degenerate).
+    #[must_use]
+    pub fn is_unlimited(&self) -> bool {
+        !(matches!(self.usd, Some(u) if u > 0.0) || matches!(self.tokens, Some(t) if t > 0))
+    }
+
+    /// Evaluate accrued `costs` against these limits.
+    ///
+    /// `Exceeded` takes priority over `Warn`; when both dimensions sit in the
+    /// same band, USD is reported first. Deterministic — no wall-clock, no I/O.
+    #[must_use]
+    pub fn evaluate(&self, costs: &CostSummary) -> BudgetVerdict {
+        let total_tokens = costs.tokens_in.saturating_add(costs.tokens_out);
+
+        // Exceeded — USD first, then tokens.
+        if let Some(limit) = self.usd.filter(|u| *u > 0.0)
+            && costs.cost_usd >= limit
+        {
+            return BudgetVerdict::Exceeded {
+                dimension: BudgetDimension::Usd,
+            };
+        }
+        if let Some(limit) = self.tokens.filter(|t| *t > 0)
+            && total_tokens >= limit
+        {
+            return BudgetVerdict::Exceeded {
+                dimension: BudgetDimension::Tokens,
+            };
+        }
+
+        // Warn — only when a warn band is configured.
+        let warn = u64::from(self.warn_threshold_pct.min(100));
+        if warn == 0 {
+            return BudgetVerdict::Ok;
+        }
+        if let Some(limit) = self.usd.filter(|u| *u > 0.0) {
+            let pct = usd_pct(costs.cost_usd, limit);
+            if u64::from(pct) >= warn {
+                return BudgetVerdict::Warn {
+                    dimension: BudgetDimension::Usd,
+                    pct,
+                };
+            }
+        }
+        if let Some(limit) = self.tokens.filter(|t| *t > 0) {
+            // Integer math: floor(total * 100 / limit), saturating, capped 100.
+            let pct = total_tokens.saturating_mul(100) / limit;
+            if pct >= warn {
+                return BudgetVerdict::Warn {
+                    dimension: BudgetDimension::Tokens,
+                    pct: u8::try_from(pct.min(100)).unwrap_or(100),
+                };
+            }
+        }
+        BudgetVerdict::Ok
+    }
+}
+
+/// Floored integer percentage of `spend` against a positive `limit`, capped at
+/// 100. Caller guarantees `limit > 0`; both inputs are finite.
+fn usd_pct(spend: f64, limit: f64) -> u8 {
+    let pct = (spend / limit * 100.0).floor().clamp(0.0, 100.0);
+    #[allow(
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss,
+        reason = "pct is floored and clamped to [0, 100], so the u8 cast is exact"
+    )]
+    let out = pct as u8;
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn costs(cost_usd: f64, tokens_in: u64, tokens_out: u64) -> CostSummary {
+        CostSummary {
+            tokens_in,
+            tokens_out,
+            cache_hits: 0,
+            cost_usd,
+        }
+    }
+
+    #[test]
+    fn unlimited_when_no_effective_limits() {
+        let limits = BudgetLimits::default();
+        assert!(limits.is_unlimited());
+        assert_eq!(limits.evaluate(&costs(999.0, 1_000_000, 0)), BudgetVerdict::Ok);
+    }
+
+    #[test]
+    fn non_positive_limits_are_unset() {
+        let limits = BudgetLimits {
+            usd: Some(0.0),
+            tokens: Some(0),
+            warn_threshold_pct: 80,
+        };
+        assert!(limits.is_unlimited());
+        assert_eq!(limits.evaluate(&costs(5.0, 100, 100)), BudgetVerdict::Ok);
+    }
+
+    #[test]
+    fn under_threshold_is_ok() {
+        let limits = BudgetLimits {
+            usd: Some(10.0),
+            tokens: None,
+            warn_threshold_pct: 80,
+        };
+        assert_eq!(limits.evaluate(&costs(5.0, 0, 0)), BudgetVerdict::Ok);
+    }
+
+    #[test]
+    fn usd_warn_at_threshold() {
+        let limits = BudgetLimits {
+            usd: Some(10.0),
+            tokens: None,
+            warn_threshold_pct: 80,
+        };
+        assert_eq!(
+            limits.evaluate(&costs(8.0, 0, 0)),
+            BudgetVerdict::Warn {
+                dimension: BudgetDimension::Usd,
+                pct: 80,
+            }
+        );
+    }
+
+    #[test]
+    fn usd_exceeded_at_limit() {
+        let limits = BudgetLimits {
+            usd: Some(10.0),
+            tokens: None,
+            warn_threshold_pct: 80,
+        };
+        assert_eq!(
+            limits.evaluate(&costs(10.0, 0, 0)),
+            BudgetVerdict::Exceeded {
+                dimension: BudgetDimension::Usd,
+            }
+        );
+        assert_eq!(
+            limits.evaluate(&costs(12.5, 0, 0)),
+            BudgetVerdict::Exceeded {
+                dimension: BudgetDimension::Usd,
+            }
+        );
+    }
+
+    #[test]
+    fn tokens_warn_and_exceed() {
+        let limits = BudgetLimits {
+            usd: None,
+            tokens: Some(1_000),
+            warn_threshold_pct: 90,
+        };
+        assert_eq!(limits.evaluate(&costs(0.0, 400, 400)), BudgetVerdict::Ok);
+        assert_eq!(
+            limits.evaluate(&costs(0.0, 500, 450)),
+            BudgetVerdict::Warn {
+                dimension: BudgetDimension::Tokens,
+                pct: 95,
+            }
+        );
+        assert_eq!(
+            limits.evaluate(&costs(0.0, 600, 400)),
+            BudgetVerdict::Exceeded {
+                dimension: BudgetDimension::Tokens,
+            }
+        );
+    }
+
+    #[test]
+    fn exceeded_beats_warn_and_usd_reported_first() {
+        let limits = BudgetLimits {
+            usd: Some(10.0),
+            tokens: Some(1_000),
+            warn_threshold_pct: 50,
+        };
+        // USD exceeded, tokens only warn → Exceeded(Usd).
+        assert_eq!(
+            limits.evaluate(&costs(10.0, 600, 0)),
+            BudgetVerdict::Exceeded {
+                dimension: BudgetDimension::Usd,
+            }
+        );
+    }
+
+    #[test]
+    fn warn_threshold_zero_disables_warn_band() {
+        let limits = BudgetLimits {
+            usd: Some(10.0),
+            tokens: None,
+            warn_threshold_pct: 0,
+        };
+        // 99% spend, no warn band → Ok until exceeded.
+        assert_eq!(limits.evaluate(&costs(9.9, 0, 0)), BudgetVerdict::Ok);
+        assert_eq!(
+            limits.evaluate(&costs(10.0, 0, 0)),
+            BudgetVerdict::Exceeded {
+                dimension: BudgetDimension::Usd,
+            }
+        );
+    }
+}

--- a/crates/surge-core/src/budget.rs
+++ b/crates/surge-core/src/budget.rs
@@ -26,14 +26,17 @@ pub enum BudgetDimension {
 /// `tokens` limit is treated as unset (degenerate, never triggers). Override
 /// resolution (global → run → milestone) happens upstream; this type holds the
 /// already-resolved effective limits.
-#[derive(Debug, Clone, Copy, Default, PartialEq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Serialize, Deserialize)]
 pub struct BudgetLimits {
     /// Hard USD ceiling. `None` = unlimited.
+    #[serde(default)]
     pub usd: Option<f64>,
     /// Hard token ceiling (prompt + output). `None` = unlimited.
+    #[serde(default)]
     pub tokens: Option<u64>,
     /// Warn once accrued spend reaches this percentage (1–100) of a limit.
     /// `0` disables the warn band (only `Exceeded` can fire).
+    #[serde(default)]
     pub warn_threshold_pct: u8,
 }
 
@@ -128,6 +131,94 @@ fn usd_pct(spend: f64, limit: f64) -> u8 {
     out
 }
 
+/// What the engine does when a run reaches a budget limit.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BudgetPolicy {
+    /// Stop the run on the first breach (default — the safe AFK posture: an
+    /// unattended run never overruns its budget).
+    #[default]
+    Abort,
+    /// Record warn/exceed events but never stop the run. For operators who
+    /// only want visibility, not enforcement.
+    WarnOnly,
+}
+
+/// Per-run budget configuration: the resolved limits plus the breach policy.
+/// Frozen at run start and carried on [`crate::run_event::RunConfig`]-adjacent
+/// engine config so enforcement is deterministic and replayable.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Serialize, Deserialize)]
+pub struct BudgetGuard {
+    /// Effective spend limits.
+    #[serde(default)]
+    pub limits: BudgetLimits,
+    /// Action on breach.
+    #[serde(default)]
+    pub policy: BudgetPolicy,
+}
+
+impl BudgetGuard {
+    /// Whether this guard enforces nothing (no effective limit).
+    #[must_use]
+    pub fn is_unlimited(&self) -> bool {
+        self.limits.is_unlimited()
+    }
+}
+
+/// The concrete action the engine takes at a stage boundary after evaluating
+/// the budget — the IO-free decision separated from event emission / abort.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BudgetAction {
+    /// Nothing to do — proceed to the next stage.
+    Continue,
+    /// Emit a one-time `BudgetWarningRaised` and proceed.
+    Warn {
+        /// Dimension that triggered the warning.
+        dimension: BudgetDimension,
+        /// Percentage of the limit reached (1..=100).
+        pct: u8,
+    },
+    /// Emit `BudgetExceeded` and abort the run.
+    Abort {
+        /// Dimension that was exceeded.
+        dimension: BudgetDimension,
+    },
+}
+
+/// Decide the engine action from a verdict, the policy, and whether a warning
+/// has already been raised this run. Pure and deterministic.
+///
+/// - `Ok` → `Continue`.
+/// - `Warn` → `Warn` once, then `Continue` (idempotent via `already_warned`).
+/// - `Exceeded` under `Abort` → `Abort`; under `WarnOnly` → a one-time `Warn`
+///   at 100% (visibility without stopping), then `Continue`.
+#[must_use]
+pub fn decide(verdict: BudgetVerdict, policy: BudgetPolicy, already_warned: bool) -> BudgetAction {
+    match verdict {
+        BudgetVerdict::Ok => BudgetAction::Continue,
+        BudgetVerdict::Warn { dimension, pct } => {
+            if already_warned {
+                BudgetAction::Continue
+            } else {
+                BudgetAction::Warn { dimension, pct }
+            }
+        },
+        BudgetVerdict::Exceeded { dimension } => match policy {
+            BudgetPolicy::Abort => BudgetAction::Abort { dimension },
+            BudgetPolicy::WarnOnly => {
+                if already_warned {
+                    BudgetAction::Continue
+                } else {
+                    BudgetAction::Warn {
+                        dimension,
+                        pct: 100,
+                    }
+                }
+            },
+        },
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -145,7 +236,10 @@ mod tests {
     fn unlimited_when_no_effective_limits() {
         let limits = BudgetLimits::default();
         assert!(limits.is_unlimited());
-        assert_eq!(limits.evaluate(&costs(999.0, 1_000_000, 0)), BudgetVerdict::Ok);
+        assert_eq!(
+            limits.evaluate(&costs(999.0, 1_000_000, 0)),
+            BudgetVerdict::Ok
+        );
     }
 
     #[test]
@@ -260,5 +354,74 @@ mod tests {
                 dimension: BudgetDimension::Usd,
             }
         );
+    }
+
+    #[test]
+    fn decide_ok_continues() {
+        assert_eq!(
+            decide(BudgetVerdict::Ok, BudgetPolicy::Abort, false),
+            BudgetAction::Continue
+        );
+    }
+
+    #[test]
+    fn decide_warn_fires_once_then_continues() {
+        let verdict = BudgetVerdict::Warn {
+            dimension: BudgetDimension::Usd,
+            pct: 85,
+        };
+        assert_eq!(
+            decide(verdict, BudgetPolicy::Abort, false),
+            BudgetAction::Warn {
+                dimension: BudgetDimension::Usd,
+                pct: 85,
+            }
+        );
+        // Already warned → no repeat.
+        assert_eq!(
+            decide(verdict, BudgetPolicy::Abort, true),
+            BudgetAction::Continue
+        );
+    }
+
+    #[test]
+    fn decide_exceeded_aborts_under_abort_policy() {
+        assert_eq!(
+            decide(
+                BudgetVerdict::Exceeded {
+                    dimension: BudgetDimension::Tokens,
+                },
+                BudgetPolicy::Abort,
+                false,
+            ),
+            BudgetAction::Abort {
+                dimension: BudgetDimension::Tokens,
+            }
+        );
+    }
+
+    #[test]
+    fn decide_exceeded_warns_once_under_warn_only() {
+        let verdict = BudgetVerdict::Exceeded {
+            dimension: BudgetDimension::Usd,
+        };
+        assert_eq!(
+            decide(verdict, BudgetPolicy::WarnOnly, false),
+            BudgetAction::Warn {
+                dimension: BudgetDimension::Usd,
+                pct: 100,
+            }
+        );
+        assert_eq!(
+            decide(verdict, BudgetPolicy::WarnOnly, true),
+            BudgetAction::Continue
+        );
+    }
+
+    #[test]
+    fn guard_default_is_unlimited_abort() {
+        let g = BudgetGuard::default();
+        assert!(g.is_unlimited());
+        assert_eq!(g.policy, BudgetPolicy::Abort);
     }
 }

--- a/crates/surge-core/src/budget.rs
+++ b/crates/surge-core/src/budget.rs
@@ -13,6 +13,7 @@ use serde::{Deserialize, Serialize};
 
 /// Which budget dimension a verdict refers to.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum BudgetDimension {
     /// US-dollar spend.
     Usd,
@@ -139,8 +140,10 @@ pub enum BudgetPolicy {
     /// unattended run never overruns its budget).
     #[default]
     Abort,
-    /// Record warn/exceed events but never stop the run. For operators who
-    /// only want visibility, not enforcement.
+    /// Never stop the run. Emit a one-time `BudgetWarningRaised` when a limit
+    /// is reached (at the warn threshold) or exceeded (reported at 100%); no
+    /// `BudgetExceeded` event and no abort. For operators who want visibility,
+    /// not enforcement.
     WarnOnly,
 }
 

--- a/crates/surge-core/src/budget.rs
+++ b/crates/surge-core/src/budget.rs
@@ -9,9 +9,10 @@
 //! [`BudgetVerdict`], so budget decisions replay identically.
 
 use crate::run_state::CostSummary;
+use serde::{Deserialize, Serialize};
 
 /// Which budget dimension a verdict refers to.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum BudgetDimension {
     /// US-dollar spend.
     Usd,

--- a/crates/surge-core/src/budget.rs
+++ b/crates/surge-core/src/budget.rs
@@ -181,6 +181,12 @@ pub enum BudgetAction {
         /// Percentage of the limit reached (1..=100).
         pct: u8,
     },
+    /// Emit a one-time `BudgetExceeded` and proceed (the `WarnOnly` breach
+    /// record — surfaces the actual limit crossing without stopping the run).
+    NoteExceeded {
+        /// Dimension that was exceeded.
+        dimension: BudgetDimension,
+    },
     /// Emit `BudgetExceeded` and abort the run.
     Abort {
         /// Dimension that was exceeded.
@@ -188,15 +194,26 @@ pub enum BudgetAction {
     },
 }
 
-/// Decide the engine action from a verdict, the policy, and whether a warning
-/// has already been raised this run. Pure and deterministic.
+/// Decide the engine action from a verdict, the policy, and the run's
+/// idempotency state. Pure and deterministic.
+///
+/// Threshold warnings and breach records carry **separate** idempotency
+/// (`already_warned` vs `already_exceeded`) so a `WarnOnly` run that first
+/// warns at the threshold still records the actual breach exactly once when it
+/// later crosses the hard limit.
 ///
 /// - `Ok` → `Continue`.
-/// - `Warn` → `Warn` once, then `Continue` (idempotent via `already_warned`).
-/// - `Exceeded` under `Abort` → `Abort`; under `WarnOnly` → a one-time `Warn`
-///   at 100% (visibility without stopping), then `Continue`.
+/// - `Warn` → `Warn` once (via `already_warned`), then `Continue`.
+/// - `Exceeded` under `Abort` → `Abort` (the run ends, so idempotency is moot).
+/// - `Exceeded` under `WarnOnly` → `NoteExceeded` once (via `already_exceeded`),
+///   then `Continue` — independent of any earlier threshold warning.
 #[must_use]
-pub fn decide(verdict: BudgetVerdict, policy: BudgetPolicy, already_warned: bool) -> BudgetAction {
+pub fn decide(
+    verdict: BudgetVerdict,
+    policy: BudgetPolicy,
+    already_warned: bool,
+    already_exceeded: bool,
+) -> BudgetAction {
     match verdict {
         BudgetVerdict::Ok => BudgetAction::Continue,
         BudgetVerdict::Warn { dimension, pct } => {
@@ -209,13 +226,10 @@ pub fn decide(verdict: BudgetVerdict, policy: BudgetPolicy, already_warned: bool
         BudgetVerdict::Exceeded { dimension } => match policy {
             BudgetPolicy::Abort => BudgetAction::Abort { dimension },
             BudgetPolicy::WarnOnly => {
-                if already_warned {
+                if already_exceeded {
                     BudgetAction::Continue
                 } else {
-                    BudgetAction::Warn {
-                        dimension,
-                        pct: 100,
-                    }
+                    BudgetAction::NoteExceeded { dimension }
                 }
             },
         },
@@ -362,7 +376,7 @@ mod tests {
     #[test]
     fn decide_ok_continues() {
         assert_eq!(
-            decide(BudgetVerdict::Ok, BudgetPolicy::Abort, false),
+            decide(BudgetVerdict::Ok, BudgetPolicy::Abort, false, false),
             BudgetAction::Continue
         );
     }
@@ -374,7 +388,7 @@ mod tests {
             pct: 85,
         };
         assert_eq!(
-            decide(verdict, BudgetPolicy::Abort, false),
+            decide(verdict, BudgetPolicy::Abort, false, false),
             BudgetAction::Warn {
                 dimension: BudgetDimension::Usd,
                 pct: 85,
@@ -382,7 +396,7 @@ mod tests {
         );
         // Already warned → no repeat.
         assert_eq!(
-            decide(verdict, BudgetPolicy::Abort, true),
+            decide(verdict, BudgetPolicy::Abort, true, false),
             BudgetAction::Continue
         );
     }
@@ -396,6 +410,7 @@ mod tests {
                 },
                 BudgetPolicy::Abort,
                 false,
+                false,
             ),
             BudgetAction::Abort {
                 dimension: BudgetDimension::Tokens,
@@ -404,19 +419,21 @@ mod tests {
     }
 
     #[test]
-    fn decide_exceeded_warns_once_under_warn_only() {
+    fn decide_warn_only_records_breach_once_independent_of_warn() {
         let verdict = BudgetVerdict::Exceeded {
             dimension: BudgetDimension::Usd,
         };
+        // Even after an earlier threshold warning (already_warned = true), a
+        // breach still surfaces once via NoteExceeded.
         assert_eq!(
-            decide(verdict, BudgetPolicy::WarnOnly, false),
-            BudgetAction::Warn {
+            decide(verdict, BudgetPolicy::WarnOnly, true, false),
+            BudgetAction::NoteExceeded {
                 dimension: BudgetDimension::Usd,
-                pct: 100,
             }
         );
+        // Already recorded the breach → no repeat.
         assert_eq!(
-            decide(verdict, BudgetPolicy::WarnOnly, true),
+            decide(verdict, BudgetPolicy::WarnOnly, true, true),
             BudgetAction::Continue
         );
     }

--- a/crates/surge-core/src/config.rs
+++ b/crates/surge-core/src/config.rs
@@ -93,6 +93,25 @@ impl Default for AnalyticsConfig {
     }
 }
 
+impl AnalyticsConfig {
+    /// Resolve the live-enforcement budget guard from the configured limits.
+    ///
+    /// The breach policy defaults to [`crate::budget::BudgetPolicy::Abort`]
+    /// (the safe AFK posture). When neither `budget_usd` nor `budget_tokens`
+    /// is set the guard is unlimited and the engine skips enforcement.
+    #[must_use]
+    pub fn budget_guard(&self) -> crate::budget::BudgetGuard {
+        crate::budget::BudgetGuard {
+            limits: crate::budget::BudgetLimits {
+                usd: self.budget_usd,
+                tokens: self.budget_tokens,
+                warn_threshold_pct: self.budget_warn_threshold,
+            },
+            policy: crate::budget::BudgetPolicy::default(),
+        }
+    }
+}
+
 fn default_budget_warn_threshold() -> u8 {
     80
 }
@@ -2023,6 +2042,28 @@ url = "ws://localhost:8080"
         let pipeline = PipelineConfig::default();
         assert!(pipeline.max_cost_usd.is_none());
         assert!(pipeline.max_tokens.is_none());
+    }
+
+    #[test]
+    fn analytics_budget_guard_default_is_unlimited() {
+        let guard = AnalyticsConfig::default().budget_guard();
+        assert!(guard.is_unlimited());
+        assert_eq!(guard.policy, crate::budget::BudgetPolicy::Abort);
+    }
+
+    #[test]
+    fn analytics_budget_guard_resolves_limits() {
+        let analytics = AnalyticsConfig {
+            budget_usd: Some(25.0),
+            budget_tokens: Some(500_000),
+            budget_warn_threshold: 75,
+            ..AnalyticsConfig::default()
+        };
+        let guard = analytics.budget_guard();
+        assert!(!guard.is_unlimited());
+        assert_eq!(guard.limits.usd, Some(25.0));
+        assert_eq!(guard.limits.tokens, Some(500_000));
+        assert_eq!(guard.limits.warn_threshold_pct, 75);
     }
 
     #[test]

--- a/crates/surge-core/src/lib.rs
+++ b/crates/surge-core/src/lib.rs
@@ -36,6 +36,7 @@ pub mod approvals;
 pub mod archetype;
 pub mod artifact_contract;
 pub mod branch_config;
+pub mod budget;
 pub mod bundled_flows;
 pub mod content_hash;
 pub mod doctor;

--- a/crates/surge-core/src/migrations/mod.rs
+++ b/crates/surge-core/src/migrations/mod.rs
@@ -31,7 +31,14 @@ pub const MIN_SUPPORTED_VERSION: u32 = 1;
 /// unchanged (same JSON wrapper); old v1/v2 payloads decode cleanly with
 /// `mcp_server: None`. Per the v2 precedent the version is still bumped so
 /// readers know per-server attribution is in scope.
-pub const MAX_SUPPORTED_VERSION: u32 = 3;
+///
+/// **v4 (introduced 2026-05):** adds the [`EventPayload::BudgetWarningRaised`]
+/// and [`EventPayload::BudgetExceeded`] variants (live budget enforcement).
+/// Purely additive — old v1/v2/v3 payloads decode cleanly (they never contain
+/// the new variants). The version is bumped so a v3-max reader rejects a
+/// budget event with a clean [`SurgeError::SchemaTooNew`] rather than an
+/// unknown-variant decode error.
+pub const MAX_SUPPORTED_VERSION: u32 = 4;
 
 /// Single schema-version translator.
 pub trait Migration: Send + Sync {
@@ -103,6 +110,27 @@ impl Migration for IdentityV3 {
     }
 }
 
+/// Identity migration for v4 — the schema bump that introduced the
+/// `BudgetWarningRaised` / `BudgetExceeded` variants (live budget
+/// enforcement). The wire shape is unchanged (same JSON-encoded
+/// [`VersionedEventPayload`] wrapper); old payloads decode cleanly because
+/// they never carry the new variants. The `schema_version` field is the only
+/// signal that distinguishes v1/v2/v3 from v4 payloads.
+#[derive(Debug, Default, Copy, Clone)]
+pub struct IdentityV4;
+
+impl Migration for IdentityV4 {
+    fn version(&self) -> u32 {
+        4
+    }
+
+    fn migrate(&self, bytes: &[u8]) -> Result<EventPayload, SurgeError> {
+        let wrapper: VersionedEventPayload = serde_json::from_slice(bytes)
+            .map_err(|e| SurgeError::Spec(format!("v4 payload decode failed: {e}")))?;
+        Ok(wrapper.payload)
+    }
+}
+
 /// Ordered registry of [`Migration`]s indexed by their declared version.
 pub struct MigrationChain {
     migrations: Vec<Box<dyn Migration>>,
@@ -110,7 +138,7 @@ pub struct MigrationChain {
 
 impl MigrationChain {
     /// Build the default chain. Contains [`IdentityV1`], [`IdentityV2`],
-    /// and [`IdentityV3`].
+    /// [`IdentityV3`], and [`IdentityV4`].
     #[must_use]
     pub fn new() -> Self {
         Self {
@@ -118,6 +146,7 @@ impl MigrationChain {
                 Box::new(IdentityV1),
                 Box::new(IdentityV2),
                 Box::new(IdentityV3),
+                Box::new(IdentityV4),
             ],
         }
     }
@@ -226,7 +255,7 @@ mod tests {
             elapsed_seconds: 30,
         });
         assert_eq!(wrapper.schema_version, MAX_SUPPORTED_VERSION);
-        assert_eq!(wrapper.schema_version, 3);
+        assert_eq!(wrapper.schema_version, 4);
     }
 
     #[test]
@@ -234,8 +263,20 @@ mod tests {
         let err = migrate_payload(99, b"{}").unwrap_err();
         assert!(matches!(
             err,
-            SurgeError::SchemaTooNew { found: 99, max: 3 }
+            SurgeError::SchemaTooNew { found: 99, max: 4 }
         ));
+    }
+
+    #[test]
+    fn v4_budget_event_round_trips() {
+        let payload = EventPayload::BudgetExceeded {
+            dimension: crate::budget::BudgetDimension::Tokens,
+            cost_usd: 0.0,
+            total_tokens: 1_500_000,
+        };
+        let bytes = serde_json::to_vec(&VersionedEventPayload::new(payload.clone())).unwrap();
+        let decoded = migrate_payload(MAX_SUPPORTED_VERSION, &bytes).unwrap();
+        assert_eq!(decoded, payload);
     }
 
     #[test]

--- a/crates/surge-core/src/run_event.rs
+++ b/crates/surge-core/src/run_event.rs
@@ -326,7 +326,7 @@ pub enum EventPayload {
     },
     /// A run's cumulative spend crossed the configured warn threshold on a
     /// budget dimension at a stage boundary. Advisory — the run continues.
-    /// Recorded once per threshold crossing (idempotent re-evaluation). Schema v3.
+    /// Recorded once per threshold crossing (idempotent re-evaluation). Schema v4.
     BudgetWarningRaised {
         /// Which limit was approached.
         dimension: crate::budget::BudgetDimension,
@@ -338,8 +338,8 @@ pub enum EventPayload {
         total_tokens: u64,
     },
     /// A run's cumulative spend reached or passed a budget limit at a stage
-    /// boundary. The engine acts per the run's budget policy (escalate via
-    /// `request_human_input`, or abort). Schema v3.
+    /// boundary. Under the `Abort` policy the engine appends `RunAborted`
+    /// immediately after this event; under `WarnOnly` it is advisory. Schema v4.
     BudgetExceeded {
         /// Which limit was exceeded.
         dimension: crate::budget::BudgetDimension,

--- a/crates/surge-core/src/run_event.rs
+++ b/crates/surge-core/src/run_event.rs
@@ -324,6 +324,30 @@ pub enum EventPayload {
         model: String,
         cost_usd: Option<f64>,
     },
+    /// A run's cumulative spend crossed the configured warn threshold on a
+    /// budget dimension at a stage boundary. Advisory — the run continues.
+    /// Recorded once per threshold crossing (idempotent re-evaluation). Schema v3.
+    BudgetWarningRaised {
+        /// Which limit was approached.
+        dimension: crate::budget::BudgetDimension,
+        /// Percentage of the limit reached (1..=100).
+        pct: u8,
+        /// Cumulative USD spend at the time of the warning.
+        cost_usd: f64,
+        /// Cumulative tokens (prompt + output) at the time of the warning.
+        total_tokens: u64,
+    },
+    /// A run's cumulative spend reached or passed a budget limit at a stage
+    /// boundary. The engine acts per the run's budget policy (escalate via
+    /// `request_human_input`, or abort). Schema v3.
+    BudgetExceeded {
+        /// Which limit was exceeded.
+        dimension: crate::budget::BudgetDimension,
+        /// Cumulative USD spend at the time of the breach.
+        cost_usd: f64,
+        /// Cumulative tokens (prompt + output) at the time of the breach.
+        total_tokens: u64,
+    },
     ForkCreated {
         new_run: RunId,
         fork_at_seq: u64,
@@ -465,6 +489,8 @@ impl EventPayload {
             Self::HookExecuted { .. } => "HookExecuted",
             Self::OutcomeRejectedByHook { .. } => "OutcomeRejectedByHook",
             Self::TokensConsumed { .. } => "TokensConsumed",
+            Self::BudgetWarningRaised { .. } => "BudgetWarningRaised",
+            Self::BudgetExceeded { .. } => "BudgetExceeded",
             Self::HumanInputRequested { .. } => "HumanInputRequested",
             Self::HumanInputResolved { .. } => "HumanInputResolved",
             Self::HumanInputTimedOut { .. } => "HumanInputTimedOut",
@@ -1092,6 +1118,44 @@ mod tests {
             error: Some("test".into()),
         };
         assert_eq!(p2.discriminant_str(), "NotifyDelivered");
+
+        let p3 = EventPayload::BudgetWarningRaised {
+            dimension: crate::budget::BudgetDimension::Usd,
+            pct: 80,
+            cost_usd: 8.0,
+            total_tokens: 1_000,
+        };
+        assert_eq!(p3.discriminant_str(), "BudgetWarningRaised");
+
+        let p4 = EventPayload::BudgetExceeded {
+            dimension: crate::budget::BudgetDimension::Tokens,
+            cost_usd: 12.5,
+            total_tokens: 5_000,
+        };
+        assert_eq!(p4.discriminant_str(), "BudgetExceeded");
+    }
+
+    #[test]
+    fn budget_events_roundtrip() {
+        for payload in [
+            EventPayload::BudgetWarningRaised {
+                dimension: crate::budget::BudgetDimension::Usd,
+                pct: 90,
+                cost_usd: 9.0,
+                total_tokens: 4_200,
+            },
+            EventPayload::BudgetExceeded {
+                dimension: crate::budget::BudgetDimension::Tokens,
+                cost_usd: 1.5,
+                total_tokens: 10_000,
+            },
+        ] {
+            let wrapped = VersionedEventPayload::new(payload.clone());
+            let bytes = serde_json::to_vec(&wrapped).unwrap();
+            let parsed: VersionedEventPayload = serde_json::from_slice(&bytes).unwrap();
+            assert_eq!(wrapped, parsed);
+            assert_eq!(parsed.payload, payload);
+        }
     }
 
     #[test]

--- a/crates/surge-core/src/run_state.rs
+++ b/crates/surge-core/src/run_state.rs
@@ -90,6 +90,10 @@ pub struct RunMemory {
     /// most once per run — and, because it is derived from the event log,
     /// survives a daemon restart / resume (the warning is not re-emitted).
     pub budget_warning_raised: bool,
+    /// Whether a `BudgetExceeded` has been folded for this run. Gates the
+    /// `WarnOnly` breach record so the hard-limit crossing is surfaced exactly
+    /// once (separate from the threshold warning) and is resume-safe.
+    pub budget_exceeded_noted: bool,
     /// Per-bootstrap-stage edit-loop counter. Incremented on every
     /// `BootstrapEditRequested` event. Read by the bootstrap HumanGate
     /// handler to enforce `EngineRunConfig.bootstrap.edit_loop_cap`.
@@ -630,6 +634,9 @@ impl RunMemory {
             },
             EventPayload::BudgetWarningRaised { .. } => {
                 self.budget_warning_raised = true;
+            },
+            EventPayload::BudgetExceeded { .. } => {
+                self.budget_exceeded_noted = true;
             },
             EventPayload::BootstrapEditRequested { stage, feedback } => {
                 *self.bootstrap_edit_counts.entry(*stage).or_insert(0) += 1;

--- a/crates/surge-core/src/run_state.rs
+++ b/crates/surge-core/src/run_state.rs
@@ -85,6 +85,11 @@ pub struct RunMemory {
     pub artifacts_by_node: BTreeMap<NodeKey, Vec<ArtifactRef>>,
     pub outcomes: BTreeMap<NodeKey, Vec<OutcomeRecord>>,
     pub costs: CostSummary,
+    /// Whether a `BudgetWarningRaised` has been folded for this run. Set once
+    /// and never cleared, so the engine's stage-boundary budget check warns at
+    /// most once per run — and, because it is derived from the event log,
+    /// survives a daemon restart / resume (the warning is not re-emitted).
+    pub budget_warning_raised: bool,
     /// Per-bootstrap-stage edit-loop counter. Incremented on every
     /// `BootstrapEditRequested` event. Read by the bootstrap HumanGate
     /// handler to enforce `EngineRunConfig.bootstrap.edit_loop_cap`.
@@ -623,6 +628,9 @@ impl RunMemory {
                 self.costs.cache_hits += u64::from(*cache_hits);
                 self.costs.cost_usd += cost_usd.unwrap_or(0.0);
             },
+            EventPayload::BudgetWarningRaised { .. } => {
+                self.budget_warning_raised = true;
+            },
             EventPayload::BootstrapEditRequested { stage, feedback } => {
                 *self.bootstrap_edit_counts.entry(*stage).or_insert(0) += 1;
                 self.last_edit_feedback_by_stage
@@ -981,6 +989,25 @@ mod tests {
         assert_eq!(m.costs.tokens_in, 0);
         assert!(m.bootstrap_edit_counts.is_empty());
         assert!(m.node_visits.is_empty());
+        assert!(!m.budget_warning_raised);
+    }
+
+    #[test]
+    fn budget_warning_raised_folds_into_memory_flag() {
+        // The flag is derived from the event log so a resumed run does not
+        // re-emit a warning it already recorded (warn-once idempotency).
+        let mut m = RunMemory::default();
+        assert!(!m.budget_warning_raised);
+        m.apply_event(&make_event(
+            1,
+            EventPayload::BudgetWarningRaised {
+                dimension: crate::budget::BudgetDimension::Tokens,
+                pct: 80,
+                cost_usd: 0.0,
+                total_tokens: 800_000,
+            },
+        ));
+        assert!(m.budget_warning_raised);
     }
 
     #[test]

--- a/crates/surge-core/tests/snapshots/fold_hook_events__fold_hook_events_memory.snap
+++ b/crates/surge-core/tests/snapshots/fold_hook_events__fold_hook_events_memory.snap
@@ -26,6 +26,8 @@ RunMemory {
         cache_hits: 0,
         cost_usd: 0.0,
     },
+    budget_warning_raised: false,
+    budget_exceeded_noted: false,
     bootstrap_edit_counts: {},
     node_visits: {},
     last_edit_feedback_by_stage: {},

--- a/crates/surge-orchestrator/src/engine/config.rs
+++ b/crates/surge-orchestrator/src/engine/config.rs
@@ -87,6 +87,13 @@ pub struct EngineRunConfig {
     /// bootstrap graph; non-bootstrap runs ignore the section entirely.
     #[serde(default)]
     pub bootstrap: BootstrapRunConfig,
+    /// Live budget enforcement: resolved spend limits + breach policy, frozen
+    /// at run start. Default is unlimited (no enforcement); the CLI/daemon
+    /// populates it from the `[analytics]` budget settings in `surge.toml`.
+    /// The engine evaluates it at every stage boundary against the run's
+    /// folded cumulative cost.
+    #[serde(default)]
+    pub budget: surge_core::budget::BudgetGuard,
 }
 
 /// Stable project context input copied into a run's artifact store.
@@ -187,6 +194,7 @@ impl Default for EngineRunConfig {
             project_context: None,
             seed_artifacts: Vec::new(),
             bootstrap: BootstrapRunConfig::default(),
+            budget: surge_core::budget::BudgetGuard::default(),
         }
     }
 }
@@ -239,6 +247,7 @@ mod tests {
             project_context: None,
             seed_artifacts: Vec::new(),
             bootstrap: BootstrapRunConfig::default(),
+            budget: surge_core::budget::BudgetGuard::default(),
         };
         let json = serde_json::to_string(&cfg).unwrap();
         let parsed: EngineRunConfig = serde_json::from_str(&json).unwrap();
@@ -269,6 +278,7 @@ mod tests {
             project_context: None,
             seed_artifacts: Vec::new(),
             bootstrap: BootstrapRunConfig::default(),
+            budget: surge_core::budget::BudgetGuard::default(),
         };
         let json = serde_json::to_string(&cfg).unwrap();
         let parsed: EngineRunConfig = serde_json::from_str(&json).unwrap();
@@ -313,6 +323,7 @@ mod tests {
             project_context: None,
             seed_artifacts: Vec::new(),
             bootstrap: BootstrapRunConfig { edit_loop_cap: 5 },
+            budget: surge_core::budget::BudgetGuard::default(),
         };
         let json = serde_json::to_string(&cfg).unwrap();
         let parsed: EngineRunConfig = serde_json::from_str(&json).unwrap();

--- a/crates/surge-orchestrator/src/engine/run_task.rs
+++ b/crates/surge-orchestrator/src/engine/run_task.rs
@@ -190,25 +190,39 @@ async fn execute_inner(mut params: RunTaskParams) -> RunOutcome {
         // Stage boundary: the just-completed stage's token usage has been
         // folded into `state.memory.costs` by `route_and_snapshot`. Enforce the
         // run's budget here — warn once at the threshold, abort on breach.
-        if let Some(outcome) = enforce_budget(&params, &mut state).await {
-            return outcome;
+        // A failure to durably record an abort decision is fatal (the run must
+        // never terminate without a persisted reason).
+        match enforce_budget(&params, &mut state).await {
+            Ok(Some(outcome)) => return outcome,
+            Ok(None) => {},
+            Err(error) => return failed(&params, error).await,
         }
     }
 }
 
-/// Evaluate the run budget against the freshly-folded cumulative cost and act:
-/// emit a one-time `BudgetWarningRaised`, or emit `BudgetExceeded` and abort.
-/// Returns `Some(outcome)` only when the run must terminate. No-op (and no
-/// event-log churn) when the run is unlimited or within budget.
+/// Evaluate the run budget against the freshly-folded cumulative cost and act.
+///
+/// Returns:
+/// - `Ok(None)` to continue (within budget, unlimited, or after recording an
+///   advisory warn/breach under `WarnOnly`).
+/// - `Ok(Some(outcome))` when an `Abort`-policy breach durably terminated the
+///   run.
+/// - `Err(reason)` when a **mandatory** abort write (`BudgetExceeded` /
+///   `RunAborted`) failed to persist — the caller turns this into a hard run
+///   failure so the run never terminates without a durable, replayable record.
+///
+/// Advisory writes (the threshold warning, and the `WarnOnly` breach record)
+/// are best-effort: on append failure the flag is left unset so the next stage
+/// boundary retries, rather than failing an otherwise-healthy run.
 async fn enforce_budget(
     params: &RunTaskParams,
     state: &mut RunExecutionState,
-) -> Option<RunOutcome> {
+) -> Result<Option<RunOutcome>, String> {
     use surge_core::budget::{BudgetAction, decide};
 
     let guard = params.run_config.budget;
     if guard.is_unlimited() {
-        return None;
+        return Ok(None);
     }
 
     let cost_usd = state.memory.costs.cost_usd;
@@ -219,10 +233,18 @@ async fn enforce_budget(
         .saturating_add(state.memory.costs.tokens_out);
     let verdict = guard.limits.evaluate(&state.memory.costs);
 
-    match decide(verdict, guard.policy, state.budget_warned) {
-        BudgetAction::Continue => None,
+    match decide(
+        verdict,
+        guard.policy,
+        state.budget_warned,
+        state.budget_exceeded_noted,
+    ) {
+        BudgetAction::Continue => Ok(None),
         BudgetAction::Warn { dimension, pct } => {
-            let appended = params
+            // Advisory: on a failed append leave the flag unset so the next
+            // boundary retries, rather than losing the warning and silencing
+            // all future ones.
+            if let Err(error) = params
                 .writer
                 .append_event(VersionedEventPayload::new(
                     EventPayload::BudgetWarningRaised {
@@ -232,19 +254,15 @@ async fn enforce_budget(
                         total_tokens,
                     },
                 ))
-                .await;
-            // Only suppress future warnings once the event is durably in the
-            // log — otherwise a failed append both loses the warning and (if we
-            // flipped the flag) silences every later one. On failure leave the
-            // flag unset so the next stage boundary retries.
-            if let Err(error) = appended {
+                .await
+            {
                 tracing::warn!(
                     target: "engine::budget",
                     run_id = %params.run_id,
                     %error,
                     "failed to append BudgetWarningRaised; will retry at next boundary"
                 );
-                return None;
+                return Ok(None);
             }
             state.budget_warned = true;
             tracing::warn!(
@@ -256,26 +274,60 @@ async fn enforce_budget(
                 total_tokens,
                 "run budget warning threshold crossed"
             );
-            None
+            Ok(None)
         },
-        BudgetAction::Abort { dimension } => {
-            let _ = params
+        BudgetAction::NoteExceeded { dimension } => {
+            // WarnOnly breach record — advisory, same retry-on-failure posture.
+            if let Err(error) = params
                 .writer
                 .append_event(VersionedEventPayload::new(EventPayload::BudgetExceeded {
                     dimension,
                     cost_usd,
                     total_tokens,
                 }))
-                .await;
+                .await
+            {
+                tracing::warn!(
+                    target: "engine::budget",
+                    run_id = %params.run_id,
+                    %error,
+                    "failed to append BudgetExceeded (warn-only); will retry at next boundary"
+                );
+                return Ok(None);
+            }
+            state.budget_exceeded_noted = true;
+            tracing::warn!(
+                target: "engine::budget",
+                run_id = %params.run_id,
+                ?dimension,
+                cost_usd,
+                total_tokens,
+                "run budget exceeded (warn-only policy; run continues)"
+            );
+            Ok(None)
+        },
+        BudgetAction::Abort { dimension } => {
+            // Mandatory: the breach record and the terminal abort MUST be
+            // durable, or replay/audit cannot explain why the run stopped.
+            params
+                .writer
+                .append_event(VersionedEventPayload::new(EventPayload::BudgetExceeded {
+                    dimension,
+                    cost_usd,
+                    total_tokens,
+                }))
+                .await
+                .map_err(|e| format!("persist BudgetExceeded for abort: {e}"))?;
             let reason = format!(
                 "budget exceeded ({dimension:?}): cost=${cost_usd:.4}, tokens={total_tokens}"
             );
-            let _ = params
+            params
                 .writer
                 .append_event(VersionedEventPayload::new(EventPayload::RunAborted {
                     reason: reason.clone(),
                 }))
-                .await;
+                .await
+                .map_err(|e| format!("persist RunAborted for budget breach: {e}"))?;
             tracing::warn!(
                 target: "engine::budget",
                 run_id = %params.run_id,
@@ -288,7 +340,7 @@ async fn enforce_budget(
             let _ = params.event_tx.send(EngineRunEvent::Terminal {
                 outcome: outcome.clone(),
             });
-            Some(outcome)
+            Ok(Some(outcome))
         },
     }
 }
@@ -307,6 +359,9 @@ struct RunExecutionState {
     /// Whether a `BudgetWarningRaised` has already been emitted this run, so the
     /// warn band fires at most once per run (idempotent re-evaluation).
     budget_warned: bool,
+    /// Whether a `BudgetExceeded` has already been recorded this run, so the
+    /// `WarnOnly` breach record fires at most once (separate from the warn).
+    budget_exceeded_noted: bool,
 }
 
 async fn initial_execution_state(params: &RunTaskParams) -> Result<RunExecutionState, String> {
@@ -327,9 +382,11 @@ async fn initial_execution_state(params: &RunTaskParams) -> Result<RunExecutionS
             .await
             .map_err(|e| format!("load pending graph revisions: {e}"))?;
 
-    // Seed the warn-once flag from the folded event log so a resumed run does
-    // not re-emit a `BudgetWarningRaised` it already recorded before a restart.
+    // Seed the warn-once / breach-once flags from the folded event log so a
+    // resumed run does not re-emit a `BudgetWarningRaised` / `BudgetExceeded`
+    // it already recorded before a restart.
     let budget_warned = memory.budget_warning_raised;
+    let budget_exceeded_noted = memory.budget_exceeded_noted;
 
     Ok(RunExecutionState {
         active_graph,
@@ -346,6 +403,7 @@ async fn initial_execution_state(params: &RunTaskParams) -> Result<RunExecutionS
         pending_graph_revisions,
         pending_elevations: params.pending_elevations.clone(),
         budget_warned,
+        budget_exceeded_noted,
     })
 }
 

--- a/crates/surge-orchestrator/src/engine/run_task.rs
+++ b/crates/surge-orchestrator/src/engine/run_task.rs
@@ -222,7 +222,7 @@ async fn enforce_budget(
     match decide(verdict, guard.policy, state.budget_warned) {
         BudgetAction::Continue => None,
         BudgetAction::Warn { dimension, pct } => {
-            let _ = params
+            let appended = params
                 .writer
                 .append_event(VersionedEventPayload::new(
                     EventPayload::BudgetWarningRaised {
@@ -233,6 +233,19 @@ async fn enforce_budget(
                     },
                 ))
                 .await;
+            // Only suppress future warnings once the event is durably in the
+            // log — otherwise a failed append both loses the warning and (if we
+            // flipped the flag) silences every later one. On failure leave the
+            // flag unset so the next stage boundary retries.
+            if let Err(error) = appended {
+                tracing::warn!(
+                    target: "engine::budget",
+                    run_id = %params.run_id,
+                    %error,
+                    "failed to append BudgetWarningRaised; will retry at next boundary"
+                );
+                return None;
+            }
             state.budget_warned = true;
             tracing::warn!(
                 target: "engine::budget",
@@ -314,6 +327,10 @@ async fn initial_execution_state(params: &RunTaskParams) -> Result<RunExecutionS
             .await
             .map_err(|e| format!("load pending graph revisions: {e}"))?;
 
+    // Seed the warn-once flag from the folded event log so a resumed run does
+    // not re-emit a `BudgetWarningRaised` it already recorded before a restart.
+    let budget_warned = memory.budget_warning_raised;
+
     Ok(RunExecutionState {
         active_graph,
         cursor,
@@ -328,7 +345,7 @@ async fn initial_execution_state(params: &RunTaskParams) -> Result<RunExecutionS
         processed_graph_revision_seq: applied_graph_revision_seq,
         pending_graph_revisions,
         pending_elevations: params.pending_elevations.clone(),
-        budget_warned: false,
+        budget_warned,
     })
 }
 

--- a/crates/surge-orchestrator/src/engine/run_task.rs
+++ b/crates/surge-orchestrator/src/engine/run_task.rs
@@ -186,6 +186,97 @@ async fn execute_inner(mut params: RunTaskParams) -> RunOutcome {
                 }
             },
         }
+
+        // Stage boundary: the just-completed stage's token usage has been
+        // folded into `state.memory.costs` by `route_and_snapshot`. Enforce the
+        // run's budget here — warn once at the threshold, abort on breach.
+        if let Some(outcome) = enforce_budget(&params, &mut state).await {
+            return outcome;
+        }
+    }
+}
+
+/// Evaluate the run budget against the freshly-folded cumulative cost and act:
+/// emit a one-time `BudgetWarningRaised`, or emit `BudgetExceeded` and abort.
+/// Returns `Some(outcome)` only when the run must terminate. No-op (and no
+/// event-log churn) when the run is unlimited or within budget.
+async fn enforce_budget(
+    params: &RunTaskParams,
+    state: &mut RunExecutionState,
+) -> Option<RunOutcome> {
+    use surge_core::budget::{BudgetAction, decide};
+
+    let guard = params.run_config.budget;
+    if guard.is_unlimited() {
+        return None;
+    }
+
+    let cost_usd = state.memory.costs.cost_usd;
+    let total_tokens = state
+        .memory
+        .costs
+        .tokens_in
+        .saturating_add(state.memory.costs.tokens_out);
+    let verdict = guard.limits.evaluate(&state.memory.costs);
+
+    match decide(verdict, guard.policy, state.budget_warned) {
+        BudgetAction::Continue => None,
+        BudgetAction::Warn { dimension, pct } => {
+            let _ = params
+                .writer
+                .append_event(VersionedEventPayload::new(
+                    EventPayload::BudgetWarningRaised {
+                        dimension,
+                        pct,
+                        cost_usd,
+                        total_tokens,
+                    },
+                ))
+                .await;
+            state.budget_warned = true;
+            tracing::warn!(
+                target: "engine::budget",
+                run_id = %params.run_id,
+                ?dimension,
+                pct,
+                cost_usd,
+                total_tokens,
+                "run budget warning threshold crossed"
+            );
+            None
+        },
+        BudgetAction::Abort { dimension } => {
+            let _ = params
+                .writer
+                .append_event(VersionedEventPayload::new(EventPayload::BudgetExceeded {
+                    dimension,
+                    cost_usd,
+                    total_tokens,
+                }))
+                .await;
+            let reason = format!(
+                "budget exceeded ({dimension:?}): cost=${cost_usd:.4}, tokens={total_tokens}"
+            );
+            let _ = params
+                .writer
+                .append_event(VersionedEventPayload::new(EventPayload::RunAborted {
+                    reason: reason.clone(),
+                }))
+                .await;
+            tracing::warn!(
+                target: "engine::budget",
+                run_id = %params.run_id,
+                ?dimension,
+                cost_usd,
+                total_tokens,
+                "run budget exceeded; aborting run"
+            );
+            let outcome = RunOutcome::Aborted { reason };
+            let _ = params.event_tx.send(EngineRunEvent::Terminal {
+                outcome: outcome.clone(),
+            });
+            Some(outcome)
+        },
     }
 }
 
@@ -200,6 +291,9 @@ struct RunExecutionState {
     processed_graph_revision_seq: u64,
     pending_graph_revisions: Vec<ObservedGraphRevision>,
     pending_elevations: std::sync::Arc<crate::engine::elevation::PendingElevations>,
+    /// Whether a `BudgetWarningRaised` has already been emitted this run, so the
+    /// warn band fires at most once per run (idempotent re-evaluation).
+    budget_warned: bool,
 }
 
 async fn initial_execution_state(params: &RunTaskParams) -> Result<RunExecutionState, String> {
@@ -234,6 +328,7 @@ async fn initial_execution_state(params: &RunTaskParams) -> Result<RunExecutionS
         processed_graph_revision_seq: applied_graph_revision_seq,
         pending_graph_revisions,
         pending_elevations: params.pending_elevations.clone(),
+        budget_warned: false,
     })
 }
 

--- a/crates/surge-orchestrator/tests/engine_budget_test.rs
+++ b/crates/surge-orchestrator/tests/engine_budget_test.rs
@@ -1,0 +1,312 @@
+//! v0.2 M1 — end-to-end live budget enforcement.
+//!
+//! Drives a one-agent graph through the full engine run loop with a mock
+//! bridge that reports a large `TokenUsage` snapshot before completing the
+//! stage. With a tiny token budget and the default `Abort` policy, the engine
+//! must emit `BudgetExceeded` and abort the run at the stage boundary — proving
+//! the `enforce_budget` hook fires against the freshly-folded cumulative cost.
+
+use std::collections::{BTreeMap, HashMap};
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use surge_acp::bridge::error::{
+    BridgeError, CloseSessionError, OpenSessionError, ReplyToToolError, SendMessageError,
+};
+use surge_acp::bridge::event::{BridgeEvent, ToolResultPayload};
+use surge_acp::bridge::facade::BridgeFacade;
+use surge_acp::bridge::session::{MessageContent, SessionConfig, SessionState};
+use surge_core::agent_config::{AgentConfig, NodeLimits};
+use surge_core::budget::{BudgetGuard, BudgetLimits, BudgetPolicy};
+use surge_core::edge::{Edge, EdgeKind, EdgePolicy, PortRef};
+use surge_core::graph::{Graph, GraphMetadata, SCHEMA_VERSION};
+use surge_core::id::{RunId, SessionId};
+use surge_core::keys::{EdgeKey, NodeKey, OutcomeKey, ProfileKey};
+use surge_core::node::{Node, NodeConfig, OutcomeDecl, Position};
+use surge_core::run_event::EventPayload;
+use surge_core::terminal_config::{TerminalConfig, TerminalKind};
+use surge_orchestrator::engine::tools::ToolDispatcher;
+use surge_orchestrator::engine::tools::worktree::WorktreeToolDispatcher;
+use surge_orchestrator::engine::{Engine, EngineConfig, EngineRunConfig, RunOutcome};
+use surge_persistence::runs::{EventSeq, Storage};
+use tokio::sync::{Mutex, broadcast};
+
+/// Mock bridge that, on each `send_message`, reports a fixed large
+/// `TokenUsage` snapshot and then the session's declared outcome — so the run
+/// accrues real cost in its event log before the stage boundary.
+struct BudgetMockBridge {
+    tx: broadcast::Sender<BridgeEvent>,
+    outcomes: Mutex<HashMap<SessionId, OutcomeKey>>,
+    prompt_tokens: u32,
+    output_tokens: u32,
+}
+
+impl BudgetMockBridge {
+    fn new(prompt_tokens: u32, output_tokens: u32) -> Self {
+        let (tx, _) = broadcast::channel(64);
+        Self {
+            tx,
+            outcomes: Mutex::new(HashMap::new()),
+            prompt_tokens,
+            output_tokens,
+        }
+    }
+}
+
+#[async_trait]
+impl BridgeFacade for BudgetMockBridge {
+    async fn open_session(&self, config: SessionConfig) -> Result<SessionId, OpenSessionError> {
+        let session = SessionId::new();
+        let outcome = config
+            .declared_outcomes
+            .first()
+            .cloned()
+            .unwrap_or_else(|| OutcomeKey::try_from("done").expect("'done' is valid"));
+        self.outcomes.lock().await.insert(session, outcome);
+        Ok(session)
+    }
+
+    async fn send_message(
+        &self,
+        session: SessionId,
+        _content: MessageContent,
+    ) -> Result<(), SendMessageError> {
+        // Report usage first so `TokensConsumed` is appended before the stage
+        // completes; the engine folds it into cumulative cost at the boundary.
+        let _ = self.tx.send(BridgeEvent::TokenUsage {
+            session,
+            prompt_tokens: self.prompt_tokens,
+            output_tokens: self.output_tokens,
+            cache_hits: 0,
+            model: "mock-model".into(),
+        });
+        let outcome = self
+            .outcomes
+            .lock()
+            .await
+            .get(&session)
+            .cloned()
+            .unwrap_or_else(|| OutcomeKey::try_from("done").expect("'done' is valid"));
+        let _ = self.tx.send(BridgeEvent::OutcomeReported {
+            session,
+            outcome,
+            summary: "budget mock outcome".into(),
+            artifacts_produced: vec![],
+        });
+        Ok(())
+    }
+
+    async fn session_state(&self, _session: SessionId) -> Result<SessionState, BridgeError> {
+        Err(BridgeError::WorkerDead)
+    }
+
+    async fn close_session(&self, _session: SessionId) -> Result<(), CloseSessionError> {
+        Ok(())
+    }
+
+    async fn reply_to_tool(
+        &self,
+        _session: SessionId,
+        _call_id: String,
+        _payload: ToolResultPayload,
+    ) -> Result<(), ReplyToToolError> {
+        Ok(())
+    }
+
+    async fn reply_to_permission(
+        &self,
+        _session: SessionId,
+        _request_id: String,
+        _response: agent_client_protocol::RequestPermissionResponse,
+    ) -> Result<(), surge_acp::bridge::ReplyToPermissionError> {
+        Ok(())
+    }
+
+    fn subscribe(&self) -> broadcast::Receiver<BridgeEvent> {
+        self.tx.subscribe()
+    }
+}
+
+/// Single agent node `work` → `done` → terminal `end` (success).
+fn one_agent_graph() -> Graph {
+    let work = NodeKey::try_from("work").unwrap();
+    let end = NodeKey::try_from("end").unwrap();
+
+    let mut nodes = BTreeMap::new();
+    nodes.insert(
+        work.clone(),
+        Node {
+            id: work.clone(),
+            position: Position::default(),
+            declared_outcomes: vec![OutcomeDecl {
+                id: OutcomeKey::try_from("done").unwrap(),
+                description: "stage completed".into(),
+                edge_kind_hint: EdgeKind::Forward,
+                is_terminal: false,
+            }],
+            config: NodeConfig::Agent(AgentConfig {
+                profile: ProfileKey::try_from("implementer@1.0").unwrap(),
+                prompt_overrides: None,
+                tool_overrides: None,
+                sandbox_override: None,
+                approvals_override: None,
+                bindings: vec![],
+                rules_overrides: None,
+                limits: NodeLimits::default(),
+                hooks: vec![],
+                custom_fields: Default::default(),
+            }),
+        },
+    );
+    nodes.insert(
+        end.clone(),
+        Node {
+            id: end.clone(),
+            position: Position::default(),
+            declared_outcomes: vec![],
+            config: NodeConfig::Terminal(TerminalConfig {
+                kind: TerminalKind::Success,
+                message: None,
+            }),
+        },
+    );
+
+    let edges = vec![Edge {
+        id: EdgeKey::try_from("e_work_done").unwrap(),
+        from: PortRef {
+            node: work.clone(),
+            outcome: OutcomeKey::try_from("done").unwrap(),
+        },
+        to: end,
+        kind: EdgeKind::Forward,
+        policy: EdgePolicy::default(),
+    }];
+
+    Graph {
+        schema_version: SCHEMA_VERSION,
+        metadata: GraphMetadata {
+            name: "one-agent-budget".into(),
+            description: None,
+            template_origin: None,
+            created_at: chrono::Utc::now(),
+            author: None,
+            archetype: None,
+        },
+        start: work,
+        nodes,
+        edges,
+        subgraphs: BTreeMap::new(),
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn run_aborts_when_token_budget_exceeded() {
+    let dir = tempfile::tempdir().unwrap();
+    let storage = Storage::open(dir.path()).await.unwrap();
+    // 15_000 tokens reported by the stage, against a 1_000-token budget.
+    let bridge = Arc::new(BudgetMockBridge::new(10_000, 5_000)) as Arc<dyn BridgeFacade>;
+    let dispatcher =
+        Arc::new(WorktreeToolDispatcher::new(dir.path().to_path_buf())) as Arc<dyn ToolDispatcher>;
+    let engine = Engine::new(bridge, storage.clone(), dispatcher, EngineConfig::default());
+
+    let run_config = EngineRunConfig {
+        budget: BudgetGuard {
+            limits: BudgetLimits {
+                usd: None,
+                tokens: Some(1_000),
+                warn_threshold_pct: 80,
+            },
+            policy: BudgetPolicy::Abort,
+        },
+        ..EngineRunConfig::default()
+    };
+
+    let run_id = RunId::new();
+    let handle = engine
+        .start_run(run_id, one_agent_graph(), dir.path().to_path_buf(), run_config)
+        .await
+        .unwrap();
+
+    let outcome = tokio::time::timeout(Duration::from_secs(30), handle.await_completion())
+        .await
+        .expect("run hung > 30s")
+        .expect("await_completion");
+
+    match outcome {
+        RunOutcome::Aborted { reason } => {
+            assert!(
+                reason.contains("budget exceeded"),
+                "abort reason should cite the budget, got: {reason}"
+            );
+        }
+        other => panic!("expected Aborted on budget breach, got {other:?}"),
+    }
+
+    drop(engine);
+
+    // The event log must carry a BudgetExceeded record (Tokens dimension) and
+    // must NOT reach the terminal `end` node (RunCompleted).
+    let reader = storage.open_run_reader(run_id).await.unwrap();
+    let last = reader.current_seq().await.unwrap();
+    let events = reader
+        .read_events(EventSeq(0)..EventSeq(last.0 + 1))
+        .await
+        .unwrap();
+
+    let saw_exceeded = events.iter().any(|ev| {
+        matches!(
+            &ev.payload.payload,
+            EventPayload::BudgetExceeded {
+                dimension: surge_core::budget::BudgetDimension::Tokens,
+                ..
+            }
+        )
+    });
+    assert!(saw_exceeded, "expected a BudgetExceeded(Tokens) event in the log");
+
+    let completed = events
+        .iter()
+        .any(|ev| matches!(ev.payload.payload, EventPayload::RunCompleted { .. }));
+    assert!(!completed, "run must not complete after a budget breach");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn run_completes_within_budget() {
+    let dir = tempfile::tempdir().unwrap();
+    let storage = Storage::open(dir.path()).await.unwrap();
+    // 150 tokens reported, well under a 10_000-token budget.
+    let bridge = Arc::new(BudgetMockBridge::new(100, 50)) as Arc<dyn BridgeFacade>;
+    let dispatcher =
+        Arc::new(WorktreeToolDispatcher::new(dir.path().to_path_buf())) as Arc<dyn ToolDispatcher>;
+    let engine = Engine::new(bridge, storage.clone(), dispatcher, EngineConfig::default());
+
+    let run_config = EngineRunConfig {
+        budget: BudgetGuard {
+            limits: BudgetLimits {
+                usd: None,
+                tokens: Some(10_000),
+                warn_threshold_pct: 80,
+            },
+            policy: BudgetPolicy::Abort,
+        },
+        ..EngineRunConfig::default()
+    };
+
+    let run_id = RunId::new();
+    let handle = engine
+        .start_run(run_id, one_agent_graph(), dir.path().to_path_buf(), run_config)
+        .await
+        .unwrap();
+
+    let outcome = tokio::time::timeout(Duration::from_secs(30), handle.await_completion())
+        .await
+        .expect("run hung > 30s")
+        .expect("await_completion");
+
+    match outcome {
+        RunOutcome::Completed { terminal } => assert_eq!(terminal.as_ref(), "end"),
+        other => panic!("expected Completed within budget, got {other:?}"),
+    }
+    drop(engine);
+}

--- a/crates/surge-orchestrator/tests/engine_budget_test.rs
+++ b/crates/surge-orchestrator/tests/engine_budget_test.rs
@@ -224,7 +224,12 @@ async fn run_aborts_when_token_budget_exceeded() {
 
     let run_id = RunId::new();
     let handle = engine
-        .start_run(run_id, one_agent_graph(), dir.path().to_path_buf(), run_config)
+        .start_run(
+            run_id,
+            one_agent_graph(),
+            dir.path().to_path_buf(),
+            run_config,
+        )
         .await
         .unwrap();
 
@@ -239,7 +244,7 @@ async fn run_aborts_when_token_budget_exceeded() {
                 reason.contains("budget exceeded"),
                 "abort reason should cite the budget, got: {reason}"
             );
-        }
+        },
         other => panic!("expected Aborted on budget breach, got {other:?}"),
     }
 
@@ -263,7 +268,10 @@ async fn run_aborts_when_token_budget_exceeded() {
             }
         )
     });
-    assert!(saw_exceeded, "expected a BudgetExceeded(Tokens) event in the log");
+    assert!(
+        saw_exceeded,
+        "expected a BudgetExceeded(Tokens) event in the log"
+    );
 
     let completed = events
         .iter()
@@ -295,7 +303,12 @@ async fn run_completes_within_budget() {
 
     let run_id = RunId::new();
     let handle = engine
-        .start_run(run_id, one_agent_graph(), dir.path().to_path_buf(), run_config)
+        .start_run(
+            run_id,
+            one_agent_graph(),
+            dir.path().to_path_buf(),
+            run_config,
+        )
         .await
         .unwrap();
 

--- a/crates/surge-orchestrator/tests/engine_budget_test.rs
+++ b/crates/surge-orchestrator/tests/engine_budget_test.rs
@@ -323,3 +323,65 @@ async fn run_completes_within_budget() {
     }
     drop(engine);
 }
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn warn_only_records_breach_but_completes() {
+    let dir = tempfile::tempdir().unwrap();
+    let storage = Storage::open(dir.path()).await.unwrap();
+    // 15_000 tokens reported, against a 1_000-token budget under WarnOnly.
+    let bridge = Arc::new(BudgetMockBridge::new(10_000, 5_000)) as Arc<dyn BridgeFacade>;
+    let dispatcher =
+        Arc::new(WorktreeToolDispatcher::new(dir.path().to_path_buf())) as Arc<dyn ToolDispatcher>;
+    let engine = Engine::new(bridge, storage.clone(), dispatcher, EngineConfig::default());
+
+    let run_config = EngineRunConfig {
+        budget: BudgetGuard {
+            limits: BudgetLimits {
+                usd: None,
+                tokens: Some(1_000),
+                warn_threshold_pct: 80,
+            },
+            policy: BudgetPolicy::WarnOnly,
+        },
+        ..EngineRunConfig::default()
+    };
+
+    let run_id = RunId::new();
+    let handle = engine
+        .start_run(
+            run_id,
+            one_agent_graph(),
+            dir.path().to_path_buf(),
+            run_config,
+        )
+        .await
+        .unwrap();
+
+    let outcome = tokio::time::timeout(Duration::from_secs(30), handle.await_completion())
+        .await
+        .expect("run hung > 30s")
+        .expect("await_completion");
+
+    // WarnOnly never stops the run — it completes.
+    match outcome {
+        RunOutcome::Completed { terminal } => assert_eq!(terminal.as_ref(), "end"),
+        other => panic!("expected Completed under WarnOnly, got {other:?}"),
+    }
+    drop(engine);
+
+    // ...but the breach is still recorded for visibility (no abort).
+    let reader = storage.open_run_reader(run_id).await.unwrap();
+    let last = reader.current_seq().await.unwrap();
+    let events = reader
+        .read_events(EventSeq(0)..EventSeq(last.0 + 1))
+        .await
+        .unwrap();
+    let saw_exceeded = events
+        .iter()
+        .any(|ev| matches!(ev.payload.payload, EventPayload::BudgetExceeded { .. }));
+    let saw_aborted = events
+        .iter()
+        .any(|ev| matches!(ev.payload.payload, EventPayload::RunAborted { .. }));
+    assert!(saw_exceeded, "WarnOnly must still record the breach");
+    assert!(!saw_aborted, "WarnOnly must not abort the run");
+}

--- a/docs/budget.md
+++ b/docs/budget.md
@@ -1,0 +1,66 @@
+# Live budget enforcement
+
+Surge can stop a run before it overruns a spend budget — the safety rail that
+makes "walk away" trustworthy for unattended (AFK) work. Enforcement is
+**opt-in**: with no budget configured, runs are unlimited and the engine skips
+the check entirely (zero overhead, no event-log churn).
+
+## Configuring a budget
+
+Budgets live in the `[analytics]` section of `surge.toml`:
+
+```toml
+[analytics]
+budget_usd = 5.0          # hard USD ceiling (omit for no USD limit)
+budget_tokens = 2_000_000 # hard token ceiling (prompt + output)
+budget_warn_threshold = 80 # warn once spend reaches this % of a limit (0 disables)
+```
+
+The CLI freezes these into the run at start, so enforcement is deterministic
+and **replayable**: the same event log always reproduces the same budget
+decisions (no wall-clock, no live config re-read mid-run).
+
+> Note: USD enforcement requires per-event `cost_usd`, which the current ACP
+> bridge path does not yet populate (`cost_usd` is `None`). Until a pricing
+> layer lands, set `budget_tokens` for hard enforcement; `budget_usd` still
+> drives the analytics surfaces.
+
+## How it works
+
+At every **stage boundary** the engine has just folded the completed stage's
+token usage (`TokensConsumed` events) into the run's cumulative cost. It then
+evaluates that cost against the resolved limits:
+
+| Verdict    | Condition                                              |
+|------------|--------------------------------------------------------|
+| `Ok`       | within all limits                                       |
+| `Warn`     | reached `budget_warn_threshold`% of a limit, not over   |
+| `Exceeded` | reached or passed a limit (USD checked before tokens)   |
+
+The verdict maps to an action via the run's **policy**:
+
+| Policy     | on `Warn`                  | on `Exceeded`                          |
+|------------|----------------------------|----------------------------------------|
+| `Abort` (default) | emit `BudgetWarningRaised` once | emit `BudgetExceeded`, then `RunAborted` |
+| `WarnOnly` | emit `BudgetWarningRaised` once | emit a one-time warning, keep running   |
+
+`Abort` is the default — an unattended run never overruns its budget. The warn
+band fires **at most once per run** (idempotent across re-evaluation).
+
+## Events
+
+Both decisions are recorded in the per-run event log, so they show up in
+`surge engine replay`, `surge engine logs`, and the cockpit status surfaces:
+
+- `BudgetWarningRaised { dimension, pct, cost_usd, total_tokens }`
+- `BudgetExceeded { dimension, cost_usd, total_tokens }`
+
+On `Abort`, a `RunAborted` event follows with a reason citing the dimension and
+the accrued cost.
+
+## Scope
+
+- Limits resolve global → run today; per-milestone overrides are a planned
+  extension (the resolution point is centralized in `AnalyticsConfig::budget_guard`).
+- A dedicated Telegram budget card (warn/exceeded with raise/abort buttons) is a
+  follow-up; the underlying events already surface through the event log.


### PR DESCRIPTION
## v0.2 M1 — Live budget enforcement

Stop a run before it overruns a spend budget — the safety rail that makes "walk away" trustworthy for unattended (AFK) work. **Opt-in**: with no budget configured, runs are unlimited and the engine skips the check entirely (zero overhead, no event-log churn).

### What

Configure in `surge.toml`:

```toml
[analytics]
budget_tokens = 2_000_000   # hard token ceiling (prompt + output)
budget_usd = 5.0            # hard USD ceiling
budget_warn_threshold = 80  # warn once spend reaches this % of a limit
```

At every **stage boundary** — where the completed stage's `TokensConsumed` usage has just been folded into the run's cumulative cost — the engine evaluates the budget and acts:

| Verdict | `Abort` policy (default) | `WarnOnly` |
|---|---|---|
| `Warn` (≥ threshold) | `BudgetWarningRaised` once | `BudgetWarningRaised` once |
| `Exceeded` (≥ limit) | `BudgetExceeded` → `RunAborted` | one-time warning, keep running |

Decisions are deterministic and **replayable** (frozen at run start, no wall-clock), and recorded in the event log so they surface in `surge engine replay` / `logs`.

### How it's built (5 commits)

1. `surge-core::budget` — pure `BudgetLimits::evaluate → BudgetVerdict` and `decide(verdict, policy, already_warned) → BudgetAction`. No I/O, no wall-clock.
2. Additive `BudgetWarningRaised` / `BudgetExceeded` event payloads (fold catch-all + exhaustive discriminant arm + serde roundtrip).
3. Engine hook: `EngineRunConfig.budget`, `enforce_budget` at the stage boundary, warn-once idempotency on `RunExecutionState`, abort mirrors the proven `abort_if_cancelled` path. `AnalyticsConfig::budget_guard()` + CLI freeze the operator's `[analytics]` budget into the run.
4. End-to-end test: a one-agent graph + mock bridge reporting 15k tokens vs a 1k budget → `RunAborted` + `BudgetExceeded(Tokens)`, never `RunCompleted`; the within-budget run completes.
5. Docs: `docs/budget.md` (model + policy matrix).

### Tests

- `surge-core`: 17 budget unit tests (evaluate × dimensions/thresholds, decide × policy/idempotency, guard resolution), serde roundtrips, discriminant coverage.
- `surge-orchestrator`: `engine_budget_test` end-to-end (abort-on-breach + complete-within-budget).
- `surge-core` strict clippy (`-D warnings`) clean; workspace builds.

### Known scope

- USD enforcement needs per-event `cost_usd`, which the ACP bridge path doesn't populate yet (`cost_usd: None`) — use `budget_tokens` for hard enforcement today. Documented in `docs/budget.md`.
- Per-milestone budget overrides and a dedicated Telegram budget card are planned follow-ups; the events already surface through the event log.

First milestone of the v0.2 "Autonomy: AFK → PR for real" roadmap (#72).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added live budget enforcement for runs. Configure cost limits (USD, tokens) and warning thresholds in `surge.toml` to monitor and control run spending. Runs enforce budgets at stage boundaries and can abort or warn based on configured policy.

* **Documentation**
  * Added budget enforcement documentation describing configuration, enforcement model, and event logging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->