### PR TITLE
test(orchestrator): fix flaky on_error_suppress Windows test (5s→30s hook timeout)

### DIFF
--- a/crates/surge-orchestrator/tests/on_error_suppress_test.rs
+++ b/crates/surge-orchestrator/tests/on_error_suppress_test.rs
@@ -51,7 +51,9 @@ fn on_error_suppress_hook(id: &str, command: String) -> Hook {
         matcher: MatcherSpec::default(),
         command,
         on_failure: HookFailureMode::Warn,
-        timeout_seconds: Some(5),
+        // Generous so a slow process cold-start under heavy parallel CI load
+        // (esp. Windows) can't blow the timeout and flake the suppression.
+        timeout_seconds: Some(30),
         inherit: HookInheritance::Extend,
     }
 }


### PR DESCRIPTION
## Fix flaky `on_error_suppress` Windows test

`on_error_suppresses_failure_into_declared_outcome` (`crates/surge-orchestrator/tests/on_error_suppress_test.rs`) flakes on the Windows CI Test Suite (it failed on PR #79, whose changes are unrelated daemon/cli path edits).

### Root cause
The test's `on_error` hook runs `powershell -NoProfile -Command Get-Content ...` (Windows) / `cat` (Unix) with `timeout_seconds: 5`. Under the heavy parallel Windows suite (~2019 tests via nextest), powershell cold-start can exceed 5s → the hook times out → the on-error suppression never produces the declared `retry_later` outcome → the run is `Failed` not `Completed` → the assertion (~L206) panics with `expected Completed after on_error suppression, got Failed`.

ubuntu/macOS passed, and a CI re-run of the same commit passed — confirming a load-timing flake, not a logic bug.

### Fix
Bump the hook `timeout_seconds` 5 → 30 (6× headroom). Verified the test still passes locally on Windows.

A faster Windows command (`cmd /c type`) was tried to eliminate the powershell cold-start entirely, but its stdout is not parsed as the suppression directive the way `Get-Content -Raw` is (the run then failed deterministically), so the timeout bump is the minimal correct fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
