### PR TITLE
feat(cli): doctor agent smoke + v0.2 remainder (M3 + M5)

### DIFF
--- a/.ai-factory/ROADMAP.md
+++ b/.ai-factory/ROADMAP.md
@@ -273,7 +273,7 @@
   - Tests: gate-green-merges, gate-red-blocks-and-escalates, conflict-escalates, idempotent double-merge, cadence backoff
   - Documentation: L3 lifecycle in `docs/tracker-automation.md` (replace the "out of scope (next milestone)" note)
 
-- [ ] **Multi-agent breadth validated live** — agent-agnostic in fact, not just in registry (touches `surge-acp`, `surge-orchestrator`, `surge-cli`)
+- [ ] **Multi-agent breadth validated live** — agent-agnostic in fact, not just in registry (touches `surge-acp`, `surge-orchestrator`, `surge-cli`) — **codeable core landed** (#76 per-runtime launch-arg unit tests + [`docs/agent-runtimes.md`](../docs/agent-runtimes.md) support matrix; `surge doctor agent <name>` real smoke with spawn/handshake/auth/prompt stage classification, env-gated `SURGE_DOCTOR_REAL`; per-runtime auth diagnostics reuse `AgentAuthenticationFailed`). **Operator-gated remainder:** live Codex/Gemini launch validation + cross-agent golden compare (need the runtimes installed + logged in).
   - Live launch validation for Codex and Gemini ACP adapters through handshake → `new_session` → `session/prompt` (the bar v0.1 hit for Claude), env-gated like `real_acp_smoke`
   - Fix any launch/arg/headless-mode gaps surfaced per runtime (mirror of the Claude headless-settings + npx-resolve work)
   - `surge doctor agent <name>` runs a real smoke session per registered runtime and reports the failure stage precisely (spawn / handshake / auth / prompt)
@@ -282,7 +282,7 @@
   - Tests: per-adapter launch-arg unit tests, doctor smoke-stage classification, golden artifact compare
   - Documentation: per-runtime support matrix + known quirks in `docs/`
 
-- [ ] **Durability proof — fault-injection harness** — recovery survives the worst case (touches `surge-daemon`, `surge-persistence`, test infra)
+- [ ] **Durability proof — fault-injection harness** — recovery survives the worst case (touches `surge-daemon`, `surge-persistence`, test infra) — **slice 1 landed** (#77): debug-only `SURGE_CHECKPOINT_EXIT` seam aborts the process uncleanly right after `StageEntered` commits; a real `surge engine run` subprocess is killed mid-run and `surge engine replay` proves the WAL log survives and folds to the partial mid-run state. **Remaining (follow-up):** the full daemon kill → restart → recover cycle across the checkpoint matrix, and the true power-cut case (`synchronous = FULL` vs the current `NORMAL`) — see [`docs/crash-recovery.md`](../docs/crash-recovery.md).
   - Harness that kills the daemon process (SIGKILL / simulated power-cut) at defined checkpoints mid-run, restarts, and asserts recovery resumes to the correct folded state
   - WAL checkpoint behavior verified: no event-log corruption, no lost committed events, no duplicate appends after restart
   - Checkpoint matrix: mid-Agent-turn, pending-HumanGate, mid-Notify, pre-Terminal-append — each asserts the v0.1 recovery decision policy
@@ -290,7 +290,7 @@
   - CI: harness runs on Linux (signals) with a Windows-named-pipe stale-handle variant
   - Closes the v0.1 deferred "`kill -9` / power-cut fault-injection harness"
 
-- [ ] **Recorded real-repo end-to-end** — the proof artifact (touches `docs/`, `examples/`, CI-adjacent)
+- [ ] **Recorded real-repo end-to-end** — the proof artifact (touches `docs/`, `examples/`, CI-adjacent) — **CI guard + operator script landed**: the mock-agent `init → describe → run` smoke runs in CI (`onboarding_smoke` in `examples_smoke.rs`) so the script can't rot; [`docs/recorded-e2e.md`](../docs/recorded-e2e.md) is the reproducible operator procedure for the real-repo + live-agent + PR run. **Operator-gated remainder:** the actual recorded run against a real public repo (needs an authenticated runtime — not runnable in CI).
   - Scripted end-to-end against a real public repo: `init → describe → approve → run → PR` with a working agent runtime, producing a real PR
   - Recorded as a reproducible example (asciinema/log + the resulting flow + artifacts) under `examples/` / `docs/`
   - Documents the one external prerequisite (agent runtime auth) and the exact commands

--- a/crates/surge-cli/src/commands/doctor.rs
+++ b/crates/surge-cli/src/commands/doctor.rs
@@ -14,12 +14,113 @@ use anyhow::Result;
 use clap::{Subcommand, ValueEnum};
 use std::path::PathBuf;
 use surge_acp::Registry;
+use surge_acp::bridge::error::{OpenSessionError, SendMessageError};
+use surge_acp::bridge::{AcpBridge, AgentKind, AlwaysAllowSandbox, MessageContent, SessionConfig};
+use surge_core::OutcomeKey;
 use surge_core::doctor::{DoctorEntry, DoctorReport, MatrixCell, MatrixCellStatus, VersionStatus};
 use surge_core::runtime::{RuntimeKind, RuntimeVersionPolicy, version_policy};
 use surge_core::sandbox::SandboxMode;
 use surge_core::sandbox_matrix::{RuntimeSandboxMatrix, RuntimeSandboxRow};
 use surge_orchestrator::engine::version_probe::{ProbeError, probe_version};
 use tracing::{debug, info, warn};
+
+/// The lifecycle stage a `surge doctor agent` smoke session reached (or
+/// failed at). Lets the operator see *where* a runtime breaks — the single
+/// most useful signal when "the agent won't work".
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SmokeStage {
+    /// Spawning the agent subprocess (binary missing / not on PATH).
+    Spawn,
+    /// ACP handshake — `initialize` / `new_session` (protocol mismatch, agent
+    /// not speaking ACP, crash before ready).
+    Handshake,
+    /// Authentication (agent process is up but not logged in / no API key).
+    Auth,
+    /// Sending the first prompt (dispatch failed for a non-auth reason).
+    Prompt,
+}
+
+impl std::fmt::Display for SmokeStage {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            Self::Spawn => "spawn",
+            Self::Handshake => "handshake",
+            Self::Auth => "auth",
+            Self::Prompt => "prompt",
+        };
+        f.write_str(s)
+    }
+}
+
+/// Map an `open_session` failure to the stage it broke at.
+fn classify_open_error(e: &OpenSessionError) -> SmokeStage {
+    match e {
+        OpenSessionError::AgentSpawnFailed { .. } => SmokeStage::Spawn,
+        // Everything else from open is the handshake leg (initialize /
+        // new_session / config validation surfaced before a session exists).
+        _ => SmokeStage::Handshake,
+    }
+}
+
+/// Map a `send_message` failure to the stage it broke at. Auth failures get
+/// their own stage (reusing the `AgentAuthenticationFailed` classification
+/// from the prompt-dispatch path) so the operator is told to log in.
+fn classify_send_error(e: &SendMessageError) -> SmokeStage {
+    match e {
+        SendMessageError::AgentAuthenticationFailed { .. } => SmokeStage::Auth,
+        _ => SmokeStage::Prompt,
+    }
+}
+
+/// Run a real ACP smoke session against `entry`: spawn → handshake →
+/// new_session → one prompt, then close. Returns the first stage that failed
+/// (with a detail string), or `Ok(())` when every reachable stage passed.
+///
+/// Requires the runtime's binary installed and authenticated — hence the
+/// `SURGE_DOCTOR_REAL` gate in [`run_agent_smoke`].
+async fn run_real_smoke(
+    entry: &surge_acp::RegistryEntry,
+) -> std::result::Result<(), (SmokeStage, String)> {
+    // The builtin registry launches via npx with the full invocation in
+    // `default_args`, so `Custom` spawns `command + args` verbatim (same as
+    // the engine's resolution; see `derive_agent_kind_from_id`).
+    let agent_kind = AgentKind::Custom {
+        binary: PathBuf::from(&entry.command),
+        args: entry.default_args.clone(),
+    };
+    let workdir = std::env::temp_dir().join(format!("surge-doctor-smoke-{}", entry.id));
+    let _ = std::fs::create_dir_all(&workdir);
+    let outcome = OutcomeKey::try_from("done").expect("static outcome key");
+    let config = SessionConfig {
+        agent_kind,
+        working_dir: workdir,
+        system_prompt: "Surge doctor smoke. Touch no files.".into(),
+        declared_outcomes: vec![outcome],
+        allows_escalation: false,
+        tools: vec![],
+        sandbox: Box::new(AlwaysAllowSandbox),
+        permission_policy: surge_acp::client::PermissionPolicy::default(),
+        bindings: Default::default(),
+    };
+
+    let bridge = AcpBridge::with_defaults().map_err(|e| (SmokeStage::Spawn, e.to_string()))?;
+    let session = match bridge.open_session(config).await {
+        Ok(s) => s,
+        Err(e) => return Err((classify_open_error(&e), e.to_string())),
+    };
+    // Spawn + handshake passed. Send one prompt to exercise auth/dispatch.
+    let send = bridge
+        .send_message(
+            session,
+            MessageContent::Text("Report the `done` outcome immediately.".into()),
+        )
+        .await;
+    let _ = bridge.close_session(session).await;
+    match send {
+        Ok(()) => Ok(()),
+        Err(e) => Err((classify_send_error(&e), e.to_string())),
+    }
+}
 
 /// `surge doctor` subcommand surface.
 #[derive(Subcommand, Debug)]
@@ -260,13 +361,30 @@ async fn run_agent_smoke(name: String) -> Result<()> {
     }
 
     if real {
-        // Real smoke: open ACP session, send canned prompt, close.
-        // Deferred to Task 11's full implementation — placeholder for now.
-        warn!(
-            target: "surge_cli.doctor",
-            "real smoke session not yet wired; rerun with SURGE_DOCTOR_REAL unset for matrix-only dry-run"
-        );
-        println!("real smoke session: NOT YET IMPLEMENTED — Task 11 follow-up");
+        // Real smoke: spawn → handshake → new_session → prompt → close.
+        // Requires the runtime installed and logged in.
+        match run_real_smoke(&entry).await {
+            Ok(()) => {
+                println!("real smoke session: PASS (spawn + handshake + prompt dispatched)");
+            },
+            Err((stage, detail)) => {
+                warn!(
+                    target: "surge_cli.doctor",
+                    agent = %name,
+                    stage = %stage,
+                    detail = %detail,
+                    "doctor smoke failed"
+                );
+                println!("real smoke session: FAIL at stage `{stage}`");
+                println!("  detail: {detail}");
+                if stage == SmokeStage::Auth {
+                    println!("  hint: log the runtime in (run its own login, or set its API key).");
+                }
+                return Err(anyhow::anyhow!(
+                    "doctor smoke for `{name}` failed at stage `{stage}`"
+                ));
+            },
+        }
     } else {
         println!("real smoke session: skipped (set SURGE_DOCTOR_REAL=1 to enable)");
     }
@@ -483,6 +601,47 @@ fn format_status(status: MatrixCellStatus) -> &'static str {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn classify_open_error_maps_spawn_vs_handshake() {
+        let spawn = OpenSessionError::AgentSpawnFailed {
+            kind: "codex".into(),
+            source: std::io::Error::new(std::io::ErrorKind::NotFound, "no binary"),
+        };
+        assert_eq!(classify_open_error(&spawn), SmokeStage::Spawn);
+
+        let handshake = OpenSessionError::HandshakeFailed {
+            reason: "protocol mismatch".into(),
+        };
+        assert_eq!(classify_open_error(&handshake), SmokeStage::Handshake);
+
+        // Non-spawn open failures all read as the handshake leg.
+        assert_eq!(
+            classify_open_error(&OpenSessionError::NoDeclaredOutcomes),
+            SmokeStage::Handshake
+        );
+    }
+
+    #[test]
+    fn classify_send_error_maps_auth_vs_prompt() {
+        let auth = SendMessageError::AgentAuthenticationFailed {
+            details: "401 authentication_error".into(),
+        };
+        assert_eq!(classify_send_error(&auth), SmokeStage::Auth);
+
+        let other = SendMessageError::Bridge(
+            surge_acp::bridge::error::BridgeError::CommandSendFailed("reset".into()),
+        );
+        assert_eq!(classify_send_error(&other), SmokeStage::Prompt);
+    }
+
+    #[test]
+    fn smoke_stage_display_is_stable() {
+        assert_eq!(SmokeStage::Spawn.to_string(), "spawn");
+        assert_eq!(SmokeStage::Handshake.to_string(), "handshake");
+        assert_eq!(SmokeStage::Auth.to_string(), "auth");
+        assert_eq!(SmokeStage::Prompt.to_string(), "prompt");
+    }
 
     #[test]
     fn matrix_dry_run_covers_four_modes() {

--- a/docs/recorded-e2e.md
+++ b/docs/recorded-e2e.md
@@ -1,0 +1,68 @@
+# Recorded end-to-end run (v0.2 M5)
+
+The core Surge thesis is **describe → approve → walk away → return to a PR**.
+This page is the reproducible proof: how to drive that loop against a real
+public repo with a real agent runtime, plus the CI guard that keeps the script
+from rotting.
+
+## CI guard (mock agent, no network)
+
+The scripted onboarding path runs in CI on every change, with the in-process
+mock agent so it needs no real runtime or network:
+
+- `crates/surge-cli/tests/examples_smoke.rs::onboarding_smoke_can_init_describe_and_start_example_run`
+  drives `surge init` → `surge project describe` → `surge engine run` with
+  `SURGE_FORCE_AGENT_MOCK=1`, asserting a run starts and prints its id.
+
+This means the `init → describe → run` plumbing — config discovery, project
+scan, graph load, engine start, event-log persistence — can't silently break;
+only the live agent + PR legs are exercised by the operator script below.
+
+## Operator script (real repo + real agent)
+
+Prerequisites — the **one** external dependency is an authenticated agent
+runtime (Claude Code is the v0.1-validated default; Codex/Gemini are wired and
+arg-tested, see [`agent-runtimes.md`](agent-runtimes.md)):
+
+```sh
+# 0. One-time: confirm the runtime is reachable and logged in.
+surge doctor agent claude-acp                 # dry-run (sandbox matrix)
+SURGE_DOCTOR_REAL=1 surge doctor agent claude-acp   # real spawn→handshake→prompt
+#   -> "real smoke session: PASS" means spawn + handshake + prompt all work.
+#   A FAIL prints the exact stage (spawn / handshake / auth / prompt).
+
+# 1. Onboard the repo.
+cd /path/to/your/repo
+surge init --default
+surge project describe          # writes project.md (captured into runs)
+
+# 2. Describe the task and run it. With a tracker (GitHub Issues / Linear)
+#    configured at L3 (`surge:auto`), the daemon will also auto-merge the PR
+#    once checks are green + the PR is approved (see tracker-automation.md).
+surge engine run --template feature --watch
+#   -> prints the run id, streams stage events, ends at a Terminal outcome.
+
+# 3. The result: a branch + PR produced by the agent in an isolated worktree.
+#    Inspect or replay the run from its event log at any point:
+surge engine replay <run_id>
+```
+
+### Recording the proof artifact
+
+To capture a shareable recording (the "recorded" part of this milestone), wrap
+step 2 in `asciinema`:
+
+```sh
+asciinema rec surge-e2e.cast -c "surge engine run --template feature --watch"
+```
+
+Attach `surge-e2e.cast`, the resulting `flow.toml`, and the produced artifacts
+(`description.md` / `roadmap.toml`) to the run record.
+
+## Status
+
+- **CI mock guard**: live (`onboarding_smoke`), runs on every change.
+- **Real-repo + live-agent run**: operator-run (needs an authenticated runtime;
+  cannot run in CI). This script is the reproducible procedure.
+- **L3 auto-merge of the resulting PR**: see [`tracker-automation.md`](tracker-automation.md)
+  (merge action + readiness gate landed in v0.2 M2).


### PR DESCRIPTION
## v0.2 remainder — CI-codeable tail (M3 + M5)

Closes the parts of the v0.2 remainder that are codeable and CI-verifiable, in one PR. (M4 slice 1 — the WAL-survives-unclean-kill durability harness — already landed in [#77](https://github.com/vanyastaff/surge/pull/77).)

### M3 — multi-agent breadth (doctor smoke)
- **`surge doctor agent <name>`** now runs a real ACP smoke under `SURGE_DOCTOR_REAL=1`: **spawn → handshake → new_session → prompt → close** via the bridge, reporting the exact **stage** that failed (`spawn` / `handshake` / `auth` / `prompt`) with an actionable login hint on auth. Auth reuses the `AgentAuthenticationFailed` classification ([#71](https://github.com/vanyastaff/surge/pull/71)). Without the gate, the existing sandbox-matrix dry-run is unchanged.
- `SmokeStage` enum + pure `classify_open_error` / `classify_send_error`, unit-tested (the CI-safe contract; the real session is operator-run since CI has no live agent).

### M5 — recorded real-repo e2e
- **`docs/recorded-e2e.md`**: the reproducible operator procedure (`init → describe → run → PR` with a live agent) + the **CI mock guard**: `onboarding_smoke` (`examples_smoke.rs`) already drives `init → describe → run` on the in-process mock agent on every change, so the scripted path can't rot.

### ROADMAP
M3/M4/M5 annotated with landed-vs-operator status.

### Honestly operator-gated (cannot run in CI — needs live runtimes/repos)
Live Codex/Gemini launch validation + cross-agent golden compare; the recorded real-repo PR run; the full daemon kill→restart→recover cycle + true power-cut (`synchronous=FULL`). All documented as operator/follow-up — no amount of in-CI code can validate them without the agents installed and authenticated.

### Tests
`doctor::tests` (smoke-stage classification + Display) + existing `onboarding_smoke` / `fault_injection`. `surge-acp`/`surge-core` strict clippy + `cargo fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
