### PR TITLE
fix(engine): persist frozen budget so resume re-arms spend enforcement

### DIFF
--- a/crates/surge-cli/src/commands/feature.rs
+++ b/crates/surge-cli/src/commands/feature.rs
@@ -1489,6 +1489,7 @@ async fn append_feature_run_started(
             project_path: worktree.to_path_buf(),
             initial_prompt: String::new(),
             config: RunConfig {
+                budget: Default::default(),
                 sandbox_default: SandboxMode::WorkspaceWrite,
                 approval_default: ApprovalPolicy::OnRequest,
                 auto_pr: false,

--- a/crates/surge-cli/src/commands/inbox.rs
+++ b/crates/surge-cli/src/commands/inbox.rs
@@ -295,6 +295,7 @@ mod tests {
             project_path: PathBuf::from("/proj"),
             initial_prompt: "x".into(),
             config: RunConfig {
+                budget: Default::default(),
                 sandbox_default: SandboxMode::WorkspaceWrite,
                 approval_default: ApprovalPolicy::OnRequest,
                 auto_pr: false,

--- a/crates/surge-cli/tests/cli_fork.rs
+++ b/crates/surge-cli/tests/cli_fork.rs
@@ -63,6 +63,7 @@ async fn seed_parent(home: &Path) -> RunId {
     let graph = minimal_graph();
     let graph_hash = ContentHash::compute(&serde_json::to_vec(&graph).unwrap());
     let config = RunConfig {
+        budget: Default::default(),
         sandbox_default: SandboxMode::WorkspaceWrite,
         approval_default: ApprovalPolicy::OnRequest,
         auto_pr: false,
@@ -207,6 +208,7 @@ async fn seed_agent_parent(home: &Path) -> RunId {
     let graph = agent_graph();
     let graph_hash = ContentHash::compute(&serde_json::to_vec(&graph).unwrap());
     let config = RunConfig {
+        budget: Default::default(),
         sandbox_default: SandboxMode::WorkspaceWrite,
         approval_default: ApprovalPolicy::OnRequest,
         auto_pr: false,

--- a/crates/surge-cli/tests/cli_replay.rs
+++ b/crates/surge-cli/tests/cli_replay.rs
@@ -63,6 +63,7 @@ async fn seed_completed_run(home: &Path) -> RunId {
     let graph_hash = ContentHash::compute(&serde_json::to_vec(&graph).unwrap());
     let end = NodeKey::try_from("end").unwrap();
     let config = RunConfig {
+        budget: Default::default(),
         sandbox_default: SandboxMode::WorkspaceWrite,
         approval_default: ApprovalPolicy::OnRequest,
         auto_pr: false,

--- a/crates/surge-core/benches/bincode_roundtrip.rs
+++ b/crates/surge-core/benches/bincode_roundtrip.rs
@@ -12,6 +12,7 @@ fn event_serde_roundtrip(c: &mut Criterion) {
         project_path: PathBuf::from("/work"),
         initial_prompt: "test".into(),
         config: RunConfig {
+            budget: Default::default(),
             sandbox_default: SandboxMode::WorkspaceWrite,
             approval_default: ApprovalPolicy::OnRequest,
             auto_pr: false,

--- a/crates/surge-core/benches/fold_events.rs
+++ b/crates/surge-core/benches/fold_events.rs
@@ -28,6 +28,7 @@ fn build_typical_event_log(n: usize) -> Vec<RunEvent> {
             project_path: PathBuf::from("/work"),
             initial_prompt: "test".into(),
             config: RunConfig {
+                budget: Default::default(),
                 sandbox_default: SandboxMode::WorkspaceWrite,
                 approval_default: ApprovalPolicy::OnRequest,
                 auto_pr: false,

--- a/crates/surge-core/src/run_event.rs
+++ b/crates/surge-core/src/run_event.rs
@@ -611,11 +611,12 @@ pub struct RunConfig {
     /// Empty by default — no MCP delegation.
     #[serde(default)]
     pub mcp_servers: Vec<crate::mcp_config::McpServerRef>,
-    // FOLLOW-UP (PR #84 deep review): the frozen budget guard is NOT persisted
-    // here, so a daemon-restart resume reverts budget to the unlimited default
-    // and drops spend enforcement for the rest of the run. Adding `budget`
-    // (serde(default)) is the fix, but it touches ~30 RunConfig construction
-    // sites + migration fixtures and warrants its own PR with roundtrip tests.
+    /// Frozen budget guard captured at run start. Persisting it here lets a
+    /// daemon-restart resume re-arm spend enforcement instead of reverting to
+    /// the unlimited default. `#[serde(default)]` keeps logs written before this
+    /// field decodable (they resume unlimited, exactly as they did before).
+    #[serde(default)]
+    pub budget: crate::budget::BudgetGuard,
 }
 
 #[cfg(test)]
@@ -665,6 +666,7 @@ mod tests {
             project_path: PathBuf::from("/work/proj"),
             initial_prompt: "build it".into(),
             config: RunConfig {
+                budget: Default::default(),
                 sandbox_default: SandboxMode::WorkspaceWrite,
                 approval_default: ApprovalPolicy::OnRequest,
                 auto_pr: true,
@@ -674,6 +676,38 @@ mod tests {
         let bytes = payload.to_bincode().unwrap();
         let parsed = EventPayload::from_bincode(&bytes).unwrap();
         assert_eq!(payload, parsed);
+    }
+
+    #[test]
+    fn run_config_persists_budget_and_defaults_when_absent() {
+        use crate::budget::{BudgetGuard, BudgetLimits};
+        let config = RunConfig {
+            sandbox_default: SandboxMode::WorkspaceWrite,
+            approval_default: ApprovalPolicy::OnRequest,
+            auto_pr: false,
+            mcp_servers: Vec::new(),
+            budget: BudgetGuard {
+                limits: BudgetLimits {
+                    usd: Some(5.0),
+                    tokens: None,
+                    warn_threshold_pct: 80,
+                },
+                ..Default::default()
+            },
+        };
+
+        // The frozen budget round-trips, so a resume can re-arm enforcement.
+        let value = serde_json::to_value(&config).unwrap();
+        let back: RunConfig = serde_json::from_value(value.clone()).unwrap();
+        assert_eq!(back, config);
+        assert_eq!(back.budget.limits.usd, Some(5.0));
+
+        // A log written before the `budget` field (key absent) decodes to the
+        // unlimited default — backward compatible, resumes as it did before.
+        let mut legacy = value;
+        legacy.as_object_mut().unwrap().remove("budget");
+        let decoded: RunConfig = serde_json::from_value(legacy).unwrap();
+        assert_eq!(decoded.budget, BudgetGuard::default());
     }
 
     #[test]
@@ -1266,6 +1300,7 @@ mod tests {
         use std::time::Duration;
 
         let cfg = RunConfig {
+            budget: Default::default(),
             sandbox_default: SandboxMode::WorkspaceWrite,
             approval_default: ApprovalPolicy::OnRequest,
             auto_pr: false,

--- a/crates/surge-core/src/run_state.rs
+++ b/crates/surge-core/src/run_state.rs
@@ -1160,6 +1160,7 @@ mod tests {
                 project_path: PathBuf::from("/tmp"),
                 initial_prompt: "test".into(),
                 config: RunConfig {
+                    budget: Default::default(),
                     sandbox_default: SandboxMode::WorkspaceWrite,
                     approval_default: ApprovalPolicy::OnRequest,
                     auto_pr: false,
@@ -1187,6 +1188,7 @@ mod tests {
                     project_path: PathBuf::from("/tmp"),
                     initial_prompt: "test".into(),
                     config: RunConfig {
+                        budget: Default::default(),
                         sandbox_default: SandboxMode::WorkspaceWrite,
                         approval_default: ApprovalPolicy::OnRequest,
                         auto_pr: false,
@@ -1215,6 +1217,7 @@ mod tests {
                     project_path: PathBuf::from("/tmp"),
                     initial_prompt: "test".into(),
                     config: RunConfig {
+                        budget: Default::default(),
                         sandbox_default: SandboxMode::WorkspaceWrite,
                         approval_default: ApprovalPolicy::OnRequest,
                         auto_pr: false,
@@ -1461,6 +1464,7 @@ mod tests {
                     project_path: PathBuf::from("/tmp"),
                     initial_prompt: "test".into(),
                     config: RunConfig {
+                        budget: Default::default(),
                         sandbox_default: SandboxMode::WorkspaceWrite,
                         approval_default: ApprovalPolicy::OnRequest,
                         auto_pr: false,
@@ -1536,6 +1540,7 @@ mod tests {
                     project_path: PathBuf::from("/tmp"),
                     initial_prompt: "test".into(),
                     config: RunConfig {
+                        budget: Default::default(),
                         sandbox_default: SandboxMode::WorkspaceWrite,
                         approval_default: ApprovalPolicy::OnRequest,
                         auto_pr: false,
@@ -1626,6 +1631,7 @@ mod tests {
                     project_path: PathBuf::from("/tmp"),
                     initial_prompt: "test".into(),
                     config: RunConfig {
+                        budget: Default::default(),
                         sandbox_default: SandboxMode::WorkspaceWrite,
                         approval_default: ApprovalPolicy::OnRequest,
                         auto_pr: false,
@@ -1730,6 +1736,7 @@ mod tests {
                     project_path: PathBuf::from("/tmp"),
                     initial_prompt: "build".into(),
                     config: RunConfig {
+                        budget: Default::default(),
                         sandbox_default: SandboxMode::WorkspaceWrite,
                         approval_default: ApprovalPolicy::OnRequest,
                         auto_pr: false,
@@ -1829,6 +1836,7 @@ mod tests {
                     project_path: PathBuf::from("/tmp"),
                     initial_prompt: "build".into(),
                     config: RunConfig {
+                        budget: Default::default(),
                         sandbox_default: SandboxMode::WorkspaceWrite,
                         approval_default: ApprovalPolicy::OnRequest,
                         auto_pr: false,
@@ -1982,6 +1990,7 @@ mod tests {
                     project_path: PathBuf::from("/tmp"),
                     initial_prompt: "build".into(),
                     config: RunConfig {
+                        budget: Default::default(),
                         sandbox_default: SandboxMode::WorkspaceWrite,
                         approval_default: ApprovalPolicy::OnRequest,
                         auto_pr: false,
@@ -2344,6 +2353,7 @@ mod tests {
                     project_path: PathBuf::from("/tmp"),
                     initial_prompt: "build".into(),
                     config: RunConfig {
+                        budget: Default::default(),
                         sandbox_default: SandboxMode::WorkspaceWrite,
                         approval_default: ApprovalPolicy::OnRequest,
                         auto_pr: false,

--- a/crates/surge-core/src/validation.rs
+++ b/crates/surge-core/src/validation.rs
@@ -2247,6 +2247,7 @@ mod tests {
             subgraphs: BTreeMap::new(),
         };
         let run_cfg = RunConfig {
+            budget: Default::default(),
             sandbox_default: SandboxMode::ReadOnly,
             approval_default: ApprovalPolicy::OnRequest,
             auto_pr: false,
@@ -2334,6 +2335,7 @@ mod tests {
         };
 
         let run_cfg = RunConfig {
+            budget: Default::default(),
             sandbox_default: SandboxMode::WorkspaceWrite,
             approval_default: ApprovalPolicy::OnRequest,
             auto_pr: false,

--- a/crates/surge-core/tests/fold_determinism_proptest.rs
+++ b/crates/surge-core/tests/fold_determinism_proptest.rs
@@ -137,6 +137,7 @@ fn build_canonical_events(graph: Graph, inner: Vec<NodeKey>, run_id: RunId) -> V
             project_path: PathBuf::from("/proptest"),
             initial_prompt: "deterministic-fold".into(),
             config: RunConfig {
+                budget: Default::default(),
                 sandbox_default: SandboxMode::WorkspaceWrite,
                 approval_default: ApprovalPolicy::OnRequest,
                 auto_pr: false,

--- a/crates/surge-core/tests/fold_hook_events.rs
+++ b/crates/surge-core/tests/fold_hook_events.rs
@@ -110,6 +110,7 @@ fn hook_events_are_pass_through_in_fold() {
                 project_path: PathBuf::from("/tmp/run"),
                 initial_prompt: "fold hooks".into(),
                 config: RunConfig {
+                    budget: Default::default(),
                     sandbox_default: SandboxMode::WorkspaceWrite,
                     approval_default: ApprovalPolicy::OnRequest,
                     auto_pr: false,

--- a/crates/surge-daemon/tests/daemon_recovery.rs
+++ b/crates/surge-daemon/tests/daemon_recovery.rs
@@ -218,6 +218,7 @@ fn run_config() -> RunConfig {
         approval_default: ApprovalPolicy::OnRequest,
         auto_pr: false,
         mcp_servers: Vec::new(),
+        budget: Default::default(),
     }
 }
 

--- a/crates/surge-orchestrator/src/engine/engine.rs
+++ b/crates/surge-orchestrator/src/engine/engine.rs
@@ -399,6 +399,9 @@ impl Engine {
             approval_default: ApprovalPolicy::OnRequest,
             auto_pr: false,
             mcp_servers: run_config.mcp_servers.clone(),
+            // Persist the frozen budget so a daemon-restart resume re-arms spend
+            // enforcement instead of reverting to the unlimited default.
+            budget: run_config.budget,
         };
 
         Ok(vec![
@@ -633,13 +636,16 @@ impl Engine {
         self.runs.write().await.insert(run_id, active);
 
         // Reconstruct EngineRunConfig from the persisted RunConfig so that
-        // mcp_servers survive a daemon restart + resume. Falls back to an
-        // empty list for runs that predate the mcp_servers field.
+        // mcp_servers and the frozen budget survive a daemon restart + resume.
+        // Falls back to defaults (empty mcp list, unlimited budget) for runs that
+        // predate those fields.
         let mut resume_run_config = EngineRunConfig::default();
         if let Some(persisted) = &replayed.run_config {
             resume_run_config
                 .mcp_servers
                 .clone_from(&persisted.mcp_servers);
+            // Re-arm spend enforcement with the run's frozen budget.
+            resume_run_config.budget = persisted.budget;
         }
 
         // Build a per-run McpRegistry exactly like start_run does.

--- a/crates/surge-orchestrator/src/engine/fork.rs
+++ b/crates/surge-orchestrator/src/engine/fork.rs
@@ -395,6 +395,7 @@ mod tests {
         let node = NodeKey::try_from("end").unwrap();
         let outcome = OutcomeKey::try_from("done").unwrap();
         let config = RunConfig {
+            budget: Default::default(),
             sandbox_default: SandboxMode::WorkspaceWrite,
             approval_default: ApprovalPolicy::OnRequest,
             auto_pr: false,
@@ -480,6 +481,7 @@ mod tests {
         let graph = minimal_graph(); // start == "end"
         let graph_hash = ContentHash::compute(&serde_json::to_vec(&graph).unwrap());
         let config = RunConfig {
+            budget: Default::default(),
             sandbox_default: SandboxMode::WorkspaceWrite,
             approval_default: ApprovalPolicy::OnRequest,
             auto_pr: false,
@@ -546,6 +548,7 @@ mod tests {
         let graph = minimal_graph();
         let graph_hash = ContentHash::compute(&serde_json::to_vec(&graph).unwrap());
         let config = RunConfig {
+            budget: Default::default(),
             sandbox_default: SandboxMode::WorkspaceWrite,
             approval_default: ApprovalPolicy::OnRequest,
             auto_pr: false,
@@ -680,6 +683,7 @@ mod tests {
         let graph = agent_graph();
         let graph_hash = ContentHash::compute(&serde_json::to_vec(&graph).unwrap());
         let config = RunConfig {
+            budget: Default::default(),
             sandbox_default: SandboxMode::WorkspaceWrite,
             approval_default: ApprovalPolicy::OnRequest,
             auto_pr: false,

--- a/crates/surge-orchestrator/src/engine/replay.rs
+++ b/crates/surge-orchestrator/src/engine/replay.rs
@@ -247,6 +247,7 @@ mod tests {
         );
 
         let run_config = RunConfig {
+            budget: Default::default(),
             sandbox_default: SandboxMode::WorkspaceWrite,
             approval_default: ApprovalPolicy::OnRequest,
             auto_pr: false,
@@ -312,6 +313,7 @@ mod tests {
 
         // Persist RunConfig with an empty mcp_servers list (mirrors pre-M7 runs).
         let run_config = RunConfig {
+            budget: Default::default(),
             sandbox_default: SandboxMode::WorkspaceWrite,
             approval_default: ApprovalPolicy::OnRequest,
             auto_pr: false,
@@ -366,6 +368,7 @@ mod tests {
         let previous_graph_hash = ContentHash::compute(b"base-flow");
         let graph_hash = ContentHash::compute(b"amended-flow");
         let run_config = RunConfig {
+            budget: Default::default(),
             sandbox_default: SandboxMode::WorkspaceWrite,
             approval_default: ApprovalPolicy::OnRequest,
             auto_pr: false,

--- a/crates/surge-orchestrator/tests/engine_bootstrap_parent_artifacts_test.rs
+++ b/crates/surge-orchestrator/tests/engine_bootstrap_parent_artifacts_test.rs
@@ -87,6 +87,7 @@ async fn start_run_with_bootstrap_parent_seeds_parent_artifacts() {
                 project_path: parent_worktree.path().to_path_buf(),
                 initial_prompt: "bootstrap this".into(),
                 config: RunConfig {
+                    budget: Default::default(),
                     sandbox_default: SandboxMode::WorkspaceWrite,
                     approval_default: ApprovalPolicy::OnRequest,
                     auto_pr: false,

--- a/crates/surge-persistence/src/runs/query.rs
+++ b/crates/surge-persistence/src/runs/query.rs
@@ -147,6 +147,7 @@ mod tests {
             approval_default: ApprovalPolicy::OnRequest,
             auto_pr: false,
             mcp_servers: Vec::new(),
+            budget: Default::default(),
         }
     }
 

--- a/crates/surge-persistence/tests/migration_payload_v1.rs
+++ b/crates/surge-persistence/tests/migration_payload_v1.rs
@@ -33,6 +33,7 @@ async fn read_path_round_trips_v1_events() {
             project_path: PathBuf::from("/migration-test"),
             initial_prompt: "v1 round trip".into(),
             config: RunConfig {
+                budget: Default::default(),
                 sandbox_default: SandboxMode::WorkspaceWrite,
                 approval_default: ApprovalPolicy::OnRequest,
                 auto_pr: false,

--- a/crates/surge-persistence/tests/task_ledger_sync.rs
+++ b/crates/surge-persistence/tests/task_ledger_sync.rs
@@ -28,6 +28,7 @@ async fn sync_mirrors_run_ledger_into_registry_index() {
             project_path: project.clone(),
             initial_prompt: "ledger sync".into(),
             config: RunConfig {
+                budget: Default::default(),
                 sandbox_default: SandboxMode::WorkspaceWrite,
                 approval_default: ApprovalPolicy::OnRequest,
                 auto_pr: false,

--- a/crates/surge-telegram/src/cockpit/dispatch.rs
+++ b/crates/surge-telegram/src/cockpit/dispatch.rs
@@ -596,6 +596,7 @@ mod tests {
                     project_path: PathBuf::from("/p"),
                     initial_prompt: String::new(),
                     config: surge_core::run_event::RunConfig {
+                        budget: Default::default(),
                         sandbox_default: surge_core::sandbox::SandboxMode::WorkspaceWrite,
                         approval_default: surge_core::approvals::ApprovalPolicy::OnRequest,
                         auto_pr: false,


### PR DESCRIPTION
## What & why

Follow-up to the **PR #84** deep review (deferred there as its own PR because it touches the persisted event schema + ~36 construction sites).

A daemon-restart **resume** rebuilt `EngineRunConfig` from `::default()` and restored only `mcp_servers`, so the run's **budget reverted to the unlimited default** — spend enforcement was silently off for the rest of a resumed run. Root cause: the frozen budget was never persisted in `RunConfig`, so it couldn't be restored regardless.

## Fix

- Add `budget: BudgetGuard` to the persisted `RunConfig`, `#[serde(default)]` — a log written before this field decodes to the unlimited default, exactly as it resumed before (backward compatible, no schema-version bump needed).
- Populate it from the run config when `RunStarted` is emitted (`engine.rs`), and restore it into the resumed `EngineRunConfig` in `resume_run`.
- Update the ~36 `RunConfig` construction sites (mostly tests/fixtures).

## Tests

- Roundtrip: a non-default budget (`usd: Some(5.0)`, `warn 80%`) survives serialize→deserialize intact; a value with the `budget` key **absent** decodes to `BudgetGuard::default()` (backward compat).
- Full workspace suite green: **2108 tests** (`cargo nextest run --workspace --exclude surge-ui`). surge-core strict clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)