### PR TITLE
feat(engine): fork-from-here — copy a run prefix into a new run (v0.3 M1)

### DIFF
--- a/.ai-factory/ROADMAP.md
+++ b/.ai-factory/ROADMAP.md
@@ -234,7 +234,7 @@
   - First-run UX: `surge init` walks user through config, agent install, telegram setup
   - End-to-end smoke against a real public repo recorded as an example run
 
-- [ ] **Replay & fork-from-here UI** — post-v0.1 polish over the same fold primitive (touches `surge-ui`, `surge-persistence`, `surge-cli`) — **CLI mirror started.** `surge engine replay <run_id> --seq <N>` folds the event log to seq `N` and prints the run state (reusing the tested `aggregate_status` primitive). Building it surfaced and fixed a real reader bug: `read_events` bound `EventSeq(u64::MAX)` as `-1` in SQLite (open-ended reads returned zero rows), which also silently degraded `current_status` (cockpit `/status`) and crash-recovery stuck/reconcile detection. Remaining: `surge fork <run_id> --seq <N>`, the GPUI scrubber/visual states, and live-vs-replay mode toggle.
+- [ ] **Replay & fork-from-here UI** — post-v0.1 polish over the same fold primitive (touches `surge-ui`, `surge-persistence`, `surge-cli`) — **CLI mirror started.** `surge engine replay <run_id> --seq <N>` folds the event log to seq `N` and prints the run state (reusing the tested `aggregate_status` primitive). Building it surfaced and fixed a real reader bug: `read_events` bound `EventSeq(u64::MAX)` as `-1` in SQLite (open-ended reads returned zero rows), which also silently degraded `current_status` (cockpit `/status`) and crash-recovery stuck/reconcile detection. The fork half now landed too (v0.3 M1): `surge engine fork <run_id> --seq N` + the `engine::fork::fork` core copy the event prefix, inherit the parent snapshot so the child resumes at the fork point, and record `ForkCreated` lineage. Remaining: pre-fork prompt/profile edits, the GPUI scrubber/visual states, and live-vs-replay mode toggle (see the **v0.3 — Time-travel** section).
   - Scrubber timeline rendered from event log with `seq` slider
   - Live mode disables scrubber; Replay mode enables it; clear visual differentiation
   - Fork CTA copies events `1..N` into a new run id; new git worktree at the same commit
@@ -296,6 +296,18 @@
   - Documents the one external prerequisite (agent runtime auth) and the exact commands
   - Doubles as the v0.1 release-notes "end-to-end smoke against a real public repo recorded as an example run" deliverable
   - Smoke variant wired into CI with the mock agent so the script itself can't rot
+
+## v0.3 — Time-travel: replay, fork-from-here, run history
+
+> North star: the §1 differentiator made real — *append-only event log → replay, time-travel, fork-from-here*. A run stops being a black box and becomes a navigable, forkable, queryable artifact, so a run that derails at stage 6/8 is forked from just-before-6 with a fix instead of re-run from scratch. Engine + CLI core is deterministic and CI-verifiable; the GPUI surface sits on top of it. Per-milestone task sequencing: run `/aif-plan <milestone>`.
+
+- [ ] **M1 — Fork-from-here (engine + CLI)** — **core landed.** `engine::fork::fork` copies parent events `1..=N` into a fresh run, inherits the parent's latest snapshot (child resumes at the fork point, not `graph.start`), and records `ForkCreated` lineage on the parent; `surge engine fork <run> --seq N` exposes it (prints new id + copied count + inspect/resume hints). Tested at the orchestrator level (prefix copy + fold-equality, snapshot-inherit resume position, out-of-bounds rejection) and end-to-end through the binary.
+  - **Remaining:** pre-fork edits — per-node prompt override + profile swap applied to the child's materialized graph, validated against the registry
+  - **Remaining:** optional new-worktree-at-fork-commit + auto-resume convenience
+  - **Remaining:** fork lineage surfaced in run views (parent ↔ children)
+- [ ] **M2 — Replay-at-seq enrichment** — extend `surge engine replay` with node status (completed/active/future), traversed edges, and cost-so-far; artifact-at-seq (`--artifact <name>` renders `description.md` / `roadmap.md` / `flow.toml` as of seq N); diff-at-seq; `--format json` for UI/script consumption
+- [ ] **M3 — Run history & cross-run analytics** — `surge runs` list/show with a lineage tree (parent ↔ forks); query by archetype / profile / agent / outcome; failure-pattern aggregation and cost / duration / outcome histograms over the run registry
+- [ ] **M4 — GPUI cockpit: scrubber + fork CTA** — wire replay-at-seq + fork into `surge-ui::screens::live_execution`: seq slider, live-vs-replay mode, completed/active/future node coloring, traversed-edge highlight, fork CTA, diff + artifact viewers. Surface-level, operator-verified (GUI is not CI-runnable). Subsumes the v0.1-era "Replay & fork-from-here UI" milestone
 
 ## Completed
 

--- a/.ai-factory/ROADMAP.md
+++ b/.ai-factory/ROADMAP.md
@@ -246,8 +246,8 @@
   - Keyboard shortcuts: arrow keys for prev/next event, `f` for fork, `space` for play/pause
   - Performance: scrubber update under 16ms (60fps) for runs up to 10k events
   - GPUI integration extends existing `surge-ui::screens::live_execution`
-  - CLI mirror: `surge replay <run_id> --seq <N>` prints state at that seq
-  - CLI mirror: `surge fork <run_id> --seq <N>` creates the forked run from terminal
+  - CLI mirror: `surge engine replay <run_id> --seq <N>` prints state at that seq
+  - CLI mirror: `surge engine fork <run_id> --seq <N>` creates the forked run from terminal
 
 ## v0.2 — Autonomy: AFK → PR for real
 

--- a/crates/surge-cli/src/commands/engine.rs
+++ b/crates/surge-cli/src/commands/engine.rs
@@ -84,6 +84,16 @@ pub enum EngineCommands {
         #[arg(long)]
         seq: Option<u64>,
     },
+    /// Fork a run at a given seq into a fresh run: copy events `1..=seq`
+    /// (inheriting the parent snapshot so the child resumes at the fork
+    /// point) and record `ForkCreated` lineage on the parent.
+    Fork {
+        /// Parent `RunId` (ULID) to fork from.
+        run_id: String,
+        /// Inclusive event seq to fork at (events `1..=seq` are inherited).
+        #[arg(long)]
+        seq: u64,
+    },
 }
 
 /// Top-level dispatcher for `surge engine` invocations.
@@ -110,6 +120,7 @@ pub async fn run(command: EngineCommands) -> Result<()> {
             follow,
         } => logs_command(run_id, since, follow).await,
         EngineCommands::Replay { run_id, seq } => replay_command(run_id, seq).await,
+        EngineCommands::Fork { run_id, seq } => fork_command(run_id, seq).await,
     }
 }
 
@@ -496,6 +507,28 @@ async fn replay_command(run_id: String, seq: Option<u64>) -> Result<()> {
     if let Some(ms) = snap.elapsed_ms {
         println!("elapsed:       {ms} ms");
     }
+    Ok(())
+}
+
+/// `surge engine fork <run_id> --seq N` — copy the parent's event history
+/// `1..=N` into a fresh run (inheriting the snapshot so it resumes at the fork
+/// point) and record `ForkCreated` lineage on the parent. The fork is
+/// immediately inspectable via `surge engine replay <new_id>` and resumable
+/// via `surge engine resume <new_id> --daemon`.
+async fn fork_command(run_id: String, seq: u64) -> Result<()> {
+    use surge_orchestrator::engine::fork::{ForkRequest, fork};
+
+    let parent = parse_run_id(&run_id)?;
+    let storage = Storage::open(&surge_runs_dir()?).await?;
+    let child = RunId::new();
+    let outcome = fork(&storage, ForkRequest::new(parent, child, seq)).await?;
+
+    println!("forked {parent} @ seq {seq}");
+    println!("  new run:       {}", outcome.new_run);
+    println!("  events copied: {}", outcome.copied_events);
+    println!();
+    println!("inspect:  surge engine replay {}", outcome.new_run);
+    println!("resume:   surge engine resume {} --daemon", outcome.new_run);
     Ok(())
 }
 

--- a/crates/surge-cli/tests/cli_fork.rs
+++ b/crates/surge-cli/tests/cli_fork.rs
@@ -102,7 +102,32 @@ async fn engine_fork_creates_child_from_seeded_parent() {
         .success();
     let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
     assert!(stdout.contains("events copied: 2"), "stdout was: {stdout}");
-    assert!(stdout.contains("new run:"), "stdout was: {stdout}");
+
+    // Parse the child run id from stdout and read it back from storage to prove
+    // the run was actually persisted — not just that the banner was printed.
+    let child_line = stdout
+        .lines()
+        .find(|l| l.contains("new run:"))
+        .unwrap_or_else(|| panic!("stdout must report the new run id; was: {stdout}"));
+    let child_id = child_line
+        .split_whitespace()
+        .last()
+        .expect("new run line has an id");
+    let child: RunId = child_id
+        .parse()
+        .unwrap_or_else(|e| panic!("new run id '{child_id}' must parse: {e}"));
+
+    let storage = Storage::open(tmp.path()).await.unwrap();
+    let reader = storage
+        .open_run_reader(child)
+        .await
+        .expect("forked child run must be persisted on disk");
+    let seq = reader.current_seq().await.unwrap();
+    assert_eq!(
+        seq.as_u64(),
+        2,
+        "child run must hold the 2 inherited events from the parent prefix"
+    );
 }
 
 #[test]

--- a/crates/surge-cli/tests/cli_fork.rs
+++ b/crates/surge-cli/tests/cli_fork.rs
@@ -1,0 +1,119 @@
+//! `surge engine fork` end-to-end.
+//!
+//! Fork is pure event copying — no agent runtime is needed — so the parent run
+//! is seeded directly through the persistence layer, then the real `surge`
+//! binary forks it and we assert the child run is created with the inherited
+//! prefix.
+
+use std::collections::BTreeMap;
+use std::path::Path;
+
+use surge_core::approvals::ApprovalPolicy;
+use surge_core::content_hash::ContentHash;
+use surge_core::graph::{Graph, GraphMetadata, SCHEMA_VERSION};
+use surge_core::id::RunId;
+use surge_core::keys::NodeKey;
+use surge_core::node::{Node, NodeConfig, Position};
+use surge_core::run_event::{EventPayload, RunConfig, VersionedEventPayload};
+use surge_core::sandbox::SandboxMode;
+use surge_core::terminal_config::{TerminalConfig, TerminalKind};
+use surge_persistence::runs::Storage;
+
+fn minimal_graph() -> Graph {
+    let end = NodeKey::try_from("end").unwrap();
+    let mut nodes = BTreeMap::new();
+    nodes.insert(
+        end.clone(),
+        Node {
+            id: end.clone(),
+            position: Position::default(),
+            declared_outcomes: vec![],
+            config: NodeConfig::Terminal(TerminalConfig {
+                kind: TerminalKind::Success,
+                message: None,
+            }),
+        },
+    );
+    Graph {
+        schema_version: SCHEMA_VERSION,
+        metadata: GraphMetadata {
+            name: "fork-cli-test".into(),
+            description: None,
+            template_origin: None,
+            created_at: chrono::Utc::now(),
+            author: None,
+            archetype: None,
+        },
+        start: end,
+        nodes,
+        edges: vec![],
+        subgraphs: BTreeMap::new(),
+    }
+}
+
+/// Seed a parent run with two events (`RunStarted`, `PipelineMaterialized`)
+/// under `home` (the `SURGE_HOME` the binary will read). Returns its id.
+async fn seed_parent(home: &Path) -> RunId {
+    let storage = Storage::open(home).await.unwrap();
+    let parent = RunId::new();
+    let worktree = home.to_path_buf();
+    let writer = storage.create_run(parent, &worktree, None).await.unwrap();
+
+    let graph = minimal_graph();
+    let graph_hash = ContentHash::compute(&serde_json::to_vec(&graph).unwrap());
+    let config = RunConfig {
+        sandbox_default: SandboxMode::WorkspaceWrite,
+        approval_default: ApprovalPolicy::OnRequest,
+        auto_pr: false,
+        mcp_servers: vec![],
+    };
+    writer
+        .append_events(vec![
+            VersionedEventPayload::new(EventPayload::RunStarted {
+                pipeline_template: None,
+                project_path: worktree.clone(),
+                initial_prompt: "seed".into(),
+                config,
+            }),
+            VersionedEventPayload::new(EventPayload::PipelineMaterialized {
+                graph: Box::new(graph),
+                graph_hash,
+            }),
+        ])
+        .await
+        .unwrap();
+    // Release the writer + registry handles before the binary opens the same
+    // SURGE_HOME in a separate process.
+    drop(writer);
+    drop(storage);
+    parent
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn engine_fork_creates_child_from_seeded_parent() {
+    let tmp = tempfile::tempdir().unwrap();
+    let parent = seed_parent(tmp.path()).await;
+
+    let assert = assert_cmd::Command::cargo_bin("surge")
+        .unwrap()
+        .env("SURGE_HOME", tmp.path())
+        .args(["engine", "fork", &parent.to_string(), "--seq", "2"])
+        .assert()
+        .success();
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+    assert!(stdout.contains("events copied: 2"), "stdout was: {stdout}");
+    assert!(stdout.contains("new run:"), "stdout was: {stdout}");
+}
+
+#[test]
+fn engine_fork_nonexistent_run_fails_cleanly() {
+    let tmp = tempfile::tempdir().unwrap();
+    // Syntactically valid ULID, but there is no such run on disk.
+    let fake = "01ARZ3NDEKTSV4RRFFQ69G5FAV";
+    assert_cmd::Command::cargo_bin("surge")
+        .unwrap()
+        .env("SURGE_HOME", tmp.path())
+        .args(["engine", "fork", fake, "--seq", "1"])
+        .assert()
+        .failure();
+}

--- a/crates/surge-orchestrator/src/engine/error.rs
+++ b/crates/surge-orchestrator/src/engine/error.rs
@@ -113,6 +113,12 @@ pub enum EngineError {
     /// block is present.
     #[error("archetype block missing: {0}")]
     ArchetypeMissing(String),
+
+    /// A `fork` request was invalid: `at_seq` is out of bounds (zero or past
+    /// the parent's last event), or the inherited prefix lacks a `RunStarted`
+    /// event to seed the child run.
+    #[error("invalid fork request: {0}")]
+    ForkInvalid(String),
 }
 
 fn format_node_cycle(nodes: &[surge_core::keys::NodeKey]) -> String {

--- a/crates/surge-orchestrator/src/engine/fork.rs
+++ b/crates/surge-orchestrator/src/engine/fork.rs
@@ -61,7 +61,8 @@ pub struct ForkOutcome {
 /// # Errors
 ///
 /// Returns [`EngineError`] if the parent has no readable log, `at_seq` is out
-/// of bounds, the prefix lacks a `RunStarted` event, or persistence fails.
+/// of bounds, the inherited prefix does not begin with a `RunStarted` event,
+/// or persistence fails.
 pub async fn fork(storage: &Arc<Storage>, req: ForkRequest) -> Result<ForkOutcome, EngineError> {
     let reader = storage
         .open_run_reader(req.parent)
@@ -85,24 +86,38 @@ pub async fn fork(storage: &Arc<Storage>, req: ForkRequest) -> Result<ForkOutcom
         .await
         .map_err(|e| EngineError::Storage(e.to_string()))?;
 
-    // The prefix must begin with `RunStarted` so the child has a project path
-    // and config to fold; reuse the parent's so the fork stays in the same
-    // project (a fresh worktree is provisioned by the caller).
-    let (project_path, pipeline_template) = prefix
-        .iter()
-        .find_map(|e| match &e.payload.payload {
-            EventPayload::RunStarted {
-                project_path,
-                pipeline_template,
-                ..
-            } => Some((project_path.clone(), pipeline_template.clone())),
-            _ => None,
-        })
-        .ok_or_else(|| {
-            EngineError::ForkInvalid(
+    // The prefix must BEGIN with `RunStarted` (it is always seq 1 in a
+    // well-formed log). Requiring the first event — rather than scanning for
+    // any `RunStarted` — rejects a malformed parent log that would otherwise be
+    // copied into the child with an impossible event order. The child reuses
+    // the parent's project path so the fork stays in the same project (a fresh
+    // worktree is provisioned by the caller).
+    let (project_path, pipeline_template) = match prefix.first().map(|e| &e.payload.payload) {
+        Some(EventPayload::RunStarted {
+            project_path,
+            pipeline_template,
+            ..
+        }) => (project_path.clone(), pipeline_template.clone()),
+        _ => {
+            return Err(EngineError::ForkInvalid(
                 "inherited prefix has no RunStarted event to seed the fork".into(),
-            )
-        })?;
+            ));
+        },
+    };
+
+    // The fork is not atomic across the two per-run logs (parent and child are
+    // separate SQLite databases — there is no shared transaction). To keep the
+    // worst-case failure benign we: (1) acquire the parent writer up front so
+    // an actively-running parent fails fast, before any orphan child is
+    // created; (2) write the child fully (it is self-contained and the
+    // authoritative artifact); then (3) append the parent lineage last. The
+    // only residual failure is a usable child without a parent back-ref — never
+    // a `ForkCreated` pointing at a child that does not exist. Each fork uses a
+    // fresh child id, so a retry creates a distinct run, not a duplicate.
+    let parent_writer = storage
+        .open_run_writer(req.parent)
+        .await
+        .map_err(|e| EngineError::Storage(e.to_string()))?;
 
     // Create the child run and copy the prefix payloads verbatim. Folding the
     // child therefore reproduces the parent's state at `at_seq` exactly.
@@ -134,12 +149,8 @@ pub async fn fork(storage: &Arc<Storage>, req: ForkRequest) -> Result<ForkOutcom
             .map_err(|e| EngineError::Storage(e.to_string()))?;
     }
 
-    // Record lineage on the parent. Appends are allowed even after a terminal
-    // event (the append-only triggers block UPDATE/DELETE, not INSERT).
-    let parent_writer = storage
-        .open_run_writer(req.parent)
-        .await
-        .map_err(|e| EngineError::Storage(e.to_string()))?;
+    // Record lineage on the parent last (append-only; valid even after a
+    // terminal event, since the triggers block UPDATE/DELETE, not INSERT).
     parent_writer
         .append_events(vec![VersionedEventPayload::new(
             EventPayload::ForkCreated {
@@ -431,6 +442,40 @@ mod tests {
         assert!(
             matches!(past, Err(EngineError::ForkInvalid(_))),
             "seq past the last event must be rejected, got {past:?}"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn fork_rejects_prefix_not_starting_with_run_started() {
+        let dir = tempfile::tempdir().unwrap();
+        let storage = Storage::open(dir.path()).await.unwrap();
+        let parent = RunId::new();
+        let worktree = dir.path().to_path_buf();
+        let writer = storage.create_run(parent, &worktree, None).await.unwrap();
+
+        let graph = minimal_graph();
+        let graph_hash = ContentHash::compute(&serde_json::to_vec(&graph).unwrap());
+        // Malformed log: the first event is NOT RunStarted. A scan-anywhere
+        // check would accept this; requiring `prefix.first()` rejects it.
+        writer
+            .append_events(vec![
+                VersionedEventPayload::new(EventPayload::PipelineMaterialized {
+                    graph: Box::new(graph),
+                    graph_hash,
+                }),
+                VersionedEventPayload::new(EventPayload::StageEntered {
+                    node: NodeKey::try_from("end").unwrap(),
+                    attempt: 1,
+                }),
+            ])
+            .await
+            .unwrap();
+        drop(writer);
+
+        let res = fork(&storage, ForkRequest::new(parent, RunId::new(), 2)).await;
+        assert!(
+            matches!(res, Err(EngineError::ForkInvalid(_))),
+            "fork must reject a prefix that does not begin with RunStarted, got {res:?}"
         );
     }
 }

--- a/crates/surge-orchestrator/src/engine/fork.rs
+++ b/crates/surge-orchestrator/src/engine/fork.rs
@@ -1,0 +1,441 @@
+//! Fork-from-here: spawn a new run that inherits a parent run's event history
+//! up to a chosen `seq`, then diverges forward from that point.
+//!
+//! Invariant: the child log is a faithful copy of the parent's first `at_seq`
+//! event payloads, so `fold(child_events) == fold(parent_events[1..=at_seq])`.
+//! The parent records a `ForkCreated { new_run, fork_at_seq }` event so the
+//! lineage survives in the (append-only) event log.
+
+use std::sync::Arc;
+
+use surge_core::id::RunId;
+use surge_core::run_event::{EventPayload, VersionedEventPayload};
+use surge_persistence::runs::Storage;
+use surge_persistence::runs::seq::EventSeq;
+
+use crate::engine::error::EngineError;
+
+/// Pre-fork edits applied to the child's inherited history before it resumes.
+///
+/// Empty today; prompt/profile overrides land in a later M1 increment.
+#[derive(Debug, Clone, Default)]
+pub struct ForkEdits {}
+
+/// Request to fork `parent` at `at_seq` into a fresh run `new_run`.
+#[derive(Debug, Clone)]
+pub struct ForkRequest {
+    /// The run whose history is inherited.
+    pub parent: RunId,
+    /// The fresh run id that receives the copied prefix.
+    pub new_run: RunId,
+    /// Inclusive sequence to fork at: events `1..=at_seq` are copied.
+    pub at_seq: u64,
+    /// Optional pre-fork edits.
+    pub edits: ForkEdits,
+}
+
+impl ForkRequest {
+    /// Build a request with no pre-fork edits.
+    #[must_use]
+    pub fn new(parent: RunId, new_run: RunId, at_seq: u64) -> Self {
+        Self {
+            parent,
+            new_run,
+            at_seq,
+            edits: ForkEdits::default(),
+        }
+    }
+}
+
+/// Outcome of a successful fork.
+#[derive(Debug, Clone)]
+pub struct ForkOutcome {
+    /// The new run id.
+    pub new_run: RunId,
+    /// Number of event payloads copied from the parent (equals `at_seq`).
+    pub copied_events: u64,
+}
+
+/// Fork a run: copy parent events `1..=at_seq` into `new_run`, then record a
+/// `ForkCreated { new_run, fork_at_seq }` event on the parent for lineage.
+///
+/// The child's log is a byte-for-byte copy of the parent prefix, so folding it
+/// reproduces the parent's state at `at_seq` exactly. The child does not start
+/// executing here; the caller resumes it (see `Engine::resume_run`).
+///
+/// # Errors
+///
+/// Returns [`EngineError`] if the parent has no readable log, `at_seq` is out
+/// of bounds, the prefix lacks a `RunStarted` event, or persistence fails.
+pub async fn fork(storage: &Arc<Storage>, req: ForkRequest) -> Result<ForkOutcome, EngineError> {
+    let reader = storage
+        .open_run_reader(req.parent)
+        .await
+        .map_err(|e| EngineError::Storage(e.to_string()))?;
+    let max = reader
+        .current_seq()
+        .await
+        .map_err(|e| EngineError::Storage(e.to_string()))?
+        .as_u64();
+    if req.at_seq == 0 || req.at_seq > max {
+        return Err(EngineError::ForkInvalid(format!(
+            "seq {} is out of bounds (parent run has {max} events)",
+            req.at_seq
+        )));
+    }
+
+    // Inherited prefix: parent events 1..=at_seq.
+    let prefix = reader
+        .read_events(EventSeq(1)..EventSeq(req.at_seq + 1))
+        .await
+        .map_err(|e| EngineError::Storage(e.to_string()))?;
+
+    // The prefix must begin with `RunStarted` so the child has a project path
+    // and config to fold; reuse the parent's so the fork stays in the same
+    // project (a fresh worktree is provisioned by the caller).
+    let (project_path, pipeline_template) = prefix
+        .iter()
+        .find_map(|e| match &e.payload.payload {
+            EventPayload::RunStarted {
+                project_path,
+                pipeline_template,
+                ..
+            } => Some((project_path.clone(), pipeline_template.clone())),
+            _ => None,
+        })
+        .ok_or_else(|| {
+            EngineError::ForkInvalid(
+                "inherited prefix has no RunStarted event to seed the fork".into(),
+            )
+        })?;
+
+    // Create the child run and copy the prefix payloads verbatim. Folding the
+    // child therefore reproduces the parent's state at `at_seq` exactly.
+    let child_writer = storage
+        .create_run(
+            req.new_run,
+            &project_path,
+            pipeline_template.map(|t| t.to_string()),
+        )
+        .await
+        .map_err(|e| EngineError::Storage(e.to_string()))?;
+    let copied: Vec<VersionedEventPayload> = prefix.iter().map(|e| e.payload.clone()).collect();
+    child_writer
+        .append_events(copied)
+        .await
+        .map_err(|e| EngineError::Storage(e.to_string()))?;
+
+    // Inherit the parent's latest snapshot at-or-before the fork point so the
+    // child resumes at the fork position rather than `graph.start`. Without
+    // this, `replay` would fall back to `graph.start` for a snapshot-less log.
+    if let Some((snap_seq, blob)) = reader
+        .latest_snapshot_at_or_before(EventSeq(req.at_seq))
+        .await
+        .map_err(|e| EngineError::Storage(e.to_string()))?
+    {
+        child_writer
+            .write_graph_snapshot(snap_seq, blob)
+            .await
+            .map_err(|e| EngineError::Storage(e.to_string()))?;
+    }
+
+    // Record lineage on the parent. Appends are allowed even after a terminal
+    // event (the append-only triggers block UPDATE/DELETE, not INSERT).
+    let parent_writer = storage
+        .open_run_writer(req.parent)
+        .await
+        .map_err(|e| EngineError::Storage(e.to_string()))?;
+    parent_writer
+        .append_events(vec![VersionedEventPayload::new(
+            EventPayload::ForkCreated {
+                new_run: req.new_run,
+                fork_at_seq: req.at_seq,
+            },
+        )])
+        .await
+        .map_err(|e| EngineError::Storage(e.to_string()))?;
+
+    Ok(ForkOutcome {
+        new_run: req.new_run,
+        // The bounds check guarantees the prefix holds exactly `at_seq`
+        // contiguous events (the log has no gaps from seq 1).
+        copied_events: req.at_seq,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeMap;
+    use surge_core::approvals::ApprovalPolicy;
+    use surge_core::content_hash::ContentHash;
+    use surge_core::graph::{Graph, GraphMetadata, SCHEMA_VERSION};
+    use surge_core::keys::{NodeKey, OutcomeKey};
+    use surge_core::node::{Node, NodeConfig, Position};
+    use surge_core::run_event::RunConfig;
+    use surge_core::run_state::RunMemory;
+    use surge_core::sandbox::SandboxMode;
+    use surge_core::terminal_config::{TerminalConfig, TerminalKind};
+    use surge_persistence::runs::reader::ReadEvent;
+
+    fn minimal_graph() -> Graph {
+        let end = NodeKey::try_from("end").unwrap();
+        let mut nodes = BTreeMap::new();
+        nodes.insert(
+            end.clone(),
+            Node {
+                id: end.clone(),
+                position: Position::default(),
+                declared_outcomes: vec![],
+                config: NodeConfig::Terminal(TerminalConfig {
+                    kind: TerminalKind::Success,
+                    message: None,
+                }),
+            },
+        );
+        Graph {
+            schema_version: SCHEMA_VERSION,
+            metadata: GraphMetadata {
+                name: "fork-test".into(),
+                description: None,
+                template_origin: None,
+                created_at: chrono::Utc::now(),
+                author: None,
+                archetype: None,
+            },
+            start: end,
+            nodes,
+            edges: vec![],
+            subgraphs: BTreeMap::new(),
+        }
+    }
+
+    /// Fold the given events (whose `seq <= upto`) into a fresh `RunMemory`,
+    /// mirroring what `engine::replay::replay` does internally.
+    fn fold_to(events: &[ReadEvent], run_id: RunId, upto: u64) -> RunMemory {
+        use chrono::TimeZone;
+        let mut mem = RunMemory::default();
+        for ev in events.iter().filter(|e| e.seq.as_u64() <= upto) {
+            let timestamp = chrono::Utc
+                .timestamp_millis_opt(ev.timestamp_ms)
+                .single()
+                .unwrap();
+            let core = surge_core::run_event::RunEvent {
+                run_id,
+                seq: ev.seq.as_u64(),
+                timestamp,
+                payload: ev.payload.payload.clone(),
+            };
+            mem.apply_event(&core);
+        }
+        mem
+    }
+
+    async fn read_all(storage: &Arc<Storage>, run_id: RunId) -> Vec<ReadEvent> {
+        let reader = storage.open_run_reader(run_id).await.unwrap();
+        let max = reader.current_seq().await.unwrap();
+        reader
+            .read_events(EventSeq(0)..EventSeq(max.as_u64() + 1))
+            .await
+            .unwrap()
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn fork_copies_prefix_and_records_lineage() {
+        let dir = tempfile::tempdir().unwrap();
+        let storage = Storage::open(dir.path()).await.unwrap();
+        let parent = RunId::new();
+        let worktree = dir.path().to_path_buf();
+        let writer = storage.create_run(parent, &worktree, None).await.unwrap();
+
+        let graph = minimal_graph();
+        let graph_hash = ContentHash::compute(&serde_json::to_vec(&graph).unwrap());
+        let node = NodeKey::try_from("end").unwrap();
+        let outcome = OutcomeKey::try_from("done").unwrap();
+        let config = RunConfig {
+            sandbox_default: SandboxMode::WorkspaceWrite,
+            approval_default: ApprovalPolicy::OnRequest,
+            auto_pr: false,
+            mcp_servers: vec![],
+        };
+
+        // 5 events; fork at seq 3 so events 4 and 5 must be excluded.
+        writer
+            .append_events(vec![
+                VersionedEventPayload::new(EventPayload::RunStarted {
+                    pipeline_template: None,
+                    project_path: worktree.clone(),
+                    initial_prompt: "orig".into(),
+                    config,
+                }),
+                VersionedEventPayload::new(EventPayload::PipelineMaterialized {
+                    graph: Box::new(graph),
+                    graph_hash,
+                }),
+                VersionedEventPayload::new(EventPayload::StageEntered {
+                    node: node.clone(),
+                    attempt: 1,
+                }),
+                VersionedEventPayload::new(EventPayload::OutcomeReported {
+                    node: node.clone(),
+                    outcome: outcome.clone(),
+                    summary: "post-fork".into(),
+                }),
+                VersionedEventPayload::new(EventPayload::StageCompleted { node, outcome }),
+            ])
+            .await
+            .unwrap();
+        // Release the writer slot so `fork` can append `ForkCreated`.
+        drop(writer);
+
+        let child = RunId::new();
+        let out = fork(&storage, ForkRequest::new(parent, child, 3))
+            .await
+            .expect("fork should succeed");
+        assert_eq!(out.copied_events, 3);
+        assert_eq!(out.new_run, child);
+
+        // Child must hold exactly the 3-event prefix.
+        let cevents = read_all(&storage, child).await;
+        assert_eq!(cevents.len(), 3, "child must have exactly 3 copied events");
+
+        // Child fold == parent fold at seq 3 (the fork invariant).
+        let pevents = read_all(&storage, parent).await;
+        let parent_at_3 = fold_to(&pevents, parent, 3);
+        let child_fold = fold_to(&cevents, child, u64::MAX);
+        assert_eq!(
+            child_fold, parent_at_3,
+            "child fold must equal parent fold at seq 3"
+        );
+
+        // Parent recorded ForkCreated lineage.
+        let lineage = pevents.iter().find_map(|e| match &e.payload.payload {
+            EventPayload::ForkCreated {
+                new_run,
+                fork_at_seq,
+            } => Some((*new_run, *fork_at_seq)),
+            _ => None,
+        });
+        assert_eq!(
+            lineage,
+            Some((child, 3)),
+            "parent must record ForkCreated for the child at seq 3"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn fork_inherits_snapshot_so_child_resumes_at_fork_position() {
+        use crate::engine::replay::replay;
+        use crate::engine::snapshot::EngineSnapshot;
+        use surge_core::run_state::Cursor;
+
+        let dir = tempfile::tempdir().unwrap();
+        let storage = Storage::open(dir.path()).await.unwrap();
+        let parent = RunId::new();
+        let worktree = dir.path().to_path_buf();
+        let writer = storage.create_run(parent, &worktree, None).await.unwrap();
+
+        let graph = minimal_graph(); // start == "end"
+        let graph_hash = ContentHash::compute(&serde_json::to_vec(&graph).unwrap());
+        let config = RunConfig {
+            sandbox_default: SandboxMode::WorkspaceWrite,
+            approval_default: ApprovalPolicy::OnRequest,
+            auto_pr: false,
+            mcp_servers: vec![],
+        };
+        let seqs = writer
+            .append_events(vec![
+                VersionedEventPayload::new(EventPayload::RunStarted {
+                    pipeline_template: None,
+                    project_path: worktree.clone(),
+                    initial_prompt: "orig".into(),
+                    config,
+                }),
+                VersionedEventPayload::new(EventPayload::PipelineMaterialized {
+                    graph: Box::new(graph),
+                    graph_hash,
+                }),
+                VersionedEventPayload::new(EventPayload::StageEntered {
+                    node: NodeKey::try_from("mid_node").unwrap(),
+                    attempt: 1,
+                }),
+            ])
+            .await
+            .unwrap();
+
+        // Snapshot whose cursor points at a node that is NOT graph.start, so a
+        // child that ignored it would (wrongly) resume at "end".
+        let snap_seq = seqs[2]; // after StageEntered mid_node
+        let cursor = Cursor {
+            node: NodeKey::try_from("mid_node").unwrap(),
+            attempt: 1,
+        };
+        let snapshot = EngineSnapshot::new(&cursor, snap_seq.as_u64(), 0);
+        writer
+            .write_graph_snapshot(snap_seq, serde_json::to_vec(&snapshot).unwrap())
+            .await
+            .unwrap();
+        drop(writer);
+
+        let child = RunId::new();
+        fork(&storage, ForkRequest::new(parent, child, 3))
+            .await
+            .expect("fork should succeed");
+
+        // Replaying the child must resume at the fork position (mid_node),
+        // inherited from the parent snapshot — not at graph.start ("end").
+        let creader = storage.open_run_reader(child).await.unwrap();
+        let replayed = replay(&creader).await.expect("replay child");
+        assert_eq!(
+            replayed.cursor.node,
+            NodeKey::try_from("mid_node").unwrap(),
+            "forked child must resume at the snapshot cursor, not graph.start"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn fork_rejects_out_of_bounds_seq() {
+        let dir = tempfile::tempdir().unwrap();
+        let storage = Storage::open(dir.path()).await.unwrap();
+        let parent = RunId::new();
+        let worktree = dir.path().to_path_buf();
+        let writer = storage.create_run(parent, &worktree, None).await.unwrap();
+
+        let graph = minimal_graph();
+        let graph_hash = ContentHash::compute(&serde_json::to_vec(&graph).unwrap());
+        let config = RunConfig {
+            sandbox_default: SandboxMode::WorkspaceWrite,
+            approval_default: ApprovalPolicy::OnRequest,
+            auto_pr: false,
+            mcp_servers: vec![],
+        };
+        // 2 events total.
+        writer
+            .append_events(vec![
+                VersionedEventPayload::new(EventPayload::RunStarted {
+                    pipeline_template: None,
+                    project_path: worktree.clone(),
+                    initial_prompt: String::new(),
+                    config,
+                }),
+                VersionedEventPayload::new(EventPayload::PipelineMaterialized {
+                    graph: Box::new(graph),
+                    graph_hash,
+                }),
+            ])
+            .await
+            .unwrap();
+        drop(writer);
+
+        let zero = fork(&storage, ForkRequest::new(parent, RunId::new(), 0)).await;
+        assert!(
+            matches!(zero, Err(EngineError::ForkInvalid(_))),
+            "seq 0 must be rejected, got {zero:?}"
+        );
+        let past = fork(&storage, ForkRequest::new(parent, RunId::new(), 99)).await;
+        assert!(
+            matches!(past, Err(EngineError::ForkInvalid(_))),
+            "seq past the last event must be rejected, got {past:?}"
+        );
+    }
+}

--- a/crates/surge-orchestrator/src/engine/fork.rs
+++ b/crates/surge-orchestrator/src/engine/fork.rs
@@ -15,13 +15,11 @@ use surge_persistence::runs::seq::EventSeq;
 
 use crate::engine::error::EngineError;
 
-/// Pre-fork edits applied to the child's inherited history before it resumes.
-///
-/// Empty today; prompt/profile overrides land in a later M1 increment.
-#[derive(Debug, Clone, Default)]
-pub struct ForkEdits {}
-
 /// Request to fork `parent` at `at_seq` into a fresh run `new_run`.
+///
+/// Pre-fork edits (per-node prompt override, profile swap) are a later M1
+/// increment; they will extend this struct when they actually take effect,
+/// rather than shipping an ignored knob now.
 #[derive(Debug, Clone)]
 pub struct ForkRequest {
     /// The run whose history is inherited.
@@ -30,19 +28,16 @@ pub struct ForkRequest {
     pub new_run: RunId,
     /// Inclusive sequence to fork at: events `1..=at_seq` are copied.
     pub at_seq: u64,
-    /// Optional pre-fork edits.
-    pub edits: ForkEdits,
 }
 
 impl ForkRequest {
-    /// Build a request with no pre-fork edits.
+    /// Build a fork request.
     #[must_use]
     pub fn new(parent: RunId, new_run: RunId, at_seq: u64) -> Self {
         Self {
             parent,
             new_run,
             at_seq,
-            edits: ForkEdits::default(),
         }
     }
 }

--- a/crates/surge-orchestrator/src/engine/mod.rs
+++ b/crates/surge-orchestrator/src/engine/mod.rs
@@ -57,7 +57,7 @@ pub use engine::Engine;
 pub use error::EngineError;
 pub use event_tap::{RunEventTap, TAP_BUFFER_SIZE};
 pub use facade::{EngineFacade, LocalEngineFacade};
-pub use fork::{ForkEdits, ForkOutcome, ForkRequest, fork};
+pub use fork::{ForkOutcome, ForkRequest, fork};
 pub use frames::{Frame, LoopFrame, SubgraphFrame, TerminalSignal};
 pub use handle::{EngineRunEvent, RunHandle, RunOutcome, RunStatus, RunSummary};
 pub use ipc::{

--- a/crates/surge-orchestrator/src/engine/mod.rs
+++ b/crates/surge-orchestrator/src/engine/mod.rs
@@ -35,6 +35,7 @@ pub mod engine;
 pub mod error;
 pub mod event_tap;
 pub mod facade;
+pub mod fork;
 pub mod frames;
 pub mod handle;
 pub mod hooks;
@@ -56,6 +57,7 @@ pub use engine::Engine;
 pub use error::EngineError;
 pub use event_tap::{RunEventTap, TAP_BUFFER_SIZE};
 pub use facade::{EngineFacade, LocalEngineFacade};
+pub use fork::{ForkEdits, ForkOutcome, ForkRequest, fork};
 pub use frames::{Frame, LoopFrame, SubgraphFrame, TerminalSignal};
 pub use handle::{EngineRunEvent, RunHandle, RunOutcome, RunStatus, RunSummary};
 pub use ipc::{

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -57,6 +57,26 @@ The product model in [`docs/ARCHITECTURE.md`](ARCHITECTURE.md) describes a riche
 
 `surge engine run <flow.toml>` and `surge engine run --template <name>` both skip bootstrap. `SPEC_PATH` and `--template` are mutually exclusive; use a path for a custom graph, or a template name such as `linear-3`, `linear-with-review`, `multi-milestone`, `bug-fix`, `refactor`, `spike`, or `single-task`.
 
+## Replay And Fork (Time-Travel)
+
+Every run is an append-only event log, so any past state is one fold away.
+
+`surge engine replay <run_id> [--seq N]` folds the event log up to seq `N`
+(default: latest) and prints the run state at that point — active node, last
+outcome, attempt, terminal status, elapsed. It is the CLI mirror of the cockpit
+replay scrubber; it reads from disk and needs no daemon.
+
+`surge engine fork <run_id> --seq N` spawns a new run that inherits the parent's
+event history `1..=N` — plus the parent's latest snapshot, so the child resumes
+at the fork point rather than the graph start — and records a `ForkCreated`
+lineage event on the parent. The fork is immediately inspectable with
+`surge engine replay <new_id>` and resumable with
+`surge engine resume <new_id> --daemon`.
+
+Use fork to retry a run from just before the stage that went wrong without
+re-executing the stages that already succeeded. Pre-fork prompt/profile edits
+are a follow-up increment.
+
 Bundled templates live in the binary; user templates under `${SURGE_HOME}/templates/*.toml` shadow bundled templates by filename stem or `metadata.name`.
 
 ## Artifact Validation


### PR DESCRIPTION
## What

Opens **v0.3 (Time-travel)** by landing the engine + CLI core of **fork-from-here** — the missing half of the ARCHITECTURE §1 differentiator (*"event log → replay, time-travel, fork-from-here"*). The `ForkCreated` event already existed in the schema with a roundtrip test but **no implementation**; this wires it up.

`surge engine fork <run_id> --seq N` spawns a new run that inherits the parent's event history `1..=N`, then diverges forward from that point — so a run that derails at stage 6/8 can be forked from just-before-6 with a fix, instead of re-run from scratch.

## How

`engine::fork::fork`:
- copies the parent's event payloads `1..=N` verbatim into a fresh run, so folding the child reproduces the parent's state at seq `N` **exactly** (`fold(child) == fold(parent[1..=N])`)
- **inherits the parent's latest snapshot** at-or-before the fork point, so the child resumes at the fork position rather than `graph.start` (without this, a snapshot-less child would replay to `graph.start`)
- records `ForkCreated { new_run, fork_at_seq }` on the parent for lineage (append-only, valid even post-terminal)
- rejects an out-of-bounds `seq` or a prefix without `RunStarted` → new typed `EngineError::ForkInvalid`

`surge engine fork` wires this to the CLI (SURGE_HOME-aware, mirrors `surge engine replay`), printing the new run id, copied-event count, and inspect/resume hints. The fork is immediately inspectable via `surge engine replay <new_id>` and resumable via `surge engine resume <new_id> --daemon`.

## Tests

- **orchestrator** (`engine::fork`): prefix-copy + fold-equality (events past `N` excluded, lineage recorded); snapshot inheritance proves the child resumes at the fork node not `graph.start`; out-of-bounds `seq` rejection
- **CLI** (`cli_fork.rs`): agent-free end-to-end — seeds a parent via the persistence layer, forks it through the real `surge` binary, asserts the child is created; plus a clean-failure case for a nonexistent run
- full workspace builds (the new `ForkInvalid` variant breaks no exhaustive match); `cargo fmt` + clippy clean on touched crates; 245/245 orchestrator lib tests pass

## Scope / follow-ups (v0.3 M1 remainder)

Deliberately out of this PR, tracked in `ROADMAP.md` → **v0.3 — Time-travel**:
- pre-fork edits (per-node prompt override + profile swap applied to the child's materialized graph, validated)
- optional new-worktree-at-fork-commit + auto-resume convenience
- fork lineage surfaced in run views
- M2 replay-at-seq enrichment, M3 run history, M4 GPUI scrubber + fork CTA

## Docs

`docs/cli.md` "Replay And Fork (Time-Travel)" section; `.ai-factory/ROADMAP.md` v0.3 milestone block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `surge engine fork <run_id> --seq N` CLI command to create new runs branching from existing runs at specific points, enabling time-travel debugging and retry workflows.

* **Documentation**
  * Expanded CLI documentation to explain replay and fork-from-here capabilities with usage examples.

* **Chores**
  * Updated project roadmap reflecting v0.3 milestone planning for time-travel and fork features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->