### PR TITLE
feat(engine): replay-at-seq enrichment — node status, edges, cost, --format json (v0.3 M2)

### DIFF
--- a/.ai-factory/ROADMAP.md
+++ b/.ai-factory/ROADMAP.md
@@ -305,7 +305,9 @@
   - **Remaining:** optional new-worktree-at-fork-commit + auto-resume convenience
   - **Remaining:** fork lineage surfaced in run views (parent ↔ children)
   - **Remaining:** pre-fork edits for runs with mid-run graph revisions
-- [ ] **M2 — Replay-at-seq enrichment** — extend `surge engine replay` with node status (completed/active/future), traversed edges, and cost-so-far; artifact-at-seq (`--artifact <name>` renders `description.md` / `roadmap.md` / `flow.toml` as of seq N); diff-at-seq; `--format json` for UI/script consumption
+- [ ] **M2 — Replay-at-seq enrichment** — **core landed.** `surge engine replay` now folds an enriched `ReplayView` against the materialized graph: per-node status (completed/active/failed/future), edges traversed, and cost-so-far (tokens + USD), plus `--format json`. Pure `engine::replay_view::build_replay_view` (orchestrator-tested) shared by the CLI today and the cockpit scrubber later.
+  - **Remaining:** artifact-at-seq (`--artifact <name>` renders `description.md` / `roadmap.md` / `flow.toml` as of seq N)
+  - **Remaining:** diff-at-seq (tool-call/result diffs up to seq N)
 - [ ] **M3 — Run history & cross-run analytics** — `surge runs` list/show with a lineage tree (parent ↔ forks); query by archetype / profile / agent / outcome; failure-pattern aggregation and cost / duration / outcome histograms over the run registry
 - [ ] **M4 — GPUI cockpit: scrubber + fork CTA** — wire replay-at-seq + fork into `surge-ui::screens::live_execution`: seq slider, live-vs-replay mode, completed/active/future node coloring, traversed-edge highlight, fork CTA, diff + artifact viewers. Surface-level, operator-verified (GUI is not CI-runnable). Subsumes the v0.1-era "Replay & fork-from-here UI" milestone
 

--- a/crates/surge-cli/src/commands/engine.rs
+++ b/crates/surge-cli/src/commands/engine.rs
@@ -1,7 +1,7 @@
 //! `surge engine` subtree — in-process M6 CLI for graph-based runs.
 
 use anyhow::{Context, Result, anyhow};
-use clap::Subcommand;
+use clap::{Subcommand, ValueEnum};
 use owo_colors::{OwoColorize, Stream};
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -9,6 +9,15 @@ use surge_core::SurgeConfig;
 use surge_core::id::RunId;
 use surge_orchestrator::engine::{Engine, EngineConfig, EngineRunConfig};
 use surge_persistence::runs::Storage;
+
+/// Output format for read-only inspection commands.
+#[derive(Debug, Clone, Copy, ValueEnum)]
+pub enum OutputFormat {
+    /// Human-readable text (default).
+    Text,
+    /// Machine-readable JSON.
+    Json,
+}
 
 /// Subcommands under `surge engine`.
 #[derive(Subcommand, Debug)]
@@ -83,6 +92,9 @@ pub enum EngineCommands {
         /// Fold events up to and including this seq (default: latest).
         #[arg(long)]
         seq: Option<u64>,
+        /// Output format (`text` or `json`).
+        #[arg(long, value_enum, default_value_t = OutputFormat::Text)]
+        format: OutputFormat,
     },
     /// Fork a run at a given seq into a fresh run: copy events `1..=seq`
     /// (inheriting the parent snapshot so the child resumes at the fork
@@ -127,7 +139,11 @@ pub async fn run(command: EngineCommands) -> Result<()> {
             since,
             follow,
         } => logs_command(run_id, since, follow).await,
-        EngineCommands::Replay { run_id, seq } => replay_command(run_id, seq).await,
+        EngineCommands::Replay {
+            run_id,
+            seq,
+            format,
+        } => replay_command(run_id, seq, format).await,
         EngineCommands::Fork {
             run_id,
             seq,
@@ -473,7 +489,9 @@ async fn follow_log_from(run_id: RunId, since_seq: u64) -> Result<u64> {
 /// `surge engine replay <run_id> --seq N` — fold the event log up to seq
 /// `N` and print the resulting run state. CLI mirror of the replay
 /// scrubber over the same fold primitive the engine/cockpit use.
-async fn replay_command(run_id: String, seq: Option<u64>) -> Result<()> {
+async fn replay_command(run_id: String, seq: Option<u64>, format: OutputFormat) -> Result<()> {
+    use surge_core::run_event::EventPayload;
+    use surge_orchestrator::engine::build_replay_view;
     use surge_persistence::runs::{EventSeq, RunReader, aggregate_status};
 
     let id = parse_run_id(&run_id)?;
@@ -490,11 +508,42 @@ async fn replay_command(run_id: String, seq: Option<u64>) -> Result<()> {
     let events = reader.read_events(EventSeq(0)..end).await?;
     let snap = aggregate_status(id, &events);
 
+    // The graph the run folds to at the cutoff: the last graph-bearing event.
+    let graph = events.iter().rev().find_map(|e| match e.payload.payload() {
+        EventPayload::PipelineMaterialized { graph, .. }
+        | EventPayload::GraphRevisionAccepted { graph, .. } => Some((**graph).clone()),
+        _ => None,
+    });
+    let view = graph.as_ref().map(|g| build_replay_view(g, &events));
+
     let seq_label = if cutoff == u64::MAX {
         "latest".to_string()
     } else {
         cutoff.to_string()
     };
+
+    if matches!(format, OutputFormat::Json) {
+        let seq_cutoff = if cutoff == u64::MAX {
+            serde_json::Value::String("latest".into())
+        } else {
+            serde_json::json!(cutoff)
+        };
+        let json = serde_json::json!({
+            "run": id.to_string(),
+            "seq_cutoff": seq_cutoff,
+            "events_folded": snap.event_count,
+            "active_node": snap.active_node,
+            "last_outcome": snap.last_outcome,
+            "attempt": snap.last_attempt,
+            "terminal": snap.terminal,
+            "failed": snap.failed,
+            "elapsed_ms": snap.elapsed_ms,
+            "view": view,
+        });
+        println!("{}", serde_json::to_string_pretty(&json)?);
+        return Ok(());
+    }
+
     println!("run:           {id}");
     println!("seq cutoff:    {seq_label}");
     println!("events folded: {}", snap.event_count);
@@ -519,6 +568,36 @@ async fn replay_command(run_id: String, seq: Option<u64>) -> Result<()> {
     println!("terminal:      {terminal}");
     if let Some(ms) = snap.elapsed_ms {
         println!("elapsed:       {ms} ms");
+    }
+
+    if let Some(view) = &view {
+        println!(
+            "cost:          {}+{} tok ({} cached), ${:.4}",
+            view.cost.prompt_tokens,
+            view.cost.output_tokens,
+            view.cost.cache_hits,
+            view.cost.cost_usd
+        );
+        println!("nodes:");
+        for n in &view.nodes {
+            let attempt = if n.attempts > 0 {
+                format!(", attempt {}", n.attempts)
+            } else {
+                String::new()
+            };
+            let outcome = n
+                .last_outcome
+                .as_deref()
+                .map(|o| format!(", outcome: {o}"))
+                .unwrap_or_default();
+            println!("  [{:<9}] {}{attempt}{outcome}", n.status.as_str(), n.node);
+        }
+        if !view.edges_traversed.is_empty() {
+            println!("edges:");
+            for e in &view.edges_traversed {
+                println!("  {} --{}--> {}", e.from, e.edge, e.to);
+            }
+        }
     }
     Ok(())
 }

--- a/crates/surge-cli/tests/cli_replay.rs
+++ b/crates/surge-cli/tests/cli_replay.rs
@@ -1,0 +1,126 @@
+//! `surge engine replay --format json` end-to-end.
+//!
+//! Replay is a pure fold over the event log, so the run is seeded directly
+//! through the persistence layer (no agent runtime), then the real `surge`
+//! binary folds it and emits the enriched JSON view.
+
+use std::collections::BTreeMap;
+use std::path::Path;
+
+use surge_core::approvals::ApprovalPolicy;
+use surge_core::content_hash::ContentHash;
+use surge_core::graph::{Graph, GraphMetadata, SCHEMA_VERSION};
+use surge_core::id::RunId;
+use surge_core::keys::{NodeKey, OutcomeKey};
+use surge_core::node::{Node, NodeConfig, Position};
+use surge_core::run_event::{EventPayload, RunConfig, VersionedEventPayload};
+use surge_core::sandbox::SandboxMode;
+use surge_core::terminal_config::{TerminalConfig, TerminalKind};
+use surge_persistence::runs::Storage;
+
+fn minimal_graph() -> Graph {
+    let end = NodeKey::try_from("end").unwrap();
+    let mut nodes = BTreeMap::new();
+    nodes.insert(
+        end.clone(),
+        Node {
+            id: end.clone(),
+            position: Position::default(),
+            declared_outcomes: vec![],
+            config: NodeConfig::Terminal(TerminalConfig {
+                kind: TerminalKind::Success,
+                message: None,
+            }),
+        },
+    );
+    Graph {
+        schema_version: SCHEMA_VERSION,
+        metadata: GraphMetadata {
+            name: "replay-cli-test".into(),
+            description: None,
+            template_origin: None,
+            created_at: chrono::Utc::now(),
+            author: None,
+            archetype: None,
+        },
+        start: end,
+        nodes,
+        edges: vec![],
+        subgraphs: BTreeMap::new(),
+    }
+}
+
+/// Seed a completed run: RunStarted, PipelineMaterialized, StageEntered(end),
+/// StageCompleted(end), RunCompleted (5 events).
+async fn seed_completed_run(home: &Path) -> RunId {
+    let storage = Storage::open(home).await.unwrap();
+    let run = RunId::new();
+    let worktree = home.to_path_buf();
+    let writer = storage.create_run(run, &worktree, None).await.unwrap();
+
+    let graph = minimal_graph();
+    let graph_hash = ContentHash::compute(&serde_json::to_vec(&graph).unwrap());
+    let end = NodeKey::try_from("end").unwrap();
+    let done = OutcomeKey::try_from("done").unwrap();
+    let config = RunConfig {
+        sandbox_default: SandboxMode::WorkspaceWrite,
+        approval_default: ApprovalPolicy::OnRequest,
+        auto_pr: false,
+        mcp_servers: vec![],
+    };
+    writer
+        .append_events(vec![
+            VersionedEventPayload::new(EventPayload::RunStarted {
+                pipeline_template: None,
+                project_path: worktree.clone(),
+                initial_prompt: "seed".into(),
+                config,
+            }),
+            VersionedEventPayload::new(EventPayload::PipelineMaterialized {
+                graph: Box::new(graph),
+                graph_hash,
+            }),
+            VersionedEventPayload::new(EventPayload::StageEntered {
+                node: end.clone(),
+                attempt: 1,
+            }),
+            VersionedEventPayload::new(EventPayload::StageCompleted {
+                node: end.clone(),
+                outcome: done,
+            }),
+            VersionedEventPayload::new(EventPayload::RunCompleted { terminal_node: end }),
+        ])
+        .await
+        .unwrap();
+    drop(writer);
+    drop(storage);
+    run
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn engine_replay_json_emits_enriched_view() {
+    let tmp = tempfile::tempdir().unwrap();
+    let run = seed_completed_run(tmp.path()).await;
+
+    let assert = assert_cmd::Command::cargo_bin("surge")
+        .unwrap()
+        .env("SURGE_HOME", tmp.path())
+        .args(["engine", "replay", &run.to_string(), "--format", "json"])
+        .assert()
+        .success();
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+    let json: serde_json::Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|e| panic!("stdout must be JSON: {e}\n{stdout}"));
+
+    assert_eq!(json["events_folded"], 5);
+    assert_eq!(json["terminal"], true);
+    assert_eq!(json["view"]["terminal"], "completed");
+
+    let nodes = json["view"]["nodes"].as_array().expect("nodes array");
+    let end = nodes
+        .iter()
+        .find(|n| n["node"] == "end")
+        .expect("end node present");
+    assert_eq!(end["status"], "completed");
+    assert_eq!(end["last_outcome"], "done");
+}

--- a/crates/surge-cli/tests/cli_replay.rs
+++ b/crates/surge-cli/tests/cli_replay.rs
@@ -11,7 +11,7 @@ use surge_core::approvals::ApprovalPolicy;
 use surge_core::content_hash::ContentHash;
 use surge_core::graph::{Graph, GraphMetadata, SCHEMA_VERSION};
 use surge_core::id::RunId;
-use surge_core::keys::{NodeKey, OutcomeKey};
+use surge_core::keys::NodeKey;
 use surge_core::node::{Node, NodeConfig, Position};
 use surge_core::run_event::{EventPayload, RunConfig, VersionedEventPayload};
 use surge_core::sandbox::SandboxMode;
@@ -50,8 +50,9 @@ fn minimal_graph() -> Graph {
     }
 }
 
-/// Seed a completed run: RunStarted, PipelineMaterialized, StageEntered(end),
-/// StageCompleted(end), RunCompleted (5 events).
+/// Seed a completed run the way the engine really emits it: the terminal node
+/// gets no `StageCompleted`; `RunCompleted { terminal_node }` is the only signal
+/// it finished. RunStarted, PipelineMaterialized, RunCompleted (3 events).
 async fn seed_completed_run(home: &Path) -> RunId {
     let storage = Storage::open(home).await.unwrap();
     let run = RunId::new();
@@ -61,7 +62,6 @@ async fn seed_completed_run(home: &Path) -> RunId {
     let graph = minimal_graph();
     let graph_hash = ContentHash::compute(&serde_json::to_vec(&graph).unwrap());
     let end = NodeKey::try_from("end").unwrap();
-    let done = OutcomeKey::try_from("done").unwrap();
     let config = RunConfig {
         sandbox_default: SandboxMode::WorkspaceWrite,
         approval_default: ApprovalPolicy::OnRequest,
@@ -79,14 +79,6 @@ async fn seed_completed_run(home: &Path) -> RunId {
             VersionedEventPayload::new(EventPayload::PipelineMaterialized {
                 graph: Box::new(graph),
                 graph_hash,
-            }),
-            VersionedEventPayload::new(EventPayload::StageEntered {
-                node: end.clone(),
-                attempt: 1,
-            }),
-            VersionedEventPayload::new(EventPayload::StageCompleted {
-                node: end.clone(),
-                outcome: done,
             }),
             VersionedEventPayload::new(EventPayload::RunCompleted { terminal_node: end }),
         ])
@@ -112,7 +104,7 @@ async fn engine_replay_json_emits_enriched_view() {
     let json: serde_json::Value = serde_json::from_str(&stdout)
         .unwrap_or_else(|e| panic!("stdout must be JSON: {e}\n{stdout}"));
 
-    assert_eq!(json["events_folded"], 5);
+    assert_eq!(json["events_folded"], 3);
     assert_eq!(json["terminal"], true);
     assert_eq!(json["view"]["terminal"], "completed");
 
@@ -121,6 +113,7 @@ async fn engine_replay_json_emits_enriched_view() {
         .iter()
         .find(|n| n["node"] == "end")
         .expect("end node present");
+    // The terminal node is promoted to `completed` by RunCompleted even though
+    // it never received a StageCompleted event.
     assert_eq!(end["status"], "completed");
-    assert_eq!(end["last_outcome"], "done");
 }

--- a/crates/surge-orchestrator/src/engine/mod.rs
+++ b/crates/surge-orchestrator/src/engine/mod.rs
@@ -42,6 +42,7 @@ pub mod hooks;
 pub mod ipc;
 pub mod predicates;
 pub mod replay;
+pub mod replay_view;
 pub mod routing;
 pub mod run_task;
 pub mod sandbox_factory;
@@ -62,4 +63,7 @@ pub use frames::{Frame, LoopFrame, SubgraphFrame, TerminalSignal};
 pub use handle::{EngineRunEvent, RunHandle, RunOutcome, RunStatus, RunSummary};
 pub use ipc::{
     DaemonEvent, DaemonRequest, DaemonResponse, ErrorCode, GlobalDaemonEvent, RequestId,
+};
+pub use replay_view::{
+    CostView, EdgeView, NodeStatus, NodeView, ReplayView, TerminalKind, build_replay_view,
 };

--- a/crates/surge-orchestrator/src/engine/replay_view.rs
+++ b/crates/surge-orchestrator/src/engine/replay_view.rs
@@ -128,8 +128,11 @@ pub fn build_replay_view(graph: &Graph, events: &[ReadEvent]) -> ReplayView {
         .keys()
         .map(|k| (k.as_str().to_owned(), (NodeStatus::Future, 0, None)))
         .collect();
-    let mut active_node = None;
+    let mut active_node: Option<String> = None;
     let mut terminal = None;
+    // `RunCompleted` names the terminal node directly; terminal stages emit no
+    // `StageCompleted` for it, so it is promoted after the fold.
+    let mut terminal_node = None;
     let mut edges_traversed = Vec::new();
     let mut cost = CostView::default();
 
@@ -151,12 +154,19 @@ pub fn build_replay_view(graph: &Graph, events: &[ReadEvent]) -> ReplayView {
                         .or_insert((NodeStatus::Future, 0, None));
                 e.0 = NodeStatus::Completed;
                 e.2 = Some(outcome.as_str().to_owned());
+                // The frontier node finished — it is no longer "running".
+                if active_node.as_deref() == Some(node.as_str()) {
+                    active_node = None;
+                }
             },
             EventPayload::StageFailed { node, .. } => {
                 status
                     .entry(node.as_str().to_owned())
                     .or_insert((NodeStatus::Future, 0, None))
                     .0 = NodeStatus::Failed;
+                if active_node.as_deref() == Some(node.as_str()) {
+                    active_node = None;
+                }
             },
             EventPayload::EdgeTraversed { edge, from, to, .. } => {
                 edges_traversed.push(EdgeView {
@@ -177,11 +187,41 @@ pub fn build_replay_view(graph: &Graph, events: &[ReadEvent]) -> ReplayView {
                 cost.cache_hits += u64::from(*cache_hits);
                 cost.cost_usd += cost_usd.unwrap_or(0.0);
             },
-            EventPayload::RunCompleted { .. } => terminal = Some(TerminalKind::Completed),
+            EventPayload::RunCompleted { terminal_node: tn } => {
+                terminal = Some(TerminalKind::Completed);
+                terminal_node = Some(tn.as_str().to_owned());
+            },
             EventPayload::RunFailed { .. } => terminal = Some(TerminalKind::Failed),
             EventPayload::RunAborted { .. } => terminal = Some(TerminalKind::Aborted),
             _ => {},
         }
+    }
+
+    // Promote the run-level terminal disposition onto the node table. Terminal
+    // stages emit `RunCompleted`/`RunFailed`/`RunAborted` directly (no
+    // `StageCompleted`/`StageFailed`), so without this the terminal/frontier
+    // node would be misclassified.
+    match terminal {
+        Some(TerminalKind::Completed) => {
+            if let Some(tn) = &terminal_node {
+                status
+                    .entry(tn.clone())
+                    .or_insert((NodeStatus::Future, 0, None))
+                    .0 = NodeStatus::Completed;
+            }
+        },
+        Some(TerminalKind::Failed) => {
+            // A direct `RunFailed` (no preceding `StageFailed`) means the live
+            // frontier failed; mark it (still-`Active`) `Failed`.
+            if let Some(frontier) = &active_node {
+                if let Some(e) = status.get_mut(frontier) {
+                    if e.0 == NodeStatus::Active {
+                        e.0 = NodeStatus::Failed;
+                    }
+                }
+            }
+        },
+        _ => {},
     }
 
     // A terminal run has no live frontier.
@@ -361,8 +401,8 @@ mod tests {
         assert_eq!(impl_v.attempts, 1);
         assert_eq!(impl_v.last_outcome.as_deref(), Some("done"));
 
-        // end entered but never completed → Active classification at node level.
-        assert_eq!(node_view(&view, "end").status, NodeStatus::Active);
+        // end entered, then promoted to Completed by RunCompleted { terminal_node }.
+        assert_eq!(node_view(&view, "end").status, NodeStatus::Completed);
 
         // Edge captured.
         assert_eq!(view.edges_traversed.len(), 1);
@@ -396,5 +436,73 @@ mod tests {
         assert_eq!(node_view(&view, "impl_1").status, NodeStatus::Active);
         assert_eq!(node_view(&view, "impl_1").attempts, 2);
         assert_eq!(node_view(&view, "end").status, NodeStatus::Future);
+    }
+
+    #[test]
+    fn build_replay_view_terminal_promotion_and_frontier_clearing() {
+        let graph = graph_impl_to_end();
+        let impl_k = NodeKey::try_from("impl_1").unwrap();
+        let end_k = NodeKey::try_from("end").unwrap();
+        let done = OutcomeKey::try_from("done").unwrap();
+
+        // (a) Realistic completed run: the terminal node is NEVER entered; it is
+        //     promoted to Completed by `RunCompleted { terminal_node }`.
+        let events = vec![
+            ev(
+                3,
+                EventPayload::StageEntered {
+                    node: impl_k.clone(),
+                    attempt: 1,
+                },
+            ),
+            ev(
+                4,
+                EventPayload::StageCompleted {
+                    node: impl_k.clone(),
+                    outcome: done.clone(),
+                },
+            ),
+            ev(
+                5,
+                EventPayload::RunCompleted {
+                    terminal_node: end_k,
+                },
+            ),
+        ];
+        let view = build_replay_view(&graph, &events);
+        assert_eq!(view.terminal, Some(TerminalKind::Completed));
+        assert_eq!(view.active_node, None);
+        assert_eq!(node_view(&view, "impl_1").status, NodeStatus::Completed);
+        assert_eq!(
+            node_view(&view, "end").status,
+            NodeStatus::Completed,
+            "terminal node promoted even though it was never entered"
+        );
+
+        // (b) Partial replay ending on StageCompleted (no terminal): the frontier
+        //     is cleared, so active_node does not name the just-finished node.
+        let events = vec![
+            ev(
+                3,
+                EventPayload::StageEntered {
+                    node: impl_k.clone(),
+                    attempt: 1,
+                },
+            ),
+            ev(
+                4,
+                EventPayload::StageCompleted {
+                    node: impl_k,
+                    outcome: done,
+                },
+            ),
+        ];
+        let view = build_replay_view(&graph, &events);
+        assert_eq!(view.terminal, None);
+        assert_eq!(
+            view.active_node, None,
+            "frontier cleared once the active node completes"
+        );
+        assert_eq!(node_view(&view, "impl_1").status, NodeStatus::Completed);
     }
 }

--- a/crates/surge-orchestrator/src/engine/replay_view.rs
+++ b/crates/surge-orchestrator/src/engine/replay_view.rs
@@ -1,0 +1,400 @@
+//! Enriched, seq-bounded view of a run for `surge engine replay`: per-node
+//! status (completed / active / failed / future), the edges traversed, and the
+//! cost accumulated — folded from the event log against the materialized graph.
+//!
+//! Pure function (no I/O), so it is unit-testable against synthetic event
+//! slices and shared by the CLI today and the cockpit scrubber later.
+
+use std::collections::BTreeMap;
+
+use surge_core::graph::Graph;
+use surge_core::run_event::EventPayload;
+use surge_persistence::runs::reader::ReadEvent;
+
+/// Lifecycle status of a node as of the replay cutoff.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum NodeStatus {
+    /// Declared in the graph but never entered up to the cutoff.
+    Future,
+    /// Entered but not yet completed or failed (the run's current frontier).
+    Active,
+    /// Reached a declared outcome.
+    Completed,
+    /// Failed at this node.
+    Failed,
+}
+
+impl NodeStatus {
+    /// Stable lowercase label for display / JSON.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            NodeStatus::Future => "future",
+            NodeStatus::Active => "active",
+            NodeStatus::Completed => "completed",
+            NodeStatus::Failed => "failed",
+        }
+    }
+}
+
+/// Per-node row in a [`ReplayView`].
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+pub struct NodeView {
+    /// Node id.
+    pub node: String,
+    /// Lifecycle status at the cutoff.
+    pub status: NodeStatus,
+    /// Most recent `StageEntered.attempt` for this node (0 if never entered).
+    pub attempts: u32,
+    /// Most recent reported outcome for this node, if any.
+    pub last_outcome: Option<String>,
+}
+
+/// A traversed edge in a [`ReplayView`].
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+pub struct EdgeView {
+    /// Edge id.
+    pub edge: String,
+    /// Source node id.
+    pub from: String,
+    /// Destination node id.
+    pub to: String,
+}
+
+/// Cumulative cost accumulated up to the cutoff.
+#[derive(Debug, Clone, Default, PartialEq, serde::Serialize)]
+pub struct CostView {
+    /// Sum of `prompt_tokens` across `TokensConsumed`.
+    pub prompt_tokens: u64,
+    /// Sum of `output_tokens`.
+    pub output_tokens: u64,
+    /// Sum of `cache_hits`.
+    pub cache_hits: u64,
+    /// Sum of `cost_usd` (events without a cost contribute 0).
+    pub cost_usd: f64,
+}
+
+/// Terminal disposition of a run.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TerminalKind {
+    /// `RunCompleted`.
+    Completed,
+    /// `RunFailed`.
+    Failed,
+    /// `RunAborted`.
+    Aborted,
+}
+
+impl TerminalKind {
+    /// Stable lowercase label.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            TerminalKind::Completed => "completed",
+            TerminalKind::Failed => "failed",
+            TerminalKind::Aborted => "aborted",
+        }
+    }
+}
+
+/// The folded, enriched view of a run as of a replay cutoff.
+#[derive(Debug, Clone, PartialEq, serde::Serialize)]
+pub struct ReplayView {
+    /// Number of events folded.
+    pub event_count: u64,
+    /// The current frontier node (last `StageEntered`), or `None` for a
+    /// terminal run or one not yet started.
+    pub active_node: Option<String>,
+    /// Terminal disposition, if the cutoff includes a terminal event.
+    pub terminal: Option<TerminalKind>,
+    /// Every graph node with its status, in graph (`BTreeMap`) order.
+    pub nodes: Vec<NodeView>,
+    /// Edges traversed up to the cutoff, in order.
+    pub edges_traversed: Vec<EdgeView>,
+    /// Cumulative cost up to the cutoff.
+    pub cost: CostView,
+}
+
+/// Fold `events` (assumed already trimmed to the replay cutoff) against `graph`
+/// into a [`ReplayView`]. Every graph node appears; nodes never entered are
+/// `Future`.
+#[must_use]
+pub fn build_replay_view(graph: &Graph, events: &[ReadEvent]) -> ReplayView {
+    // Seed every graph node as Future; events promote them.
+    let mut status: BTreeMap<String, (NodeStatus, u32, Option<String>)> = graph
+        .nodes
+        .keys()
+        .map(|k| (k.as_str().to_owned(), (NodeStatus::Future, 0, None)))
+        .collect();
+    let mut active_node = None;
+    let mut terminal = None;
+    let mut edges_traversed = Vec::new();
+    let mut cost = CostView::default();
+
+    for ev in events {
+        match ev.payload.payload() {
+            EventPayload::StageEntered { node, attempt } => {
+                let e =
+                    status
+                        .entry(node.as_str().to_owned())
+                        .or_insert((NodeStatus::Future, 0, None));
+                e.0 = NodeStatus::Active;
+                e.1 = *attempt;
+                active_node = Some(node.as_str().to_owned());
+            },
+            EventPayload::StageCompleted { node, outcome } => {
+                let e =
+                    status
+                        .entry(node.as_str().to_owned())
+                        .or_insert((NodeStatus::Future, 0, None));
+                e.0 = NodeStatus::Completed;
+                e.2 = Some(outcome.as_str().to_owned());
+            },
+            EventPayload::StageFailed { node, .. } => {
+                status
+                    .entry(node.as_str().to_owned())
+                    .or_insert((NodeStatus::Future, 0, None))
+                    .0 = NodeStatus::Failed;
+            },
+            EventPayload::EdgeTraversed { edge, from, to, .. } => {
+                edges_traversed.push(EdgeView {
+                    edge: edge.as_str().to_owned(),
+                    from: from.as_str().to_owned(),
+                    to: to.as_str().to_owned(),
+                });
+            },
+            EventPayload::TokensConsumed {
+                prompt_tokens,
+                output_tokens,
+                cache_hits,
+                cost_usd,
+                ..
+            } => {
+                cost.prompt_tokens += u64::from(*prompt_tokens);
+                cost.output_tokens += u64::from(*output_tokens);
+                cost.cache_hits += u64::from(*cache_hits);
+                cost.cost_usd += cost_usd.unwrap_or(0.0);
+            },
+            EventPayload::RunCompleted { .. } => terminal = Some(TerminalKind::Completed),
+            EventPayload::RunFailed { .. } => terminal = Some(TerminalKind::Failed),
+            EventPayload::RunAborted { .. } => terminal = Some(TerminalKind::Aborted),
+            _ => {},
+        }
+    }
+
+    // A terminal run has no live frontier.
+    if terminal.is_some() {
+        active_node = None;
+    }
+
+    let nodes = status
+        .into_iter()
+        .map(|(node, (status, attempts, last_outcome))| NodeView {
+            node,
+            status,
+            attempts,
+            last_outcome,
+        })
+        .collect();
+
+    ReplayView {
+        event_count: events.len() as u64,
+        active_node,
+        terminal,
+        nodes,
+        edges_traversed,
+        cost,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeMap;
+    use surge_core::agent_config::{AgentConfig, NodeLimits};
+    use surge_core::graph::{GraphMetadata, SCHEMA_VERSION};
+    use surge_core::keys::{EdgeKey, NodeKey, OutcomeKey, ProfileKey};
+    use surge_core::node::{Node, NodeConfig, Position};
+    use surge_core::run_event::VersionedEventPayload;
+    use surge_core::terminal_config::{TerminalConfig, TerminalKind as TermCfgKind};
+    use surge_persistence::runs::seq::EventSeq;
+
+    fn graph_impl_to_end() -> Graph {
+        let impl_node = NodeKey::try_from("impl_1").unwrap();
+        let end = NodeKey::try_from("end").unwrap();
+        let mut nodes = BTreeMap::new();
+        nodes.insert(
+            impl_node.clone(),
+            Node {
+                id: impl_node.clone(),
+                position: Position::default(),
+                declared_outcomes: vec![],
+                config: NodeConfig::Agent(AgentConfig {
+                    profile: ProfileKey::try_from("implementer@1.0").unwrap(),
+                    prompt_overrides: None,
+                    tool_overrides: None,
+                    sandbox_override: None,
+                    approvals_override: None,
+                    bindings: vec![],
+                    rules_overrides: None,
+                    limits: NodeLimits::default(),
+                    hooks: vec![],
+                    custom_fields: BTreeMap::new(),
+                }),
+            },
+        );
+        nodes.insert(
+            end.clone(),
+            Node {
+                id: end.clone(),
+                position: Position::default(),
+                declared_outcomes: vec![],
+                config: NodeConfig::Terminal(TerminalConfig {
+                    kind: TermCfgKind::Success,
+                    message: None,
+                }),
+            },
+        );
+        Graph {
+            schema_version: SCHEMA_VERSION,
+            metadata: GraphMetadata {
+                name: "replay-view-test".into(),
+                description: None,
+                template_origin: None,
+                created_at: chrono::Utc::now(),
+                author: None,
+                archetype: None,
+            },
+            start: impl_node,
+            nodes,
+            edges: vec![],
+            subgraphs: BTreeMap::new(),
+        }
+    }
+
+    fn ev(seq: u64, payload: EventPayload) -> ReadEvent {
+        let kind = payload.discriminant_str().to_owned();
+        ReadEvent {
+            seq: EventSeq(seq),
+            timestamp_ms: i64::try_from(seq).unwrap() * 1000,
+            kind,
+            payload: VersionedEventPayload::new(payload),
+        }
+    }
+
+    fn node_view<'a>(view: &'a ReplayView, id: &str) -> &'a NodeView {
+        view.nodes
+            .iter()
+            .find(|n| n.node == id)
+            .expect("node present")
+    }
+
+    #[test]
+    fn build_replay_view_classifies_nodes_edges_cost() {
+        let graph = graph_impl_to_end();
+        let impl_k = NodeKey::try_from("impl_1").unwrap();
+        let end_k = NodeKey::try_from("end").unwrap();
+        let done = OutcomeKey::try_from("done").unwrap();
+
+        let events = vec![
+            ev(
+                3,
+                EventPayload::StageEntered {
+                    node: impl_k.clone(),
+                    attempt: 1,
+                },
+            ),
+            ev(
+                4,
+                EventPayload::TokensConsumed {
+                    session: surge_core::id::SessionId::new(),
+                    prompt_tokens: 100,
+                    output_tokens: 50,
+                    cache_hits: 10,
+                    model: "m".into(),
+                    cost_usd: Some(0.25),
+                },
+            ),
+            ev(
+                5,
+                EventPayload::StageCompleted {
+                    node: impl_k.clone(),
+                    outcome: done.clone(),
+                },
+            ),
+            ev(
+                6,
+                EventPayload::EdgeTraversed {
+                    edge: EdgeKey::try_from("impl_to_end").unwrap(),
+                    from: impl_k.clone(),
+                    to: end_k.clone(),
+                    kind: surge_core::edge::EdgeKind::Forward,
+                },
+            ),
+            ev(
+                7,
+                EventPayload::StageEntered {
+                    node: end_k.clone(),
+                    attempt: 1,
+                },
+            ),
+            ev(
+                8,
+                EventPayload::RunCompleted {
+                    terminal_node: end_k.clone(),
+                },
+            ),
+        ];
+
+        let view = build_replay_view(&graph, &events);
+
+        assert_eq!(view.event_count, 6);
+        assert_eq!(view.terminal, Some(TerminalKind::Completed));
+        // Terminal run → no active frontier.
+        assert_eq!(view.active_node, None);
+
+        // impl_1 entered then completed → Completed with the outcome.
+        let impl_v = node_view(&view, "impl_1");
+        assert_eq!(impl_v.status, NodeStatus::Completed);
+        assert_eq!(impl_v.attempts, 1);
+        assert_eq!(impl_v.last_outcome.as_deref(), Some("done"));
+
+        // end entered but never completed → Active classification at node level.
+        assert_eq!(node_view(&view, "end").status, NodeStatus::Active);
+
+        // Edge captured.
+        assert_eq!(view.edges_traversed.len(), 1);
+        assert_eq!(view.edges_traversed[0].from, "impl_1");
+        assert_eq!(view.edges_traversed[0].to, "end");
+
+        // Cost summed.
+        assert_eq!(view.cost.prompt_tokens, 100);
+        assert_eq!(view.cost.output_tokens, 50);
+        assert_eq!(view.cost.cache_hits, 10);
+        assert!((view.cost.cost_usd - 0.25).abs() < 1e-9);
+    }
+
+    #[test]
+    fn build_replay_view_future_node_and_active_frontier() {
+        let graph = graph_impl_to_end();
+        let impl_k = NodeKey::try_from("impl_1").unwrap();
+
+        // Only impl_1 entered; not terminal. end stays Future, impl_1 Active.
+        let events = vec![ev(
+            3,
+            EventPayload::StageEntered {
+                node: impl_k,
+                attempt: 2,
+            },
+        )];
+        let view = build_replay_view(&graph, &events);
+
+        assert_eq!(view.terminal, None);
+        assert_eq!(view.active_node.as_deref(), Some("impl_1"));
+        assert_eq!(node_view(&view, "impl_1").status, NodeStatus::Active);
+        assert_eq!(node_view(&view, "impl_1").attempts, 2);
+        assert_eq!(node_view(&view, "end").status, NodeStatus::Future);
+    }
+}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -61,10 +61,14 @@ The product model in [`docs/ARCHITECTURE.md`](ARCHITECTURE.md) describes a riche
 
 Every run is an append-only event log, so any past state is one fold away.
 
-`surge engine replay <run_id> [--seq N]` folds the event log up to seq `N`
-(default: latest) and prints the run state at that point — active node, last
-outcome, attempt, terminal status, elapsed. It is the CLI mirror of the cockpit
-replay scrubber; it reads from disk and needs no daemon.
+`surge engine replay <run_id> [--seq N] [--format text|json]` folds the event
+log up to seq `N` (default: latest) and prints the run state at that point: the
+summary (active node, last outcome, attempt, terminal status, elapsed) plus,
+when a graph has been materialized, an enriched view — per-node status
+(`completed` / `active` / `failed` / `future`), the edges traversed, and the
+cost accumulated (tokens + USD). `--format json` emits the whole thing for
+scripts and the cockpit scrubber. It is the CLI mirror of that scrubber; it
+reads from disk and needs no daemon.
 
 `surge engine fork <run_id> --seq N` spawns a new run that inherits the parent's
 event history `1..=N` — plus the parent's latest snapshot, so the child resumes


### PR DESCRIPTION
## What

Opens **v0.3 M2**. `surge engine replay` was a flat summary (active node, last outcome, terminal, elapsed). It now also folds an **enriched, seq-bounded view** against the run's materialized graph:

- **per-node status** — `completed` / `active` / `failed` / `future`
- **edges traversed** up to the cutoff
- **cost-so-far** — prompt + output tokens, cache hits, USD
- **`--format json`** — the whole view, for scripts and the future cockpit scrubber (M4)

```
surge engine replay <run> --seq 6
surge engine replay <run> --format json | jq '.view.nodes'
```

## How

- `engine::replay_view::build_replay_view(graph, events)` — a **pure fold** (no I/O) that seeds every graph node as `future` and promotes it via `StageEntered`/`StageCompleted`/`StageFailed`, collects `EdgeTraversed`, and sums `TokensConsumed`. Shared by the CLI today and the GPUI scrubber later.
- The CLI extracts the latest graph-bearing event within the cutoff (`PipelineMaterialized` / `GraphRevisionAccepted`), builds the view, and renders text or JSON. The **existing summary lines are unchanged** in order and format, so the durability `fault_injection` test (which asserts that text) still passes.
- View types derive `serde::Serialize` (`snake_case` enums) so JSON is a derive, not hand-rolled.

## Tests

- **orchestrator** (`replay_view`): node classification + edges + cost from a full synthetic run; future-node + active-frontier from a partial run.
- **CLI** (`cli_replay.rs`): agent-free end-to-end — seeds a completed run via the persistence layer, runs `surge engine replay --format json`, parses stdout and asserts `events_folded`, `terminal`, and the per-node view (`end` → `completed`, outcome `done`).
- fmt + clippy clean; 251 orchestrator lib tests; `fault_injection` regression green.

## Scope / follow-ups (M2 remainder)

Tracked in `ROADMAP.md` → v0.3 M2:
- artifact-at-seq (`--artifact <name>` renders `description.md`/`roadmap.md`/`flow.toml` as of seq N)
- diff-at-seq (tool-call/result diffs up to seq N)

## Docs

`docs/cli.md` replay section; `.ai-factory/ROADMAP.md` M2 core marked landed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--format json` option to `surge engine replay` command, enabling JSON output for programmatic consumption. Default text mode now displays enriched run details: per-node completion status, traversed edges, and accumulated cost metrics (tokens + USD).

* **Documentation**
  * Updated CLI reference documentation for the replay command to reflect new format options and enhanced output details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->