### PR TITLE
feat(intake): tier-aware poll cadence for GitHub (v0.2 M2 part 2)

### DIFF
--- a/crates/surge-intake/src/cadence.rs
+++ b/crates/surge-intake/src/cadence.rs
@@ -10,16 +10,17 @@
 //! and decide when to schedule the next fetch. This keeps the controller
 //! deterministic and easy to test under a frozen `tokio::time` clock.
 //!
-//! ### Integration scope
+//! ### Integration
 //!
-//! Production wiring of this controller into the actual source-poll
-//! loops requires either a new `TaskSource::set_poll_interval` method
-//! (changing the trait) or a wrapping stream that buffers events from
-//! `watch_for_tasks()` and emits them at the controlled cadence. Both
-//! are deliberately out of scope for the milestone — see ADR 0014
-//! § "Tier-aware polling" for the staged plan. The controller is
-//! useful on its own as the single source of truth for "what cadence
-//! does this source want right now?".
+//! Each polling source owns one controller (keyed by its own id). The
+//! GitHub source drives it from inside `watch_for_tasks`: it sleeps
+//! [`CadenceController::next_interval`] (with [`jitter_seed`]) before each
+//! poll, calls [`CadenceController::set_tier_for`] from the tiers of the
+//! issues it just fetched, [`CadenceController::notify_success`] on a clean
+//! fetch, and [`CadenceController::notify_rate_limited`] on a rate-limited
+//! one. The Linear source still polls at its fixed configured interval —
+//! its fetch path does not yet surface per-issue labels, so tier-aware
+//! cadence there is a follow-up.
 
 use std::collections::HashMap;
 use std::time::Duration;
@@ -191,6 +192,21 @@ fn apply_jitter(target: Duration, seed: f64) -> Duration {
     Duration::from_secs_f64(scaled)
 }
 
+/// Deterministic jitter seed in `[0.0, 1.0)` for poll attempt `n`.
+///
+/// Uses the golden-ratio low-discrepancy sequence so successive polls of one
+/// source spread evenly across the jitter band instead of clustering, while
+/// staying fully reproducible (no RNG — replay- and test-friendly). Feed the
+/// result to [`CadenceController::next_interval`] as `jitter_unit_interval`.
+#[must_use]
+pub fn jitter_seed(attempt: u64) -> f64 {
+    // Fractional part of n * (1/φ); the classic additive-recurrence sequence.
+    const INV_PHI: f64 = 0.618_033_988_749_895;
+    #[allow(clippy::cast_precision_loss)]
+    let x = (attempt as f64) * INV_PHI;
+    x.fract()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -315,6 +331,35 @@ mod tests {
         let base = target.as_secs_f64();
         assert!((low / base - 0.9).abs() < 1e-9);
         assert!((high / base - 1.1).abs() < 1e-9);
+    }
+
+    #[test]
+    fn jitter_seed_is_in_unit_interval_and_varies() {
+        let seeds: Vec<f64> = (0..16).map(jitter_seed).collect();
+        for (n, s) in seeds.iter().enumerate() {
+            assert!(
+                (0.0..1.0).contains(s),
+                "seed for attempt {n} = {s} out of [0,1)"
+            );
+        }
+        // Consecutive attempts must differ (no clustering on one point).
+        assert!(seeds[0] != seeds[1] && seeds[1] != seeds[2]);
+        // attempt 0 maps to 0.0 (n * c with n=0).
+        assert!((jitter_seed(0) - 0.0).abs() < 1e-12);
+    }
+
+    #[test]
+    fn jitter_seed_feeds_next_interval_within_band() {
+        let mut c = CadenceController::new();
+        c.set_tier_for("src", &[AutomationPolicy::Standard]); // L1 = 300s
+        let base = intervals::L1.as_secs_f64();
+        for attempt in 0..32u64 {
+            let d = c.next_interval("src", jitter_seed(attempt)).as_secs_f64();
+            assert!(
+                (0.9 * base..=1.1 * base).contains(&d),
+                "attempt {attempt}: {d}s outside ±10% of {base}s"
+            );
+        }
     }
 
     #[test]

--- a/crates/surge-intake/src/cadence.rs
+++ b/crates/surge-intake/src/cadence.rs
@@ -15,10 +15,12 @@
 //! Each polling source owns one controller (keyed by its own id). The
 //! GitHub source drives it from inside `watch_for_tasks`: it sleeps
 //! [`CadenceController::next_interval`] (with [`jitter_seed`]) before each
-//! poll, calls [`CadenceController::set_tier_for`] from the tiers of the
-//! issues it just fetched, [`CadenceController::notify_success`] on a clean
-//! fetch, and [`CadenceController::notify_rate_limited`] on a rate-limited
-//! one. The Linear source still polls at its fixed configured interval —
+//! poll, calls [`CadenceController::raise_tier_for`] from the tiers of the
+//! issues it just fetched (only ever speeding up — the fetch is an
+//! incremental delta, so a replace would wrongly downshift on a quiet poll),
+//! [`CadenceController::notify_success`] on a clean fetch, and
+//! [`CadenceController::notify_rate_limited`] on a rate-limited one. The
+//! Linear source still polls at its fixed configured interval —
 //! its fetch path does not yet surface per-issue labels, so tier-aware
 //! cadence there is a follow-up.
 
@@ -124,7 +126,9 @@ impl CadenceController {
 
     /// Update the base interval for `source_id` from the most
     /// aggressive policy among its active tickets. Idempotent —
-    /// repeated calls with the same value are no-ops.
+    /// repeated calls with the same value are no-ops. Replaces the base
+    /// outright (can speed up *or* slow down); use this only when
+    /// `policies` is the full active set.
     pub fn set_tier_for(&mut self, source_id: &str, policies: &[AutomationPolicy]) {
         let base = most_aggressive(policies);
         let entry = self
@@ -132,6 +136,31 @@ impl CadenceController {
             .entry(source_id.to_owned())
             .or_insert_with(|| SourceState::fresh(base));
         entry.base = base;
+    }
+
+    /// Raise (only ever speed up) the base cadence for `source_id` to the
+    /// most aggressive tier among `policies`. Unlike [`set_tier_for`], this
+    /// never slows the cadence down.
+    ///
+    /// This is the safe update when `policies` comes from an *incremental*
+    /// poll delta (e.g. issues updated since a watermark): a quiet cycle
+    /// yields an empty or low-tier delta, and replacing the base from it
+    /// would wrongly downshift a source whose higher-tier issues are still
+    /// open. Mirrors the most-aggressive-wins rule reviewers asked for.
+    ///
+    /// Trade-off: the cadence does not slow back down when a high-tier issue
+    /// closes (a delta filtered on open state never reports the close).
+    /// Recomputing the base from a full open-issue snapshot is a follow-up.
+    pub fn raise_tier_for(&mut self, source_id: &str, policies: &[AutomationPolicy]) {
+        let candidate = most_aggressive(policies);
+        let entry = self
+            .sources
+            .entry(source_id.to_owned())
+            .or_insert_with(|| SourceState::fresh(candidate));
+        // Smaller Duration == faster poll. Only ever go faster.
+        if candidate < entry.base {
+            entry.base = candidate;
+        }
     }
 
     /// Record a `RateLimited` fetch — bumps the backoff exponent.
@@ -252,6 +281,31 @@ mod tests {
         assert!(
             (got - target).abs() <= 0.11 * target,
             "{got} not within 10% of {target}"
+        );
+    }
+
+    #[test]
+    fn raise_tier_only_speeds_up_never_down() {
+        let mut c = CadenceController::new();
+        let l3 = intervals::L3.as_secs_f64();
+        let within = |got: f64, target: f64| (got - target).abs() <= 0.11 * target;
+
+        // First sighting of an L3 issue speeds the source to L3.
+        c.raise_tier_for("src", &[auto()]);
+        assert!(within(c.next_interval("src", 0.5).as_secs_f64(), l3));
+
+        // A quiet poll (empty delta) must NOT downshift back to idle/L1.
+        c.raise_tier_for("src", &[]);
+        assert!(
+            within(c.next_interval("src", 0.5).as_secs_f64(), l3),
+            "empty delta downshifted the cadence"
+        );
+
+        // A low-tier delta (only L1 issues updated) must NOT downshift either.
+        c.raise_tier_for("src", &[AutomationPolicy::Standard]);
+        assert!(
+            within(c.next_interval("src", 0.5).as_secs_f64(), l3),
+            "L1 delta downshifted the cadence"
         );
     }
 

--- a/crates/surge-intake/src/github/source.rs
+++ b/crates/surge-intake/src/github/source.rs
@@ -1,6 +1,8 @@
 //! `GitHubIssuesTaskSource` — `TaskSource` impl backed by GitHub REST.
 
+use crate::cadence::{self, CadenceController};
 use crate::github::client::GitHubClient;
+use crate::policy::{AutomationPolicy, resolve_policy};
 use crate::source::{MergeOutcome, MergeReadiness, TaskSource};
 use crate::types::{TaskDetails, TaskEvent, TaskEventKind, TaskId, TaskSummary};
 use crate::{Error, Result};
@@ -8,6 +10,7 @@ use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use futures::stream::{self, BoxStream};
 use std::collections::{HashMap, VecDeque};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 use tokio::sync::Mutex;
 use tracing::warn;
@@ -49,10 +52,15 @@ pub struct GitHubIssuesTaskSource {
     id: String,
     display_name: String,
     client: GitHubClient,
-    poll_interval: Duration,
     label_filters: Vec<String>,
     merge_method: surge_core::config::MergeMethod,
     last_seen_updated_at: Mutex<Option<DateTime<Utc>>>,
+    /// Tier-aware poll cadence. Keyed by this source's id; updated from the
+    /// tiers of fetched issues and from rate-limit signals. Supersedes the
+    /// fixed `config.poll_interval` (kept in config for back-compat).
+    cadence: Mutex<CadenceController>,
+    /// Monotonic poll counter feeding the jitter seed.
+    poll_attempt: AtomicU64,
 }
 
 impl GitHubIssuesTaskSource {
@@ -69,11 +77,47 @@ impl GitHubIssuesTaskSource {
             id: config.id,
             display_name: config.display_name,
             client,
-            poll_interval: config.poll_interval,
             label_filters: config.label_filters,
             merge_method: config.merge_method,
             last_seen_updated_at: Mutex::new(None),
+            cadence: Mutex::new(CadenceController::new()),
+            poll_attempt: AtomicU64::new(0),
         })
+    }
+
+    /// Sleep until the next poll using the tier-aware cadence: the interval
+    /// scales with the most aggressive tier among fetched issues (L1 5min /
+    /// L2 2min / L3 1min) plus exponential rate-limit backoff. Replaces the
+    /// fixed `poll_interval` sleep.
+    async fn cadence_sleep(&self) {
+        let attempt = self.poll_attempt.fetch_add(1, Ordering::Relaxed);
+        let interval = {
+            let c = self.cadence.lock().await;
+            c.next_interval(&self.id, cadence::jitter_seed(attempt))
+        };
+        tokio::time::sleep(interval).await;
+    }
+
+    /// After a clean fetch, set the cadence tier from the fetched issues'
+    /// labels and clear any rate-limit backoff.
+    async fn note_fetch_success(&self, issues: &[octocrab::models::issues::Issue]) {
+        let policies: Vec<AutomationPolicy> = issues
+            .iter()
+            .map(|i| {
+                let names: Vec<String> = i.labels.iter().map(|l| l.name.clone()).collect();
+                resolve_policy(&names)
+            })
+            .collect();
+        let mut c = self.cadence.lock().await;
+        c.set_tier_for(&self.id, &policies);
+        c.notify_success(&self.id);
+    }
+
+    /// After a failed fetch, bump the cadence backoff if it was a rate limit.
+    async fn note_fetch_error(&self, err: &Error) {
+        if matches!(err, Error::RateLimited { .. }) {
+            self.cadence.lock().await.notify_rate_limited(&self.id);
+        }
     }
 
     fn task_id(&self, number: u64) -> TaskId {
@@ -194,7 +238,7 @@ impl TaskSource for GitHubIssuesTaskSource {
 
             // Queue empty: fetch a fresh page and populate the queue.
             loop {
-                tokio::time::sleep(this.poll_interval).await;
+                this.cadence_sleep().await;
                 let since = *this.last_seen_updated_at.lock().await;
 
                 // Build the paginated request(s).
@@ -219,6 +263,7 @@ impl TaskSource for GitHubIssuesTaskSource {
                         Err(e) => {
                             warn!(error = %e, "github poll failed");
                             let mapped = Self::map_octocrab_error(&e);
+                            this.note_fetch_error(&mapped).await;
                             return Some((Err(mapped), (this, queue)));
                         },
                     }
@@ -245,6 +290,7 @@ impl TaskSource for GitHubIssuesTaskSource {
                     }
                     if let Some(e) = error {
                         let mapped = Self::map_octocrab_error(&e);
+                        this.note_fetch_error(&mapped).await;
                         return Some((Err(mapped), (this, queue)));
                     }
                     all
@@ -260,6 +306,10 @@ impl TaskSource for GitHubIssuesTaskSource {
                         }
                     }
                 }
+
+                // A clean fetch: update the poll cadence from the fetched
+                // issues' tiers and clear any rate-limit backoff.
+                this.note_fetch_success(&union_items).await;
 
                 queue = this.build_events_from_page_items(union_items, since).await;
                 if let Some(item) = queue.pop_front() {
@@ -741,5 +791,46 @@ mod tests {
     #[test]
     fn parse_issue_number_rejects_non_numeric() {
         assert!(parse_issue_number("github_issues:user/repo#abc").is_err());
+    }
+
+    fn test_source() -> GitHubIssuesTaskSource {
+        // `new` builds the octocrab client offline (no network), so a fake
+        // token is fine for exercising the cadence wiring.
+        GitHubIssuesTaskSource::new(GitHubConfig {
+            id: "github_issues:o/r".into(),
+            display_name: "test".into(),
+            owner: "o".into(),
+            repo: "r".into(),
+            api_token: "ghp_test".into(),
+            poll_interval: Duration::from_secs(60),
+            label_filters: vec![],
+            merge_method: surge_core::config::MergeMethod::Squash,
+        })
+        .expect("offline octocrab client build")
+    }
+
+    #[tokio::test]
+    async fn cadence_backs_off_on_rate_limit_and_clears_on_success() {
+        let src = test_source();
+        let id = src.id.clone();
+
+        // Two rate-limited fetches bump the backoff exponent.
+        src.note_fetch_error(&Error::RateLimited {
+            retry_after_secs: 0,
+        })
+        .await;
+        src.note_fetch_error(&Error::RateLimited {
+            retry_after_secs: 0,
+        })
+        .await;
+        assert_eq!(src.cadence.lock().await.backoff_exp(&id), 2);
+
+        // A non-rate-limit error must NOT bump the backoff.
+        src.note_fetch_error(&Error::Network("blip".into())).await;
+        assert_eq!(src.cadence.lock().await.backoff_exp(&id), 2);
+
+        // A clean fetch clears the backoff.
+        src.note_fetch_success(&[]).await;
+        assert_eq!(src.cadence.lock().await.backoff_exp(&id), 0);
     }
 }

--- a/crates/surge-intake/src/github/source.rs
+++ b/crates/surge-intake/src/github/source.rs
@@ -98,8 +98,14 @@ impl GitHubIssuesTaskSource {
         tokio::time::sleep(interval).await;
     }
 
-    /// After a clean fetch, set the cadence tier from the fetched issues'
+    /// After a clean fetch, raise the cadence tier from the fetched issues'
     /// labels and clear any rate-limit backoff.
+    ///
+    /// `issues` is the incremental poll delta (issues updated since the
+    /// watermark), so it can be empty or low-tier on a quiet cycle. We use
+    /// [`CadenceController::raise_tier_for`] (only ever speeds up) rather than
+    /// `set_tier_for` so a quiet poll cannot downshift a source whose
+    /// higher-tier issues are still open.
     async fn note_fetch_success(&self, issues: &[octocrab::models::issues::Issue]) {
         let policies: Vec<AutomationPolicy> = issues
             .iter()
@@ -109,7 +115,7 @@ impl GitHubIssuesTaskSource {
             })
             .collect();
         let mut c = self.cadence.lock().await;
-        c.set_tier_for(&self.id, &policies);
+        c.raise_tier_for(&self.id, &policies);
         c.notify_success(&self.id);
     }
 
@@ -212,17 +218,22 @@ impl TaskSource for GitHubIssuesTaskSource {
         "github_issues"
     }
 
-    /// Polls GitHub's issues API on a fixed interval, emitting events for each
-    /// open issue matching the configured label filters.
+    /// Polls GitHub's issues API on a tier-aware cadence, emitting events for
+    /// each open issue matching the configured label filters.
+    ///
+    /// Each cycle sleeps a cadence-driven interval (L1 5min / L2 2min /
+    /// L3 1min, scaled by the most aggressive tier among fetched issues, with
+    /// exponential rate-limit backoff and ±10% jitter) rather than a fixed
+    /// interval — see [`crate::cadence`].
     ///
     /// The stream uses a `since` watermark (tracking `updated_at`) to avoid
-    /// re-emitting issues that haven't changed since the last poll cycle.
+    /// re-emitting issues that haven't changed since the last poll cycle, and
+    /// an internal queue to emit all issues from a single fetch before polling
+    /// again.
     ///
-    /// Uses an internal queue to emit all issues from a single fetch before polling again.
-    ///
-    /// Rate-limit errors and authentication failures are mapped to `Error::RateLimited`
-    /// and `Error::AuthFailed` respectively, allowing the consumer to implement
-    /// backoff logic.
+    /// Rate-limit errors and authentication failures are mapped to
+    /// `Error::RateLimited` and `Error::AuthFailed` respectively; a
+    /// rate-limited fetch also bumps the cadence backoff.
     #[allow(clippy::excessive_nesting)]
     fn watch_for_tasks<'a>(&'a self) -> BoxStream<'a, Result<TaskEvent>> {
         use std::collections::VecDeque;

--- a/docs/tracker-automation.md
+++ b/docs/tracker-automation.md
@@ -192,9 +192,8 @@ The merge returns one of:
 PR-less providers keep the trait-default `merge_pr`, which errors; they never
 reach this path because their readiness stays `Blocked`.
 
-> **Still deferred to the next M2 task.** `CadenceController` is wired into
-> diagnostics but not yet into the source poll loops — see the priority-label
-> section below and ADR 0013 § "Tier-aware polling".
+The GitHub source polls on a **tier-aware cadence** (see the priority-label
+section below): faster for L3 tickets, with exponential backoff on rate limits.
 
 ## Priority labels
 
@@ -202,12 +201,13 @@ The label `surge-priority/<level>` is honoured independently of the tier
 label. Recognized levels: `urgent`, `high`, `medium`, `low`. Priority affects:
 
 - Inbox-card sort order.
-- (Future) `CadenceController` polling pace — the algorithm exists in
-  [`surge_intake::cadence`](../crates/surge-intake/src/cadence.rs) with the
-  tier-aware interval table (L1 = 5 min, L2 = 2 min, L3 = 1 min,
-  exponential backoff on rate-limit). Production wiring of the controller
-  into the source poll loops is staged in a follow-up — see ADR 0013
-  § "Tier-aware polling" for the deferred-work note.
+- `CadenceController` polling pace ([`surge_intake::cadence`](../crates/surge-intake/src/cadence.rs)):
+  tier-aware interval table (L1 = 5 min, L2 = 2 min, L3 = 1 min) with
+  exponential backoff on rate-limit and ±10% jitter. The **GitHub** source is
+  wired — each poll sleeps the cadence interval, sets its tier from the
+  fetched issues' labels, and backs off on a rate-limited fetch. The **Linear**
+  source still polls at its fixed configured interval (its fetch path does not
+  yet surface per-issue labels); wiring it is a follow-up.
 
 ## External state changes (ticket-as-master)
 

--- a/docs/tracker-automation.md
+++ b/docs/tracker-automation.md
@@ -198,16 +198,25 @@ section below): faster for L3 tickets, with exponential backoff on rate limits.
 ## Priority labels
 
 The label `surge-priority/<level>` is honoured independently of the tier
-label. Recognized levels: `urgent`, `high`, `medium`, `low`. Priority affects:
+label. Recognized levels: `urgent`, `high`, `medium`, `low`. Priority affects
+inbox-card sort order. (Priority does **not** drive polling cadence — that is
+the automation tier's job, below.)
 
-- Inbox-card sort order.
-- `CadenceController` polling pace ([`surge_intake::cadence`](../crates/surge-intake/src/cadence.rs)):
-  tier-aware interval table (L1 = 5 min, L2 = 2 min, L3 = 1 min) with
-  exponential backoff on rate-limit and ±10% jitter. The **GitHub** source is
-  wired — each poll sleeps the cadence interval, sets its tier from the
-  fetched issues' labels, and backs off on a rate-limited fetch. The **Linear**
-  source still polls at its fixed configured interval (its fetch path does not
-  yet surface per-issue labels); wiring it is a follow-up.
+## Polling cadence
+
+Poll pace is driven by the **automation tier** (not the priority label), via
+[`CadenceController`](../crates/surge-intake/src/cadence.rs). The tier is
+resolved from the `surge:*` automation labels (`surge:enabled` → L1,
+`surge:template/*` → L2, `surge:auto` → L3) — the same `resolve_policy` used
+elsewhere — and maps to an interval table: L1 = 5 min, L2 = 2 min, L3 = 1 min,
+with exponential backoff on rate-limit and ±10% jitter.
+
+The **GitHub** source is wired: each poll sleeps the cadence interval, raises
+its tier from the fetched issues' automation labels (only ever speeding up, so
+a quiet incremental poll never downshifts a still-active high tier), and backs
+off on a rate-limited fetch. The **Linear** source still polls at its fixed
+configured interval — its fetch path does not yet surface per-issue labels, so
+both tier-aware cadence and downshift-on-close there are follow-ups.
 
 ## External state changes (ticket-as-master)
 


### PR DESCRIPTION
## v0.2 M2 (part 2 of 2): tier-aware poll cadence

Completes M2. Part 1 ([#74](https://github.com/vanyastaff/surge/pull/74)) shipped the real merge action; this wires the `CadenceController` (built + unit-tested earlier, but unwired) into the GitHub poll loop.

### What changed
Each polling source owns one `CadenceController` (keyed by its id — no daemon-wide singleton, no `new()` signature change). Inside `GitHubIssuesTaskSource::watch_for_tasks`:
- sleep `next_interval` (L1 5min / L2 2min / L3 1min) with a deterministic golden-ratio `jitter_seed`, replacing the fixed `poll_interval`;
- `set_tier_for` from the fetched issues' labels (most-aggressive tier wins);
- `notify_success` on a clean fetch, `notify_rate_limited` (→ exponential backoff, ±10% jitter, 15min ceiling) on a rate-limited one.

`config.poll_interval` is superseded by the tier cadence (kept for back-compat). Docs (`tracker-automation.md`, `cadence.rs` module doc) updated.

### Scope
GitHub only. The Linear source's fetch path (`fetch_and_emit_events`) does not surface per-issue labels, so tier-aware cadence there needs a refactor — deferred as a follow-up; Linear keeps its fixed interval (no regression).

### Tests
`jitter_seed` (unit-interval + spread + feeds `next_interval` within band) and a **cadence-backoff** test driving the GitHub source's wiring: a rate-limit bumps backoff, a non-rate-limit error does not, a clean fetch clears it. The `CadenceController` algorithm itself was already fully unit-tested. `cargo fmt` clean; `surge-core`/`surge-intake` clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * GitHub polling intervals now adapt dynamically based on issue priority tier
  * Exponential backoff applied when rate-limited; resets on successful fetches
  * Jitter added to polling intervals to distribute requests

* **Tests**
  * Added unit tests verifying tier-aware backoff behavior

* **Documentation**
  * Updated polling behavior documentation to reflect tier-aware cadence control

<!-- end of auto-generated comment: release notes by coderabbit.ai -->