### PR TITLE
feat(orchestrator): durability fault-injection harness (v0.2 M4 slice 1)

### DIFF
--- a/crates/surge-cli/src/commands/engine.rs
+++ b/crates/surge-cli/src/commands/engine.rs
@@ -504,19 +504,22 @@ fn parse_run_id(s: &str) -> Result<RunId> {
 }
 
 fn surge_runs_dir() -> Result<PathBuf> {
-    // `SURGE_HOME` relocates the entire `.surge` tree. It gives the durability
-    // harness an isolated, cross-platform sandbox (HOME overrides are
-    // unreliable on Windows where `dirs` reads a Win32 known-folder, not the
-    // env). Falls back to the user home.
-    let home = match std::env::var_os("SURGE_HOME") {
-        Some(h) => PathBuf::from(h),
-        None => dirs::home_dir().ok_or_else(|| anyhow!("HOME not set"))?,
+    // `SURGE_HOME`, when set and non-empty, IS the surge home dir itself
+    // (matching `feature::surge_home_dir` and `profile_loader::paths::surge_home`);
+    // otherwise fall back to `~/.surge`. It gives the durability harness an
+    // isolated, cross-platform sandbox — `dirs::home_dir()` on Windows reads a
+    // Win32 known-folder and ignores HOME/USERPROFILE overrides.
+    let surge_home = match std::env::var("SURGE_HOME") {
+        Ok(custom) if !custom.is_empty() => PathBuf::from(custom),
+        _ => dirs::home_dir()
+            .ok_or_else(|| anyhow!("SURGE_HOME unset and home directory unknown"))?
+            .join(".surge"),
     };
-    let dir = home.join(".surge").join("runs");
-    std::fs::create_dir_all(&dir).with_context(|| format!("create {}", dir.display()))?;
-    // Storage::open expects the parent .surge dir, not .surge/runs;
-    // storage itself creates the runs/ subdir. Return .surge.
-    Ok(home.join(".surge"))
+    let runs = surge_home.join("runs");
+    std::fs::create_dir_all(&runs).with_context(|| format!("create {}", runs.display()))?;
+    // Storage::open expects the surge-home dir (parent of runs/), which it
+    // populates with the runs/ subdir itself.
+    Ok(surge_home)
 }
 
 fn build_default_notifier() -> Arc<dyn surge_notify::NotifyDeliverer> {

--- a/crates/surge-cli/src/commands/engine.rs
+++ b/crates/surge-cli/src/commands/engine.rs
@@ -504,7 +504,14 @@ fn parse_run_id(s: &str) -> Result<RunId> {
 }
 
 fn surge_runs_dir() -> Result<PathBuf> {
-    let home = dirs::home_dir().ok_or_else(|| anyhow!("HOME not set"))?;
+    // `SURGE_HOME` relocates the entire `.surge` tree. It gives the durability
+    // harness an isolated, cross-platform sandbox (HOME overrides are
+    // unreliable on Windows where `dirs` reads a Win32 known-folder, not the
+    // env). Falls back to the user home.
+    let home = match std::env::var_os("SURGE_HOME") {
+        Some(h) => PathBuf::from(h),
+        None => dirs::home_dir().ok_or_else(|| anyhow!("HOME not set"))?,
+    };
     let dir = home.join(".surge").join("runs");
     std::fs::create_dir_all(&dir).with_context(|| format!("create {}", dir.display()))?;
     // Storage::open expects the parent .surge dir, not .surge/runs;

--- a/crates/surge-cli/tests/fault_injection.rs
+++ b/crates/surge-cli/tests/fault_injection.rs
@@ -50,6 +50,9 @@ fn unclean_exit_mid_run_preserves_and_folds_event_log() {
         .env("USERPROFILE", &surge_home)
         .env("SURGE_HOME", &surge_home)
         .env("SURGE_CHECKPOINT_EXIT", "impl_1")
+        // Fail fast if the seam ever regresses: `--watch` would otherwise keep
+        // the CLI alive waiting for a terminal event that never comes.
+        .timeout(std::time::Duration::from_secs(60))
         .output()
         .expect("spawn surge engine run");
 

--- a/crates/surge-cli/tests/fault_injection.rs
+++ b/crates/surge-cli/tests/fault_injection.rs
@@ -1,0 +1,90 @@
+//! Durability fault-injection harness (v0.2 M4, slice 1).
+//!
+//! Proves the per-run SQLite event log survives an **unclean** process death
+//! mid-run: a real `surge engine run` subprocess is aborted via the
+//! `SURGE_CHECKPOINT_EXIT` seam (`std::process::exit(99)` — no async teardown,
+//! no `Drop`, like a `kill -9`) the instant it enters the first stage, right
+//! after the `StageEntered` event is durably committed to the WAL. A fresh
+//! `surge engine replay` then folds that log and must see the precise mid-run
+//! state — proving the committed event was not lost and the log is not
+//! corrupt.
+//!
+//! The seam is `#[cfg(debug_assertions)]`, so this test only runs in debug.
+
+#![cfg(debug_assertions)]
+
+use assert_cmd::Command;
+use predicates::str::contains;
+
+/// Absolute path to the bundled two-node example flow (`impl_1` → terminal).
+fn minimal_flow() -> std::path::PathBuf {
+    let flow = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("..")
+        .join("examples")
+        .join("flow_minimal_agent.toml");
+    assert!(flow.exists(), "flow fixture missing: {}", flow.display());
+    flow
+}
+
+#[test]
+fn unclean_exit_mid_run_preserves_and_folds_event_log() {
+    let temp = tempfile::tempdir().unwrap();
+    let surge_home = temp.path().join("surge_home");
+    let worktree = temp.path().join("wt");
+    std::fs::create_dir_all(&surge_home).unwrap();
+    std::fs::create_dir_all(&worktree).unwrap();
+    let flow = minimal_flow();
+
+    // Run the flow, but abort the process uncleanly the instant it enters the
+    // first stage (`impl_1`), after StageEntered is committed. `--watch` keeps
+    // the CLI alive long enough for the spawned run task to reach the stage.
+    let out = Command::cargo_bin("surge")
+        .unwrap()
+        .args(["engine", "run"])
+        .arg(&flow)
+        .arg("--watch")
+        .arg("--worktree")
+        .arg(&worktree)
+        .env("HOME", &surge_home)
+        .env("USERPROFILE", &surge_home)
+        .env("SURGE_HOME", &surge_home)
+        .env("SURGE_CHECKPOINT_EXIT", "impl_1")
+        .output()
+        .expect("spawn surge engine run");
+
+    assert_eq!(
+        out.status.code(),
+        Some(99),
+        "expected unclean checkpoint exit (99); got {:?}. stderr:\n{}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    // The run id is printed before the run starts (first stdout line).
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let run_id = stdout
+        .lines()
+        .next()
+        .expect("run id on first stdout line")
+        .trim()
+        .to_string();
+    assert!(
+        run_id.starts_with("run"),
+        "unexpected run id {run_id:?}; stdout:\n{stdout}"
+    );
+
+    // The log left by the unclean kill must fold cleanly (no corruption) and
+    // show the run mid-flight: entered `impl_1`, not terminal.
+    Command::cargo_bin("surge")
+        .unwrap()
+        .args(["engine", "replay"])
+        .arg(&run_id)
+        .env("HOME", &surge_home)
+        .env("USERPROFILE", &surge_home)
+        .env("SURGE_HOME", &surge_home)
+        .assert()
+        .success()
+        .stdout(contains("active node:   impl_1"))
+        .stdout(contains("terminal:      no"));
+}

--- a/crates/surge-orchestrator/src/engine/run_task.rs
+++ b/crates/surge-orchestrator/src/engine/run_task.rs
@@ -459,6 +459,38 @@ async fn abort_if_cancelled(params: &RunTaskParams) -> Option<RunOutcome> {
     Some(outcome)
 }
 
+/// Pure check for the [`checkpoint_exit_if_requested`] fault-injection seam:
+/// does `env` (the `SURGE_CHECKPOINT_EXIT` value) name `node_key`?
+///
+/// Always compiled (not debug-gated) so it is unit-testable; only the actual
+/// `process::exit` wrapper is debug-gated.
+fn checkpoint_exit_matches(env: Option<&str>, node_key: &str) -> bool {
+    env.is_some_and(|target| target == node_key)
+}
+
+/// Durability fault-injection seam (debug builds only). When
+/// `SURGE_CHECKPOINT_EXIT` names the node about to execute, abort the process
+/// **uncleanly** — `std::process::exit` runs no async teardown and no `Drop`,
+/// the way a `kill -9` would. Called right after the `StageEntered` event is
+/// durably committed, so the on-disk event log is left in a precise mid-run
+/// state for the recovery/durability harness to assert against.
+#[cfg(debug_assertions)]
+fn checkpoint_exit_if_requested(node_key: &surge_core::keys::NodeKey) {
+    let target = std::env::var("SURGE_CHECKPOINT_EXIT").ok();
+    if checkpoint_exit_matches(target.as_deref(), node_key.as_str()) {
+        tracing::warn!(
+            target: "engine::fault_injection",
+            node = %node_key,
+            "SURGE_CHECKPOINT_EXIT hit; aborting process uncleanly (exit 99) after StageEntered commit"
+        );
+        std::process::exit(99);
+    }
+}
+
+#[cfg(not(debug_assertions))]
+#[inline]
+fn checkpoint_exit_if_requested(_node_key: &surge_core::keys::NodeKey) {}
+
 async fn enter_stage(
     params: &RunTaskParams,
     cursor: &Cursor,
@@ -471,6 +503,8 @@ async fn enter_stage(
         }))
         .await
         .map_err(|e| format!("write StageEntered: {e}"))?;
+    // Fault-injection: simulate a crash mid-run, with StageEntered durable.
+    checkpoint_exit_if_requested(&cursor.node);
     params
         .writer
         .current_seq()
@@ -1461,6 +1495,14 @@ mod tests {
     use surge_core::hooks::{Hook, HookFailureMode, HookInheritance, HookTrigger, MatcherSpec};
     use surge_core::keys::ProfileKey;
     use surge_core::node::{Node, OutcomeDecl, Position};
+
+    #[test]
+    fn checkpoint_exit_matches_only_named_node() {
+        assert!(checkpoint_exit_matches(Some("impl_1"), "impl_1"));
+        assert!(!checkpoint_exit_matches(Some("impl_1"), "review_1"));
+        assert!(!checkpoint_exit_matches(None, "impl_1"));
+        assert!(!checkpoint_exit_matches(Some(""), "impl_1"));
+    }
 
     fn agent_node(hooks: Vec<Hook>, declared: Vec<&str>) -> Node {
         Node {

--- a/docs/crash-recovery.md
+++ b/docs/crash-recovery.md
@@ -109,10 +109,30 @@ Re-running recovery is a no-op:
 - `Engine::resume_run` itself guards with `RunAlreadyActive` and short-
   circuits runs whose log is already terminal.
 
-## Deferred
+## Fault-injection harness
 
-- **`kill -9` / power-cut fault-injection harness.** WAL durability is
-  provided by SQLite WAL mode (configured in the per-run pragmas) and the
-  resume-from-log path is covered by integration tests; a dedicated
-  process-kill harness that asserts checkpoint behavior under hard kill is
-  a follow-up.
+The durability claim is exercised by a real fault-injection test rather than
+trusted on inspection (v0.2 M4).
+
+**Checkpoint seam.** `engine::run_task` carries a debug-only seam: when
+`SURGE_CHECKPOINT_EXIT` names the node about to execute, the process aborts
+**uncleanly** (`std::process::exit(99)` — no async teardown, no `Drop`, like a
+`kill -9`) the instant after the node's `StageEntered` event is durably
+committed. Release builds compile this to a no-op. The match is pinned by a
+pure, unit-tested predicate (`checkpoint_exit_matches`).
+
+**Slice 1 — WAL durability under unclean death** (`surge-cli/tests/fault_injection.rs`):
+a real `surge engine run` subprocess is aborted via the seam mid-run, then a
+fresh `surge engine replay` folds the surviving on-disk log and asserts it
+shows the precise mid-run state (`active node: impl_1`, not terminal). This
+proves the committed event was not lost and the WAL log is not corrupt after a
+hard process death. Tests use `SURGE_HOME` for an isolated, cross-platform
+sandbox (HOME overrides are unreliable on Windows).
+
+**Deferred to slice 2.** The full daemon-process kill → restart → recovery
+cycle (spawn the `surge-daemon` binary, abort at each checkpoint in the matrix
+— mid-Agent-turn / pending-HumanGate / mid-Notify / pre-Terminal-append —
+restart, and assert the recovery decision policy resumes/reconciles correctly),
+plus the true power-cut case (which needs `synchronous = FULL` rather than the
+current `NORMAL`), are follow-ups. The recovery decision policy itself is
+already exhaustively unit-tested; slice 2 adds the live subprocess cycle.

--- a/docs/crash-recovery.md
+++ b/docs/crash-recovery.md
@@ -115,10 +115,10 @@ The durability claim is exercised by a real fault-injection test rather than
 trusted on inspection (v0.2 M4).
 
 **Checkpoint seam.** `engine::run_task` carries a debug-only seam: when
-`SURGE_CHECKPOINT_EXIT` names the node about to execute, the process aborts
+`SURGE_CHECKPOINT_EXIT` names the node being entered, the process aborts
 **uncleanly** (`std::process::exit(99)` — no async teardown, no `Drop`, like a
-`kill -9`) the instant after the node's `StageEntered` event is durably
-committed. Release builds compile this to a no-op. The match is pinned by a
+`kill -9`) the instant after that node's `StageEntered` event is durably
+committed, before the stage body runs. Release builds compile this to a no-op. The match is pinned by a
 pure, unit-tested predicate (`checkpoint_exit_matches`).
 
 **Slice 1 — WAL durability under unclean death** (`surge-cli/tests/fault_injection.rs`):


### PR DESCRIPTION
## v0.2 M4 (slice 1): durability fault-injection harness

Proves — via a real killed subprocess, not inspection — that the per-run SQLite event log survives a hard process death mid-run. Closes the v0.1-deferred "`kill -9` fault-injection harness" for the process-death case.

### What changed
- **Checkpoint seam** (`engine::run_task`, debug-only): `SURGE_CHECKPOINT_EXIT=<node>` aborts the process **uncleanly** (`std::process::exit(99)` — no async teardown, no `Drop`, like a `kill -9`) the instant after that node's `StageEntered` event is durably committed. The match is a pure, unit-tested predicate (`checkpoint_exit_matches`); release builds compile the seam to a no-op.
- **`SURGE_HOME`** relocates the `.surge` tree for an isolated, cross-platform test sandbox (HOME overrides are unreliable on Windows, where `dirs` reads a Win32 known-folder, not the env).
- **Harness** (`surge-cli/tests/fault_injection.rs`): spawns a real `surge engine run --watch`, the seam kills it mid-run at the first stage, then `surge engine replay` folds the surviving on-disk WAL log and asserts the precise mid-run state — `active node: impl_1`, `terminal: no` — proving **no lost committed event** and **no corruption** after a hard kill.
- **docs/crash-recovery.md**: fault-injection harness section.

### Why this shape
The recovery *decision policy* (`decide_action` / `plan_recovery` / `execute_recovery`) is already exhaustively unit-tested. What was untested is the on-disk durability under a hard kill — exactly what this real-subprocess test now exercises, deterministically (self-exit at a pinned stage, no kill-timing race → not flaky).

### Deferred to slice 2
The full daemon-process cycle (spawn `surge-daemon`, kill at each checkpoint in the matrix — mid-Agent-turn / pending-HumanGate / mid-Notify / pre-Terminal-append — restart, assert recovery resumes/reconciles), and the true power-cut case (needs `synchronous = FULL` vs the current `NORMAL`).

### Tests
`checkpoint_exit_matches` unit test + the `fault_injection` harness (debug-gated). `cargo fmt` clean; no new clippy warnings in changed code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The `SURGE_HOME` environment variable now allows customizing where Surge stores its data directory.

* **Documentation**
  * Enhanced crash recovery documentation with durability validation and recovery testing details.

* **Tests**
  * Added fault-injection testing for unclean exit and recovery scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->